### PR TITLE
Moved Fire and Red Fire from Unused tab to Global tab; New Icons

### DIFF
--- a/resources/EntitiesRebirth.xml
+++ b/resources/EntitiesRebirth.xml
@@ -1,795 +1,1125 @@
 <data>
-	<entity Group="Props" ID="0" Image="resources/Entities/0.10.0 - Random Props A.png" Kind="Stage" Name="Random Props A" Subtype="0" Variant="10" InEmptyRooms="1" NoBlockDoors="1" IsGrid="1" />
-	<entity Group="Props" ID="0" Image="resources/Entities/0.20.0 - Random Props B.png" Kind="Stage" Name="Random Props B" Subtype="0" Variant="20" InEmptyRooms="1" NoBlockDoors="1" IsGrid="1" />
-	<entity Group="Props" ID="0" Image="resources/Entities/0.30.0 - Random Props C.png" Kind="Stage" Name="Random Props C" Subtype="0" Variant="30" InEmptyRooms="1" NoBlockDoors="1" IsGrid="1" />
+	<!--——— Important Tags ———-->
+	<tag Label="In Empty Rooms" Attribute="InEmptyRooms" Filterable="1">InEmptyRooms</tag>
+	<tag Label="In Non-Combat Rooms" Attribute="InNonCombatRooms" Filterable="1">InNonCombatRooms</tag>
+	<tag Label="Grid Entity" Attribute="IsGrid" Filterable="1">Grid</tag>
+	<tag Label="Boss" Attribute="Boss" Filterable="1">Boss</tag>
+	<tag Label="Can be Champion" Attribute="Champion" Filterable="1">Champion</tag>
+	<tag Label="Metadata" Attribute="Metadata" Filterable="1">Metadata</tag>
+	<tag Attribute="NoBlockDoors">NoBlockDoors</tag>
 
-	<entity Group="Broken" ID="1" Image="resources/Entities/1.0.0 - Player.png" Kind="Stage" Name="Player (crashes)" Subtype="0" Variant="0" />
-	<entity Group="Tears" ID="2" Image="resources/Entities/2.0.0 - Tear.png" Kind="Stage" Name="Tear" Subtype="0" Variant="0" />
-	<entity Group="Tears" ID="2" Image="resources/Entities/2.1.0 - Blood Tear.png" Kind="Stage" Name="Blood Tear" Subtype="0" Variant="1" />
-	<entity Group="Tears" ID="2" Image="resources/Entities/2.2.0 - Tooth Tear.png" Kind="Stage" Name="Tooth Tear" Subtype="0" Variant="2" />
-	<entity Group="Tears" ID="2" Image="resources/Entities/2.3.0 - Metallic Tear.png" Kind="Stage" Name="Metallic Tear" Subtype="0" Variant="3" />
-	<entity Group="Tears" ID="2" Image="resources/Entities/2.4.0 - Bob's Tear.png" Kind="Stage" Name="Bob's Tear" Subtype="0" Variant="4" />
-	<entity Group="Tears" ID="2" Image="resources/Entities/2.5.0 - Fire Tear.png" Kind="Stage" Name="Fire Tear" Subtype="0" Variant="5" />
-	<entity Group="Tears" ID="2" Image="resources/Entities/2.6.0 - Dark Matter Tear.png" Kind="Stage" Name="Dark Matter Tear" Subtype="0" Variant="6" />
-	<entity Group="Tears" ID="2" Image="resources/Entities/2.7.0 - Mysterious Tear.png" Kind="Stage" Name="Mysterious Tear" Subtype="0" Variant="7" />
-	<entity Group="Tears" ID="2" Image="resources/Entities/2.8.0 - Scythe Tear.png" Kind="Stage" Name="Scythe Tear" Subtype="0" Variant="8" />
-	<entity Group="Tears" ID="2" Image="resources/Entities/2.9.0 - Chaos Tear.png" Kind="Stage" Name="Chaos Tear" Subtype="0" Variant="9" />
-	<entity Group="Tears" ID="2" Image="resources/Entities/2.10.0 - Shield Tear.png" Kind="Stage" Name="Shield Tear" Subtype="0" Variant="10" />
-	<entity Group="Tears" ID="2" Image="resources/Entities/2.11.0 - Cupid Tear.png" Kind="Stage" Name="Cupid Tear" Subtype="0" Variant="11" />
-	<entity Group="Broken" ID="3" Image="resources/Entities/3.0.0 - Familiar.png" Kind="Stage" Name="Familiar (No Effect)" Subtype="0" Variant="0" />
-	<entity Group="Live Bombs" ID="4" Image="resources/Entities/4.0.0 - Bomb.png" Kind="Stage" Name="Active Bomb" Subtype="0" Variant="0" />
-	<entity Group="Live Bombs" ID="4" Image="resources/Entities/4.0.1 - Big Bomb.png" Kind="Stage" Name="Big Bomb" Subtype="0" Variant="1" />
-	<entity Group="Live Bombs" ID="4" Image="resources/Entities/4.0.2 - Decoy Bomb.png" Kind="Stage" Name="Decoy Bomb" Subtype="0" Variant="2" />
-	<entity Group="Live Bombs" ID="4" Image="resources/Entities/4.0.3 - Troll Bomb.png" Kind="Stage" Name="Troll Bomb" Subtype="0" Variant="3" />
-	<entity Group="Live Bombs" ID="4" Image="resources/Entities/4.0.4 - Megatroll Bomb.png" Kind="Stage" Name="Megatroll Bomb" Subtype="0" Variant="4" />
-	<entity Group="Live Bombs" ID="4" Image="resources/Entities/4.0.5 - Poison Bomb.png" Kind="Stage" Name="Poison Bomb" Subtype="0" Variant="5" />
-	<entity Group="Live Bombs" ID="4" Image="resources/Entities/4.0.6 - Big Poison Bomb.png" Kind="Stage" Name="Big Poison Bomb" Subtype="0" Variant="6" />
-	<entity Group="Live Bombs" ID="4" Image="resources/Entities/4.0.7 - Sad Bomb.png" Kind="Stage" Name="Sad Bomb" Subtype="0" Variant="7" />
-	<entity Group="Live Bombs" ID="4" Image="resources/Entities/4.0.8 - Fire Bomb.png" Kind="Stage" Name="Fire Bomb" Subtype="0" Variant="8" />
-	<entity Group="Live Bombs" ID="4" Image="resources/Entities/4.0.9 - Butt Bomb.png" Kind="Stage" Name="Butt Bomb" Subtype="0" Variant="9" />
-	<entity Group="Live Bombs" ID="4" Image="resources/Entities/4.0.10 - Mr Mega Bomb.png" Kind="Stage" Name="Mr Mega Bomb" Subtype="0" Variant="10" />
-	<entity Group="Live Bombs" ID="4" Image="resources/Entities/4.0.11 - Bobby Bomb.png" Kind="Stage" Name="Bobby Bomb" Subtype="0" Variant="11" />
-	<entity Group=" Random" ID="5" Image="resources/Entities/5.0.0 - Pickup.png" Kind="Pickups" Name="Pickup" Subtype="0" Variant="0" />
-	<entity Group=" Random" ID="5" Image="resources/Entities/5.10.0 - RHeart.png" Kind="Pickups" Name="Random Heart" Subtype="0" Variant="10" />
-	<entity Group="Hearts" ID="5" Image="resources/Entities/5.10.0 - RHeart.png" Kind="Pickups" Name="Random Heart" Subtype="0" Variant="10" />
-	<entity Group="Hearts" ID="5" Image="resources/Entities/5.10.1 - Heart.png" Kind="Pickups" Name="Heart" Subtype="1" Variant="10" />
-	<entity Group="Hearts" ID="5" Image="resources/Entities/5.10.2 - Heart (half).png" Kind="Pickups" Name="Heart (half)" Subtype="2" Variant="10" />
-	<entity Group="Hearts" ID="5" Image="resources/Entities/5.10.3 - Heart (soul).png" Kind="Pickups" Name="Heart (soul)" Subtype="3" Variant="10" />
-	<entity Group="Hearts" ID="5" Image="resources/Entities/5.10.4 - Heart (eternal).png" Kind="Pickups" Name="Heart (eternal)" Subtype="4" Variant="10" />
-	<entity Group="Hearts" ID="5" Image="resources/Entities/5.10.5 - Heart (double).png" Kind="Pickups" Name="Heart (double)" Subtype="5" Variant="10" />
-	<entity Group="Hearts" ID="5" Image="resources/Entities/5.10.6 - Black Heart.png" Kind="Pickups" Name="Black Heart" Subtype="6" Variant="10" />
-	<entity Group=" Random" ID="5" Image="resources/Entities/5.20.0 - RCoin.png" Kind="Pickups" Name="Random Coin" Subtype="0" Variant="20" />
-	<entity Group="Coins" ID="5" Image="resources/Entities/5.20.0 - RCoin.png" Kind="Pickups" Name="Random Coin" Subtype="0" Variant="20" />
-	<entity Group="Coins" ID="5" Image="resources/Entities/5.20.1 - Penny.png" Kind="Pickups" Name="Penny" Subtype="1" Variant="20" />
-	<entity Group="Coins" ID="5" Image="resources/Entities/5.20.2 - Nickel.png" Kind="Pickups" Name="Nickel" Subtype="2" Variant="20" />
-	<entity Group="Coins" ID="5" Image="resources/Entities/5.20.3 - Dime.png" Kind="Pickups" Name="Dime" Subtype="3" Variant="20" />
-	<entity Group="Coins" ID="5" Image="resources/Entities/5.20.4 - Double Penny.png" Kind="Pickups" Name="Double Penny" Subtype="4" Variant="20" />
-	<entity Group=" Random" ID="5" Image="resources/Entities/5.30.0 - RKey.png" Kind="Pickups" Name="Random Key" Subtype="0" Variant="30" />
-	<entity Group="Keys and Bombs" ID="5" Image="resources/Entities/5.30.0 - RKey.png" Kind="Pickups" Name="Random Key" Subtype="0" Variant="30" />
-	<entity Group="Keys and Bombs" ID="5" Image="resources/Entities/5.30.1 - Key.png" Kind="Pickups" Name="Key" Subtype="1" Variant="30" />
-	<entity Group="Keys and Bombs" ID="5" Image="resources/Entities/5.30.2 - Golden Key.png" Kind="Pickups" Name="Golden Key" Subtype="2" Variant="30" />
-	<entity Group="Keys and Bombs" ID="5" Image="resources/Entities/5.30.3 - Key Ring.png" Kind="Pickups" Name="Key Ring" Subtype="3" Variant="30" />
-	<entity Group=" Random" ID="5" Image="resources/Entities/5.40.0 - RBomb.png" Kind="Pickups" Name="Random Bomb" Subtype="0" Variant="40" />
-	<entity Group="Keys and Bombs" ID="5" Image="resources/Entities/5.40.0 - RBomb.png" Kind="Pickups" Name="Random Bomb" Subtype="0" Variant="40" />
-	<entity Group="Keys and Bombs" ID="5" Image="resources/Entities/5.40.1 - Bomb.png" Kind="Pickups" Name="Bomb" Subtype="1" Variant="40" />
-	<entity Group="Keys and Bombs" ID="5" Image="resources/Entities/5.40.2 - Double Bomb.png" Kind="Pickups" Name="Double Bomb" Subtype="2" Variant="40" />
-	<entity Group="Chests" ID="5" Image="resources/Entities/5.50.0 - Chest.png" Kind="Pickups" Name="Chest" Subtype="0" Variant="50" />
-	<entity Group="Chests" ID="5" Image="resources/Entities/5.51.0 - Bomb Chest.png" Kind="Pickups" Name="Bomb Chest" Subtype="0" Variant="51" />
-	<entity Group="Chests" ID="5" Image="resources/Entities/5.60.0 - Locked Chest.png" Kind="Pickups" Name="Locked Chest" Subtype="0" Variant="60" />
-	<entity Group=" Random" ID="5" Image="resources/Entities/5.70.0 - Random Pill.png" Kind="Pickups" Name="Random Pill" Subtype="0" Variant="70" />
-	<entity Group=" Random" ID="5" Image="resources/Entities/5.90.1 - Lil' Battery.png" Kind="Pickups" Name="Lil' Battery" Subtype="0" Variant="90" />
-	<entity Group=" Random" ID="5" Image="resources/Entities/Items/5.100.0 - Random.png" Kind="Collect" Name="Random Collectible" Subtype="0" Variant="100" />
-	<entity Group=" Random" ID="5" Image="resources/Entities/Items/5.150.0 - Random.png" Kind="Collect" Name="Random Shop Item" Subtype="0" Variant="150" />
-	<entity Group=" Random" ID="5" Image="resources/Entities/5.300.0 - Random Card.png" Kind="Pickups" Name="Random Card" Subtype="0" Variant="300" />
-	<entity Group="Cards" ID="5" Image="resources/Entities/5.300.0 - Random Card.png" Kind="Pickups" Name="Random Card" Subtype="0" Variant="300" />
-	<entity Group="Cards" ID="5" Image="resources/Entities/5.300.1 - The Fool.png" Kind="Pickups" Name="The Fool" Subtype="1" Variant="300" />
-	<entity Group="Cards" ID="5" Image="resources/Entities/5.300.2 - The Magician.png" Kind="Pickups" Name="The Magician" Subtype="2" Variant="300" />
-	<entity Group="Cards" ID="5" Image="resources/Entities/5.300.3 - The High Priestess.png" Kind="Pickups" Name="The High Priestess" Subtype="3" Variant="300" />
-	<entity Group="Cards" ID="5" Image="resources/Entities/5.300.4 - The Empress.png" Kind="Pickups" Name="The Empress" Subtype="4" Variant="300" />
-	<entity Group="Cards" ID="5" Image="resources/Entities/5.300.5 - The Emperor.png" Kind="Pickups" Name="The Emperor" Subtype="5" Variant="300" />
-	<entity Group="Cards" ID="5" Image="resources/Entities/5.300.6 - The Hierophant.png" Kind="Pickups" Name="The Hierophant" Subtype="6" Variant="300" />
-	<entity Group="Cards" ID="5" Image="resources/Entities/5.300.7 - The Lovers.png" Kind="Pickups" Name="The Lovers" Subtype="7" Variant="300" />
-	<entity Group="Cards" ID="5" Image="resources/Entities/5.300.8 - The Chariot.png" Kind="Pickups" Name="The Chariot" Subtype="8" Variant="300" />
-	<entity Group="Cards" ID="5" Image="resources/Entities/5.300.9 - Justice.png" Kind="Pickups" Name="Justice" Subtype="9" Variant="300" />
-	<entity Group="Cards" ID="5" Image="resources/Entities/5.300.10 - The Hermit.png" Kind="Pickups" Name="The Hermit" Subtype="10" Variant="300" />
-	<entity Group="Cards" ID="5" Image="resources/Entities/5.300.11 - Wheel of Fortune.png" Kind="Pickups" Name="Wheel of Fortune" Subtype="11" Variant="300" />
-	<entity Group="Cards" ID="5" Image="resources/Entities/5.300.12 - Strength.png" Kind="Pickups" Name="Strength" Subtype="12" Variant="300" />
-	<entity Group="Cards" ID="5" Image="resources/Entities/5.300.13 - The Hanged Man.png" Kind="Pickups" Name="The Hanged Man" Subtype="13" Variant="300" />
-	<entity Group="Cards" ID="5" Image="resources/Entities/5.300.14 - Death.png" Kind="Pickups" Name="Death" Subtype="14" Variant="300" />
-	<entity Group="Cards" ID="5" Image="resources/Entities/5.300.15 - Temperance.png" Kind="Pickups" Name="Temperance" Subtype="15" Variant="300" />
-	<entity Group="Cards" ID="5" Image="resources/Entities/5.300.16 - The Devil.png" Kind="Pickups" Name="The Devil" Subtype="16" Variant="300" />
-	<entity Group="Cards" ID="5" Image="resources/Entities/5.300.17 - The Tower.png" Kind="Pickups" Name="The Tower" Subtype="17" Variant="300" />
-	<entity Group="Cards" ID="5" Image="resources/Entities/5.300.18 - The Stars.png" Kind="Pickups" Name="The Stars" Subtype="18" Variant="300" />
-	<entity Group="Cards" ID="5" Image="resources/Entities/5.300.19 - The Moon.png" Kind="Pickups" Name="The Moon" Subtype="19" Variant="300" />
-	<entity Group="Cards" ID="5" Image="resources/Entities/5.300.20 - The Sun.png" Kind="Pickups" Name="The Sun" Subtype="20" Variant="300" />
-	<entity Group="Cards" ID="5" Image="resources/Entities/5.300.21 - Judgement.png" Kind="Pickups" Name="Judgement" Subtype="21" Variant="300" />
-	<entity Group="Cards" ID="5" Image="resources/Entities/5.300.22 - The World.png" Kind="Pickups" Name="The World" Subtype="22" Variant="300" />
-	<entity Group="Cards" ID="5" Image="resources/Entities/5.300.23 - 2 of Clubs.png" Kind="Pickups" Name="2 of Clubs" Subtype="23" Variant="300" />
-	<entity Group="Cards" ID="5" Image="resources/Entities/5.300.24 - 2 of Diamonds.png" Kind="Pickups" Name="2 of Diamonds" Subtype="24" Variant="300" />
-	<entity Group="Cards" ID="5" Image="resources/Entities/5.300.25 - 2 of Spades.png" Kind="Pickups" Name="2 of Spades" Subtype="25" Variant="300" />
-	<entity Group="Cards" ID="5" Image="resources/Entities/5.300.26 - 2 of Hearts.png" Kind="Pickups" Name="2 of Hearts" Subtype="26" Variant="300" />
-	<entity Group="Cards" ID="5" Image="resources/Entities/5.300.31 - Joker.png" Kind="Pickups" Name="Joker" Subtype="27" Variant="300" />
-	<entity Group="Runes" ID="5" Image="resources/Entities/5.300.32 - Hagalaz.png" Kind="Pickups" Name="Hagalaz" Subtype="28" Variant="300" />
-	<entity Group="Runes" ID="5" Image="resources/Entities/5.300.33 - Jera.png" Kind="Pickups" Name="Jera" Subtype="29" Variant="300" />
-	<entity Group="Runes" ID="5" Image="resources/Entities/5.300.34 - Ehwaz.png" Kind="Pickups" Name="Ehwaz" Subtype="30" Variant="300" />
-	<entity Group="Runes" ID="5" Image="resources/Entities/5.300.35 - Dagaz.png" Kind="Pickups" Name="Dagaz" Subtype="31" Variant="300" />
-	<entity Group="Runes" ID="5" Image="resources/Entities/5.300.36 - Ansuz.png" Kind="Pickups" Name="Ansuz" Subtype="32" Variant="300" />
-	<entity Group="Runes" ID="5" Image="resources/Entities/5.300.37 - Perthro.png" Kind="Pickups" Name="Perthro" Subtype="33" Variant="300" />
-	<entity Group="Runes" ID="5" Image="resources/Entities/5.300.38 - Berkano.png" Kind="Pickups" Name="Berkano" Subtype="34" Variant="300" />
-	<entity Group="Runes" ID="5" Image="resources/Entities/5.300.39 - Algiz.png" Kind="Pickups" Name="Algiz" Subtype="35" Variant="300" />
-	<entity Group="Cards" ID="5" Image="resources/Entities/5.300.42 - Chaos Card.png" Kind="Pickups" Name="Chaos Card" Subtype="36" Variant="300" />
-	<entity Group="Cards" ID="5" Image="resources/Entities/5.300.43 - Credit Card.png" Kind="Pickups" Name="Credit Card" Subtype="37" Variant="300" />
-	<entity Group="Cards" ID="5" Image="resources/Entities/5.300.44 - Rules Card.png" Kind="Pickups" Name="Rules Card" Subtype="38" Variant="300" />
-	<entity Group="Cards" ID="5" Image="resources/Entities/5.300.45 - A Card Against Humanity.png" Kind="Pickups" Name="A Card Against Humanity" Subtype="39" Variant="300" />
-    <entity Group="Cards" ID="5" Image="resources/Entities/5.300.46 - Suicide King.png" Kind="Pickups" Name="Suicide King" Subtype="40" Variant="300" />
-	<entity Group="Special Exits" ID="5" Image="resources/Entities/5.340.0 - Big Chest.png" Kind="Stage" Name="Big Chest" Subtype="0" Variant="340" />
-	<entity Group=" Random" ID="5" Image="resources/Entities/5.350.0 - Trinket.png" Kind="Collect" Name="Random Trinket" Subtype="0" Variant="350" />
-	<entity Group="Chests" ID="5" Image="resources/Entities/5.360.0 - Red Chest.png" Kind="Pickups" Name="Red Chest" Subtype="0" Variant="360" />
-	<entity Group="Special Exits" ID="5" Image="resources/Entities/5.370.0 - Trophy.png" Kind="Stage" Name="Trophy" Subtype="0" Variant="370" />
-	<entity Group="Props" ID="5" Image="resources/Entities/5.380.0 - Isaac's Bed.png" Kind="Stage" Name="Isaac's Bed" Subtype="0" Variant="380" />
-	<entity Group="Arcade" ID="6" Image="resources/Entities/6.1.0 - Slot Machine.png" Kind="Stage" Name="Slot Machine" Subtype="0" Variant="1" />
-	<entity Group="Arcade" ID="6" Image="resources/Entities/6.2.0 - Blood Donation Machine.png" Kind="Stage" Name="Blood Donation Machine" Subtype="0" Variant="2" />
-	<entity Group="Arcade" ID="6" Image="resources/Entities/6.3.0 - Fortune Telling Machine.png" Kind="Stage" Name="Fortune Telling Machine" Subtype="0" Variant="3" />
-	<entity Group="Arcade" ID="6" Image="resources/Entities/6.4.0 - Beggar.png" Kind="Stage" Name="Beggar" Subtype="0" Variant="4" />
-	<entity Group="Arcade" ID="6" Image="resources/Entities/6.5.0 - Devil Beggar.png" Kind="Stage" Name="Devil Beggar" Subtype="0" Variant="5" />
-	<entity Group="Arcade" ID="6" Image="resources/Entities/6.6.0 - Shell Game.png" Kind="Stage" Name="Shell Game" Subtype="0" Variant="6" />
-	<entity Group="Arcade" ID="6" Image="resources/Entities/6.7.0 - Key Master.png" Kind="Stage" Name="Key Master" Subtype="0" Variant="7" />
-	<entity Group="Arcade" ID="6" Image="resources/Entities/6.8.0 - Donation Machine.png" Kind="Stage" Name="Donation Machine" Subtype="0" Variant="8" />
-	<entity Group="Broken" ID="7" Image="resources/Entities/7.0.0 - Laser.png" Kind="Stage" Name="Laser (crashes)" Subtype="0" Variant="0" />
-	<entity Group="Broken" ID="8" Image="resources/Entities/8.0.0 - Knife.png" Kind="Stage" Name="Knife" Subtype="0" Variant="0" />
-	<entity Group="Tears" ID="9" Image="resources/Entities/9.0.0 - Enemy Tear.png" Kind="Stage" Name="Enemy Tear" Subtype="0" Variant="0" />
-	<entity Group="Tears" ID="9" Image="resources/Entities/9.0.1 - Bone.png" Kind="Stage" Name="Bone" Subtype="0" Variant="1" />
-	<entity Group="Tears" ID="9" Image="resources/Entities/9.0.2 - Fire.png" Kind="Stage" Name="Fire" Subtype="0" Variant="2" />
-	<entity Group="Tears" ID="9" Image="resources/Entities/9.0.3 - Puke.png" Kind="Stage" Name="Puke" Subtype="0" Variant="3" />
+	<!--——— Sorting Tags ———-->
+	<tag Label="Retracting Spikes" StatisticsGroup="1">RetractingSpikes</tag>
+	<tag Label="Wall Huggers" StatisticsGroup="1">WallHuggers</tag>
+	<tag Label="Random Props" StatisticsGroup="1">RandomProps</tag>
+	<tag Label="Gapers" StatisticsGroup="1">DefaultGaper</tag>
+	<tag Label="Pacers and Gushers" StatisticsGroup="1">DefaultGusher</tag>
+	<tag Label="Constant Stone Shooters" StatisticsGroup="1">ConstantStoneShooters</tag>
+	<tag Label="Guts" StatisticsGroup="1">GutsEnemy</tag>
 
-	<entity BaseHP="10" Champion="1" Group="Gapers" ID="10" Image="resources/Entities/10.0.0 - Frowning Gaper.png" Kind="Enemies" Name="Frowning Gaper" Subtype="0" Variant="0" />
-	<entity BaseHP="10" Champion="1" Group="Gapers" ID="10" Image="resources/Entities/10.1.0 - Gaper.png" Kind="Enemies" Name="Gaper" Subtype="0" Variant="1" />
-	<entity BaseHP="10" Champion="1" Group="Gapers" ID="10" Image="resources/Entities/10.2.0 - Sleepy Gaper.png" Kind="Enemies" Name="Sleepy Gaper" Subtype="0" Variant="2" />
-	<entity BaseHP="10" Champion="1" Group="Gapers" ID="11" Image="resources/Entities/11.0.0 - Gusher.png" Kind="Enemies" Name="Gusher" Subtype="0" Variant="0" />
-	<entity BaseHP="10" Champion="1" Group="Gapers" ID="11" Image="resources/Entities/11.1.0 - Pacer.png" Kind="Enemies" Name="Pacer" Subtype="0" Variant="1" />
-	<entity BaseHP="10" Champion="1" Group="Maws" ID="12" Image="resources/Entities/12.0.0 - Horf.png" Kind="Enemies" Name="Horf" Subtype="0" Variant="0" />
-	<entity BaseHP="3" Group="Flies" ID="13" Image="resources/Entities/13.0.0 - Fly.png" Kind="Enemies" Name="Fly" Subtype="0" Variant="0" />
-	<entity BaseHP="8" Champion="1" Group="Flies" ID="14" Image="resources/Entities/14.0.0 - Pooter.png" Kind="Enemies" Name="Pooter" Subtype="0" Variant="0" />
-	<entity BaseHP="8" Champion="1" Group="Flies" ID="14" Image="resources/Entities/14.1.0 - Super Pooter.png" Kind="Enemies" Name="Super Pooter" Subtype="0" Variant="1" />
-	<entity BaseHP="15" Champion="1" Group="Blobs" ID="15" Image="resources/Entities/15.0.0 - Clotty.png" Kind="Enemies" Name="Clotty" Subtype="0" Variant="0" />
-	<entity BaseHP="15" Champion="1" Group="Blobs" ID="15" Image="resources/Entities/15.1.0 - Clot.png" Kind="Enemies" Name="Clot" Subtype="0" Variant="1" />
-	<entity BaseHP="15" Champion="1" Group="Blobs" ID="15" Image="resources/Entities/15.2.0 - I.Blob.png" Kind="Enemies" Name="I.Blob" Subtype="0" Variant="2" />
-	<entity BaseHP="13" Champion="1" Group="Mulligans" ID="16" Image="resources/Entities/16.0.0 - Mulligan.png" Kind="Enemies" Name="Mulligan" Subtype="0" Variant="0" />
-	<entity BaseHP="13" Champion="1" Group="Mulligans" ID="16" Image="resources/Entities/16.1.0 - Mulligoon.png" Kind="Enemies" Name="Mulligoon" Subtype="0" Variant="1" />
-	<entity BaseHP="13" Champion="1" Group="Mulligans" ID="16" Image="resources/Entities/16.2.0 - Mulliboom.png" Kind="Enemies" Name="Mulliboom" Subtype="0" Variant="2" />
-	<entity BaseHP="5" Group="Props" ID="17" Image="resources/Entities/17.0.0 - Keeper.png" Kind="Stage" Name="Shopkeeper" Subtype="0" Variant="0" />
-	<entity BaseHP="5" Group="Props" ID="17" Image="resources/Entities/17.1.0 - Hanging Keeper.png" Kind="Stage" Name="Secret Room Keeper" Subtype="0" Variant="1" />
-	<entity BaseHP="5" Group="Props" ID="17" Image="resources/Entities/17.2.0 - Error Room Keeper.png" Kind="Stage" Name="Error Room Keeper" Subtype="0" Variant="2" />
-	<entity BaseHP="5" Group="Flies" ID="18" Image="resources/Entities/18.0.0 - Attack Fly.png" Kind="Enemies" Name="Attack Fly" Subtype="0" Variant="0" />
-	<entity BaseHP="22" Boss="1" Group="Boss Rooms" ID="19" Image="resources/Entities/19.0.0 - Larry Jr.png" Kind="Bosses" Name="Larry Jr." Subtype="0" Variant="0" />
-	<entity BaseHP="22" Boss="1" Group="Boss Rooms" ID="19" Image="resources/Entities/19.1.0 - The Hollow.png" Kind="Bosses" Name="The Hollow" Subtype="0" Variant="1" />
-	<entity BaseHP="250" Boss="1" Group="Boss Rooms" ID="20" Image="resources/Entities/20.0.0 - Monstro.png" Kind="Bosses" Name="Monstro" Subtype="0" Variant="0" />
-	<entity BaseHP="15" Champion="1" Group="Worms" ID="21" Image="resources/Entities/21.0.0 - Maggot.png" Kind="Enemies" Name="Maggot" Subtype="0" Variant="0" />
-	<entity BaseHP="20" Champion="1" Group="Mulligans" ID="22" Image="resources/Entities/22.0.0 - Hive.png" Kind="Enemies" Name="Hive" Subtype="0" Variant="0" />
-	<entity BaseHP="20" Champion="1" Group="Worms" ID="23" Image="resources/Entities/23.0.0 - Charger.png" Kind="Enemies" Name="Charger" Subtype="0" Variant="0" />
-	<entity BaseHP="33" Champion="1" Group="Gapers" ID="24" Image="resources/Entities/24.0.0 - Globin.png" Kind="Enemies" Name="Globin" Subtype="0" Variant="0" />
-	<entity BaseHP="33" Champion="1" Group="Gapers" ID="24" Image="resources/Entities/24.1.0 - Gazing Globin.png" Kind="Enemies" Name="Gazing Globin" Subtype="0" Variant="1" />
-	<entity BaseHP="20" Champion="1" Group="Flies" ID="25" Image="resources/Entities/25.0.0 - Boom Fly.png" Kind="Enemies" Name="Boom Fly" Subtype="0" Variant="0" />
-	<entity BaseHP="20" Champion="1" Group="Flies" ID="25" Image="resources/Entities/25.1.0 - Red Boom Fly.png" Kind="Enemies" Name="Red Boom Fly" Subtype="0" Variant="1" />
-	<entity BaseHP="20" Champion="1" Group="Maws" ID="26" Image="resources/Entities/26.0.0 - Maw.png" Kind="Enemies" Name="Maw" Subtype="0" Variant="0" />
-	<entity BaseHP="20" Champion="1" Group="Maws" ID="26" Image="resources/Entities/26.1.0 - Red Maw.png" Kind="Enemies" Name="Red Maw" Subtype="0" Variant="1" />
-	<entity BaseHP="20" Champion="1" Group="Maws" ID="26" Image="resources/Entities/26.2.0 - Psychic Maw.png" Kind="Enemies" Name="Psychic Maw" Subtype="0" Variant="2" />
-	<entity BaseHP="15" Champion="1" Group="Hosts" ID="27" Image="resources/Entities/27.0.0 - Host.png" Kind="Enemies" Name="Host" Subtype="0" Variant="0" />
-	<entity BaseHP="15" Champion="1" Group="Hosts" ID="27" Image="resources/Entities/27.1.0 - Red Host.png" Kind="Enemies" Name="Red Host" Subtype="0" Variant="1" />
-	<entity BaseHP="350" Boss="1" Group="Boss Rooms" ID="28" Image="resources/Entities/28.0.0 - Chub.png" Kind="Bosses" Name="Chub" Subtype="0" Variant="0" />
-	<entity BaseHP="350" Boss="1" Group="Boss Rooms" ID="28" Image="resources/Entities/28.1.0 - C.H.A.D..png" Kind="Bosses" Name="C.H.A.D." Subtype="0" Variant="1" />
-	<entity BaseHP="350" Boss="1" Group="Boss Rooms" ID="28" Image="resources/Entities/28.2.0 - The Carrion Queen.png" Kind="Bosses" Name="The Carrion Queen" Subtype="0" Variant="2" />
-	<entity BaseHP="10" Champion="1" Group="Gapers" ID="29" Image="resources/Entities/29.0.0 - Hopper.png" Kind="Enemies" Name="Hopper" Subtype="0" Variant="0" />
-	<entity BaseHP="10" Champion="1" Group="Spiders" ID="29" Image="resources/Entities/29.1.0 - Trite.png" Kind="Enemies" Name="Trite" Subtype="0" Variant="1" />
-	<entity BaseHP="20" Champion="1" Group="Boils" ID="30" Image="resources/Entities/30.0.0 - Boil.png" Kind="Enemies" Name="Boil" Subtype="0" Variant="0" />
-	<entity BaseHP="20" Champion="1" Group="Boils" ID="30" Image="resources/Entities/30.1.0 - Gut.png" Kind="Enemies" Name="Gut" Subtype="0" Variant="1" />
-	<entity BaseHP="20" Champion="1" Group="Boils" ID="30" Image="resources/Entities/30.2.0 - Sack.png" Kind="Enemies" Name="Sack" Subtype="0" Variant="2" />
-	<entity BaseHP="10" Champion="1" Group="Worms" ID="31" Image="resources/Entities/31.0.0 - Spitty.png" Kind="Enemies" Name="Spitty" Subtype="0" Variant="0" />
-	<entity BaseHP="20" Champion="1" Group="Organs" ID="32" Image="resources/Entities/32.0.0 - Brain.png" Kind="Enemies" Name="Brain" Subtype="0" Variant="0" />
-	<entity BaseHP="5" Group="Fireplaces" ID="33" Image="resources/Entities/33.0.0 - Fire Place.png" Kind="Stage" Name="Fire Place" Subtype="0" Variant="0" />
-	<entity BaseHP="5" Group="Fireplaces" ID="33" Image="resources/Entities/33.1.0 - Red Fire Place.png" Kind="Stage" Name="Red Fire Place" Subtype="0" Variant="1" />
-	<entity BaseHP="5" Group="Fireplaces" ID="33" Image="resources/Entities/33.2.0 - Blue Fire Place.png" Kind="Stage" Name="Blue Fire Place" Subtype="0" Variant="2" />
-	<entity BaseHP="5" Group="Fireplaces" ID="33" Image="resources/Entities/33.3.0 - Purple Fire Place.png" Kind="Stage" Name="Purple Fire Place" Subtype="0" Variant="3" />
-	<entity BaseHP="25" Champion="1" Group="Gapers" ID="34" Image="resources/Entities/34.0.0 - Leaper.png" Kind="Enemies" Name="Leaper" Subtype="0" Variant="0" />
-	<entity BaseHP="25" Group="Maws" ID="35" Image="resources/Entities/35.0.0 - Mr. Maw.png" Kind="Enemies" Name="Mr. Maw" Subtype="0" Variant="0" />
-	<entity BaseHP="595" Boss="1" Group="Boss Rooms" ID="36" Image="resources/Entities/36.0.0 - Gurdy.png" Kind="Bosses" Name="Gurdy" Subtype="0" Variant="0" />
-	<entity BaseHP="25" Champion="1" Group="Babies" ID="38" Image="resources/Entities/38.0.0 - Baby.png" Kind="Enemies" Name="Baby" Subtype="0" Variant="0" />
-	<entity BaseHP="25" Champion="1" Group="Babies" ID="38" Image="resources/Entities/38.1.0 - Angelic Baby.png" Kind="Enemies" Name="Angelic Baby" Subtype="0" Variant="1" />
-	<entity BaseHP="25" Boss="1" Champion="1" Group="The Sins" ID="38" Image="resources/Entities/38.2.0 - Ultra Pride Baby.png" Kind="Bosses" Name="Ultra Pride Baby" Subtype="0" Variant="2" />
-	<entity BaseHP="25" Champion="1" Group="Vises" ID="39" Image="resources/Entities/39.0.0 - Vis.png" Kind="Enemies" Name="Vis" Subtype="0" Variant="0" />
-	<entity BaseHP="25" Champion="1" Group="Vises" ID="39" Image="resources/Entities/39.1.0 - Double Vis.png" Kind="Enemies" Name="Double Vis" Subtype="0" Variant="1" />
-	<entity BaseHP="25" Champion="1" Group="Vises" ID="39" Image="resources/Entities/39.2.0 - Chubber.png" Kind="Enemies" Name="Chubber" Subtype="0" Variant="2" />
-	<entity BaseHP="25" Champion="1" Group="Organs" ID="40" Image="resources/Entities/40.0.0 - Guts.png" Kind="Enemies" Name="Guts (Down)" Subtype="0" Variant="0" />
-	<entity BaseHP="25" Champion="1" Group="Organs" ID="40" Image="resources/Entities/40.0.0 - Guts.png" Kind="Enemies" Name="Guts (Left)" Subtype="1" Variant="0" />
-	<entity BaseHP="25" Champion="1" Group="Organs" ID="40" Image="resources/Entities/40.0.0 - Guts.png" Kind="Enemies" Name="Guts (Up)" Subtype="2" Variant="0" />
-	<entity BaseHP="25" Champion="1" Group="Organs" ID="40" Image="resources/Entities/40.0.0 - Guts.png" Kind="Enemies" Name="Guts (Right)" Subtype="3" Variant="0" />
-	<entity BaseHP="20" Champion="1" Group="Knights" ID="41" Image="resources/Entities/41.0.0 - Knight.png" Kind="Enemies" Name="Knight" Subtype="0" Variant="0" />
-	<entity BaseHP="20" Champion="1" Group="Knights" ID="41" Image="resources/Entities/41.1.0 - Selfless Knight.png" Kind="Enemies" Name="Selfless Knight" Subtype="0" Variant="1" />
-	<entity BaseHP="20" Group="Stones" ID="42" Image="resources/Entities/42.0.0 - Stone Grimace.png" Kind="Enemies" Name="Stone Grimace" Subtype="0" Variant="0" />
-	<entity BaseHP="20" Group="Stones" ID="42" Image="resources/Entities/42.1.0 - Vomit Grimace.png" Kind="Enemies" Name="Vomit Grimace" Subtype="0" Variant="1" />
-	<entity BaseHP="632.5" Boss="1" Group="Boss Rooms" ID="43" Image="resources/Entities/43.0.0 - Monstro II.png" Kind="Bosses" Name="Monstro II" Subtype="0" Variant="0" />
-	<entity BaseHP="632.5" Boss="1" Group="Boss Rooms" ID="43" Image="resources/Entities/43.1.0 - Gish.png" Kind="Bosses" Name="Gish" Subtype="0" Variant="1" />
-	<entity BaseHP="100" Group="Spikes" ID="44" Image="resources/Entities/44.0.0 - Poky.png" Kind="Enemies" Name="Poky" Subtype="0" Variant="0" />
-	<entity BaseHP="100" Group="Spikes" ID="44" Image="resources/Entities/44.1.0 - Slide.png" Kind="Enemies" Name="Slide" Subtype="0" Variant="1" />
-	<entity BaseHP="645" Boss="1" Group="Boss Rooms" ID="45" Image="resources/Entities/45.0.0 - Mom.png" Kind="Bosses" Name="Mom" Subtype="0" Variant="0" />
-	<entity BaseHP="60" Boss="1" Group="The Sins" ID="46" Image="resources/Entities/46.0.0 - Sloth.png" Kind="Bosses" Name="Sloth" Subtype="0" Variant="0" />
-	<entity BaseHP="60" Boss="1" Group="The Sins" ID="46" Image="resources/Entities/46.1.0 - Super Sloth.png" Kind="Bosses" Name="Super Sloth" Subtype="0" Variant="1" />
-	<entity BaseHP="60" Boss="1" Group="The Sins" ID="46" Image="resources/Entities/46.2.0 - Ultra Pride.png" Kind="Bosses" Name="Ultra Pride" Subtype="0" Variant="2" />
-	<entity BaseHP="60" Boss="1" Group="The Sins" ID="47" Image="resources/Entities/47.0.0 - Lust.png" Kind="Bosses" Name="Lust" Subtype="0" Variant="0" />
-	<entity BaseHP="60" Boss="1" Group="The Sins" ID="47" Image="resources/Entities/47.1.0 - Super Lust.png" Kind="Bosses" Name="Super Lust" Subtype="0" Variant="1" />
-	<entity BaseHP="60" Boss="1" Group="The Sins" ID="48" Image="resources/Entities/48.0.0 - Wrath.png" Kind="Bosses" Name="Wrath" Subtype="0" Variant="0" />
-	<entity BaseHP="60" Boss="1" Group="The Sins" ID="48" Image="resources/Entities/48.1.0 - Super Wrath.png" Kind="Bosses" Name="Super Wrath" Subtype="0" Variant="1" />
-	<entity BaseHP="60" Boss="1" Group="The Sins" ID="49" Image="resources/Entities/49.0.0 - Gluttony.png" Kind="Bosses" Name="Gluttony" Subtype="0" Variant="0" />
-	<entity BaseHP="60" Boss="1" Group="The Sins" ID="49" Image="resources/Entities/49.1.0 - Super Gluttony.png" Kind="Bosses" Name="Super Gluttony" Subtype="0" Variant="1" />
-	<entity BaseHP="60" Boss="1" Group="The Sins" ID="50" Image="resources/Entities/50.0.0 - Greed.png" Kind="Bosses" Name="Greed" Subtype="0" Variant="0" />
-	<entity BaseHP="60" Boss="1" Group="The Sins" ID="50" Image="resources/Entities/50.1.0 - Super Greed.png" Kind="Bosses" Name="Super Greed" Subtype="0" Variant="1" />
-	<entity BaseHP="60" Boss="1" Group="The Sins" ID="51" Image="resources/Entities/51.0.0 - Envy.png" Kind="Bosses" Name="Envy" Subtype="0" Variant="0" />
-	<entity BaseHP="60" Boss="1" Champion="1" Group="The Sins" ID="51" Image="resources/Entities/51.1.0 - Super Envy.png" Kind="Bosses" Name="Super Envy" Subtype="0" Variant="1" />
-	<entity BaseHP="60" Boss="1" Group="The Sins" ID="52" Image="resources/Entities/52.0.0 - Pride.png" Kind="Bosses" Name="Pride" Subtype="0" Variant="0" />
-	<entity BaseHP="60" Boss="1" Group="The Sins" ID="52" Image="resources/Entities/52.1.0 - Super Pride.png" Kind="Bosses" Name="Super Pride" Subtype="0" Variant="1" />
-	<entity BaseHP="20" Champion="1" Group="Twins" ID="53" Image="resources/Entities/53.0.0 - Dople.png" Kind="Enemies" Name="Dople" Subtype="0" Variant="0" />
-	<entity BaseHP="20" Champion="1" Group="Twins" ID="53" Image="resources/Entities/53.1.0 - Evil Twin.png" Kind="Enemies" Name="Evil Twin" Subtype="0" Variant="1" />
-	<entity BaseHP="20" Champion="1" Group="Gapers" ID="54" Image="resources/Entities/54.0.0 - Flaming Hopper.png" Kind="Enemies" Name="Flaming Hopper" Subtype="0" Variant="0" />
-	<entity BaseHP="25" Champion="1" Group="Worms" ID="55" Image="resources/Entities/55.0.0 - Leech.png" Kind="Enemies" Name="Leech" Subtype="0" Variant="0" />
-	<entity BaseHP="25" Champion="1" Group="Worms" ID="55" Image="resources/Entities/55.1.0 - Kamikaze Leech.png" Kind="Enemies" Name="Kamikaze Leech" Subtype="0" Variant="1" />
-	<entity BaseHP="25" Champion="1" Group="Worms" ID="55" Image="resources/Entities/55.2.0 - Holy Leech.png" Kind="Enemies" Name="Holy Leech" Subtype="0" Variant="2" />
-	<entity BaseHP="30" Champion="1" Group="Lumps" ID="56" Image="resources/Entities/56.0.0 - Lump.png" Kind="Enemies" Name="Lump" Subtype="0" Variant="0" />
-	<entity BaseHP="62" Champion="1" Group="Organs" ID="57" Image="resources/Entities/57.0.0 - MemBrain.png" Kind="Enemies" Name="MemBrain" Subtype="0" Variant="0" />
-	<entity BaseHP="62" Champion="1" Group="Organs" ID="57" Image="resources/Entities/57.1.0 - Mama Guts.png" Kind="Enemies" Name="Mama Guts" Subtype="0" Variant="1" />
-	<entity BaseHP="35" Champion="1" Group="Lumps" ID="58" Image="resources/Entities/58.0.0 - Para-Bite.png" Kind="Enemies" Name="Para-Bite" Subtype="0" Variant="0" />
-	<entity BaseHP="20" Champion="1" Group="Lumps" ID="59" Image="resources/Entities/59.0.0 - Fred.png" Kind="Enemies" Name="Fred" Subtype="0" Variant="0" />
-	<entity BaseHP="20" Champion="1" Group="Organs" ID="60" Image="resources/Entities/60.0.0 - Eye.png" Kind="Enemies" Name="Eye" Subtype="0" Variant="0" />
-	<entity BaseHP="20" Champion="1" Group="Organs" ID="60" Image="resources/Entities/60.1.0 - Bloodshot Eye.png" Kind="Enemies" Name="Bloodshot Eye" Subtype="0" Variant="1" />
-	<entity BaseHP="10" Champion="1" Group="Flies" ID="61" Image="resources/Entities/61.0.0 - Sucker.png" Kind="Enemies" Name="Sucker" Subtype="0" Variant="0" />
-	<entity BaseHP="10" Champion="1" Group="Flies" ID="61" Image="resources/Entities/61.1.0 - Spit.png" Kind="Enemies" Name="Spit" Subtype="0" Variant="1" />
-	<entity BaseHP="180" Boss="1" Group="Boss Rooms" ID="62" Image="resources/Entities/62.0.0 - Pin.png" Kind="Bosses" Name="Pin" Subtype="0" Variant="0" />
-	<entity BaseHP="300" Boss="1" Group="Boss Rooms" ID="62" Image="resources/Entities/62.1.0 - Scolex.png" Kind="Bosses" Name="Scolex" Subtype="0" Variant="1" />
-	<entity BaseHP="240" Boss="1" Group="Horsemen" ID="63" Image="resources/Entities/63.0.0 - Famine.png" Kind="Bosses" Name="Famine" Subtype="0" Variant="0" />
-	<entity BaseHP="280" Boss="1" Group="Horsemen" ID="64" Image="resources/Entities/64.0.0 - Pestilence.png" Kind="Bosses" Name="Pestilence" Subtype="0" Variant="0" />
-	<entity BaseHP="500" Boss="1" Group="Horsemen" ID="65" Image="resources/Entities/65.0.0 - War.png" Kind="Bosses" Name="War" Subtype="0" Variant="0" />
-	<entity BaseHP="500" Boss="1" Group="Horsemen" ID="65" Image="resources/Entities/65.1.0 - Conquest.png" Kind="Bosses" Name="Conquest" Subtype="0" Variant="1" />
-	<entity BaseHP="450" Boss="1" Group="Horsemen" ID="66" Image="resources/Entities/66.0.0 - Death.png" Kind="Bosses" Name="Death" Subtype="0" Variant="0" />
-	<entity BaseHP="110" Boss="1" Group="Boss Rooms" ID="67" Image="resources/Entities/67.0.0 - The Duke of Flies.png" Kind="Bosses" Name="The Duke of Flies" Subtype="0" Variant="0" />
-	<entity BaseHP="150" Boss="1" Group="Boss Rooms" ID="67" Image="resources/Entities/67.1.0 - The Husk.png" Kind="Bosses" Name="The Husk" Subtype="0" Variant="1" />
-	<entity BaseHP="450" Boss="1" Group="Boss Rooms" ID="68" Image="resources/Entities/68.0.0 - Peep.png" Kind="Bosses" Name="Peep" Subtype="0" Variant="0" />
-	<entity BaseHP="450" Boss="1" Group="Boss Rooms" ID="68" Image="resources/Entities/68.1.0 - The Bloat.png" Kind="Bosses" Name="The Bloat" Subtype="0" Variant="1" />
-	<entity BaseHP="350" Boss="1" Group="Boss Rooms" ID="69" Image="resources/Entities/69.0.0 - Loki.png" Kind="Bosses" Name="Loki" Subtype="0" Variant="0" />
-	<entity BaseHP="350" Boss="1" Group="Boss Rooms" ID="69" Image="resources/Entities/69.1.0 - Lokii.png" Kind="Bosses" Name="Lokii" Subtype="0" Variant="1" />
-	<entity BaseHP="60" Boss="1" Group="Boss Rooms" ID="71" Image="resources/Entities/71.0.0 - Fistula Big.png" Kind="Bosses" Name="Fistula Big" Subtype="0" Variant="0" />
-	<entity BaseHP="60" Boss="1" Group="Boss Rooms" ID="71" Image="resources/Entities/71.1.0 - Teratoma Big.png" Kind="Bosses" Name="Teratoma Big" Subtype="0" Variant="1" />
-	<entity BaseHP="15" Boss="1" Group="Boss Rooms" ID="72" Image="resources/Entities/72.0.0 - Fistula Medium.png" Kind="Bosses" Name="Fistula Medium" Subtype="0" Variant="0" />
-	<entity BaseHP="15" Boss="1" Group="Boss Rooms" ID="72" Image="resources/Entities/72.1.0 - Teratoma Medium.png" Kind="Bosses" Name="Teratoma Medium" Subtype="0" Variant="1" />
-	<entity BaseHP="8" Boss="1" Group="Boss Rooms" ID="73" Image="resources/Entities/73.0.0 - Fistula Small.png" Kind="Bosses" Name="Fistula Small" Subtype="0" Variant="0" />
-	<entity BaseHP="8" Boss="1" Group="Boss Rooms" ID="73" Image="resources/Entities/73.1.0 - Teratoma Small.png" Kind="Bosses" Name="Teratoma Small" Subtype="0" Variant="1" />
-	<entity BaseHP="190" Boss="1" Group="Boss Rooms" ID="74" Image="resources/Entities/74.0.0 - Blastocyst Big.png" Kind="Bosses" Name="Blastocyst Big" Subtype="0" Variant="0" />
-	<entity BaseHP="75" Boss="1" Group="Boss Rooms" ID="75" Image="resources/Entities/75.0.0 - Blastocyst Medium.png" Kind="Bosses" Name="Blastocyst Medium" Subtype="0" Variant="0" />
-	<entity BaseHP="30" Boss="1" Group="Boss Rooms" ID="76" Image="resources/Entities/76.0.0 - Blastocyst Small.png" Kind="Bosses" Name="Blastocyst Small" Subtype="0" Variant="0" />
-	<entity BaseHP="12" Group="Worms" ID="77" Image="resources/Entities/77.0.0 - Embryo.png" Kind="Enemies" Name="Embryo" Subtype="0" Variant="0" />
-	<entity BaseHP="950" Boss="1" Group="Boss Rooms" ID="78" Image="resources/Entities/78.0.0 - Mom's Heart.png" Kind="Bosses" Name="Mom's Heart" Subtype="0" Variant="0" />
-	<entity BaseHP="950" Boss="1" Group="Boss Rooms" ID="78" Image="resources/Entities/78.1.0 - It Lives.png" Kind="Bosses" Name="It Lives" Subtype="0" Variant="1" />
-	<entity BaseHP="140" Boss="1" Group="Boss Rooms" ID="79" Image="resources/Entities/79.0.0 - Gemini.png" Kind="Bosses" Name="Gemini" Subtype="0" Variant="0" />
-	<entity BaseHP="140" Boss="1" Group="Boss Rooms" ID="79" Image="resources/Entities/79.1.0 - Steven.png" Kind="Bosses" Name="Steven" Subtype="0" Variant="1" />
-	<entity BaseHP="140" Boss="1" Group="Boss Rooms" ID="79" Image="resources/Entities/79.2.0 - The Blighted Ovum.png" Kind="Bosses" Name="The Blighted Ovum" Subtype="0" Variant="2" />
-	<entity BaseHP="10" Group="Flies" ID="80" Image="resources/Entities/80.0.0 - Moter.png" Kind="Enemies" Name="Moter" Subtype="0" Variant="0" />
-	<entity BaseHP="60" Boss="1" Group="Heaven and Hell" ID="81" Image="resources/Entities/81.0.0 - The Fallen.png" Kind="Bosses" Name="The Fallen" Subtype="0" Variant="0" />
-	<entity BaseHP="60" Boss="1" Group="Heaven and Hell" ID="81" Image="resources/Entities/81.1.0 - Krampus.png" Kind="Bosses" Name="Krampus" Subtype="0" Variant="1" />
-	<entity BaseHP="60" Boss="1" Group="Horsemen" ID="82" Image="resources/Entities/82.0.0 - Headless Horseman Body.png" Kind="Bosses" Name="Headless Horseman's Body" Subtype="0" Variant="0" />
-	<entity BaseHP="100" Boss="1" Group="Horsemen" ID="83" Image="resources/Entities/83.0.0 - Headless Horsemans Head.png" Kind="Bosses" Name="Headless Horseman's Head" Subtype="0" Variant="0" />
-	<entity BaseHP="600" Boss="1" Group="Heaven and Hell" ID="84" Image="resources/Entities/84.0.0 - Satan.png" Kind="Bosses" Name="Satan" Subtype="0" Variant="0" />
-	<entity BaseHP="6.5" Group="Spiders" ID="85" Image="resources/Entities/85.0.0 - Spider.png" Kind="Enemies" Name="Spider" Subtype="0" Variant="0" />
-	<entity BaseHP="36" Champion="1" Group="Maws" ID="86" Image="resources/Entities/86.0.0 - Keeper.png" Kind="Enemies" Name="Keeper" Subtype="0" Variant="0" />
-	<entity BaseHP="40" Champion="1" Group="Gapers" ID="87" Image="resources/Entities/87.0.0 - Gurgle.png" Kind="Enemies" Name="Gurgle" Subtype="0" Variant="0" />
-	<entity BaseHP="20" Champion="1" Group="Boils" ID="88" Image="resources/Entities/88.0.0 - Walking Boil.png" Kind="Enemies" Name="Walking Boil" Subtype="0" Variant="0" />
-	<entity BaseHP="20" Champion="1" Group="Boils" ID="88" Image="resources/Entities/88.1.0 - Walking Gut.png" Kind="Enemies" Name="Walking Gut" Subtype="0" Variant="1" />
-	<entity BaseHP="20" Champion="1" Group="Boils" ID="88" Image="resources/Entities/88.2.0 - Walking Sack.png" Kind="Enemies" Name="Walking Sack" Subtype="0" Variant="2" />
-	<entity BaseHP="20" Group="Worms" ID="89" Image="resources/Entities/89.0.0 - Buttlicker.png" Kind="Enemies" Name="Buttlicker" Subtype="0" Variant="0" />
-	<entity BaseHP="40" Group="Other" ID="90" Image="resources/Entities/90.0.0 - Hanger.png" Kind="Enemies" Name="Hanger" Subtype="0" Variant="0" />
-	<entity BaseHP="40" Champion="1" Group="Flies" ID="91" Image="resources/Entities/91.0.0 - Swarmer.png" Kind="Enemies" Name="Swarmer" Subtype="0" Variant="0" />
-	<entity BaseHP="40" Group="Organs" ID="92" Image="resources/Entities/92.0.0 - Heart.png" Kind="Enemies" Name="Heart" Subtype="0" Variant="0" />
-	<entity BaseHP="40" Group="Organs" ID="93" Image="resources/Entities/93.0.0 - Mask.png" Kind="Enemies" Name="Mask" Subtype="0" Variant="0" />
-	<entity BaseHP="20" Group="Spiders" ID="94" Image="resources/Entities/94.0.0 - Big Spider.png" Kind="Enemies" Name="Big Spider" Subtype="0" Variant="0" />
-	<entity BaseHP="150" Boss="1" Group="Boss Rooms" ID="97" Image="resources/Entities/97.0.0 - Mask of Infamy.png" Kind="Bosses" Name="Mask of Infamy" Subtype="0" Variant="0" />
-	<entity BaseHP="200" Boss="1" Group="Boss Rooms" ID="98" Image="resources/Entities/98.0.0 - Heart of Infamy.png" Kind="Bosses" Name="Heart of Infamy" Subtype="0" Variant="0" />
-	<entity BaseHP="250" Boss="1" Group="Boss Rooms" ID="99" Image="resources/Entities/99.0.0 - Gurdy Jr.png" Kind="Bosses" Name="Gurdy Jr." Subtype="0" Variant="0" />
-	<entity BaseHP="130" Boss="1" Group="Boss Rooms" ID="100" Image="resources/Entities/100.0.0 - Widow.png" Kind="Bosses" Name="Widow" Subtype="0" Variant="0" />
-	<entity BaseHP="215" Boss="1" Group="Boss Rooms" ID="100" Image="resources/Entities/100.1.0 - The Wretched.png" Kind="Bosses" Name="The Wretched" Subtype="0" Variant="1" />
-	<entity BaseHP="300" Boss="1" Group="Boss Rooms" ID="101" Image="resources/Entities/101.0.0 - Daddy Long Legs.png" Kind="Bosses" Name="Daddy Long Legs" Subtype="0" Variant="0" />
-	<entity BaseHP="300" Boss="1" Group="Boss Rooms" ID="101" Image="resources/Entities/101.1.0 - Triachnid.png" Kind="Bosses" Name="Triachnid" Subtype="0" Variant="1" />
-	<entity BaseHP="2000" Boss="1" Group="Heaven and Hell" ID="102" Image="resources/Entities/102.0.0 - Isaac (final boss).png" Kind="Bosses" Name="Isaac (final boss)" Subtype="0" Variant="0" />
-	<entity BaseHP="2000" Boss="1" Group="Heaven and Hell" ID="102" Image="resources/Entities/102.1.0 - Blue Baby (final boss).png" Kind="Bosses" Name="??? (final boss)" Subtype="0" Variant="1" />
+	<!--——— Tabs ———-->
+	<tab Name="Pickups"/>
+	<tab Name="Global"/>
+	<tab Name="Floors"/>
+	<tab Name="Bosses" IconSize="52, 52"/>
+	<tab Name="Collect" IconSize="32, 64"/>
+	<tab Name="Unused"/>
 
-	<entity BaseHP="1" Group="Organs" ID="201" Image="resources/Entities/201.0.0 - Stone Eye.png" Kind="Enemies" Name="Stone Eye" Subtype="0" Variant="0" />
-	<entity BaseHP="1" Group="Stones" ID="202" Image="resources/Entities/202.0.3 - Constant Stone Shooter.png" Kind="Enemies" Name="Constant Stone Shooter (Left)" Subtype="0" Variant="0" />
-	<entity BaseHP="1" Group="Stones" ID="202" Image="resources/Entities/202.0.1 - Constant Stone Shooter.png" Kind="Enemies" Name="Constant Stone Shooter (Up)" Subtype="1" Variant="0" />
-	<entity BaseHP="1" Group="Stones" ID="202" Image="resources/Entities/202.0.2 - Constant Stone Shooter.png" Kind="Enemies" Name="Constant Stone Shooter (Right)" Subtype="2" Variant="0" />
-	<entity BaseHP="1" Group="Stones" ID="202" Image="resources/Entities/202.0.0 - Constant Stone Shooter.png" Kind="Enemies" Name="Constant Stone Shooter (Down)" Subtype="3" Variant="0" />
-	<entity BaseHP="1" Group="Stones" ID="203" Image="resources/Entities/203.0.0 - Brimstone Head.png" Kind="Enemies" Name="Brimstone Head (Left)" Subtype="0" Variant="0" />
-	<entity BaseHP="1" Group="Stones" ID="203" Image="resources/Entities/203.0.1 - Brimstone Head.png" Kind="Enemies" Name="Brimstone Head (Up)" Subtype="1" Variant="0" />
-	<entity BaseHP="1" Group="Stones" ID="203" Image="resources/Entities/203.0.2 - Brimstone Head.png" Kind="Enemies" Name="Brimstone Head (Right)" Subtype="2" Variant="0" />
-	<entity BaseHP="1" Group="Stones" ID="203" Image="resources/Entities/203.0.3 - Brimstone Head.png" Kind="Enemies" Name="Brimstone Head (Down)" Subtype="3" Variant="0" />
-	<entity BaseHP="20" Champion="1" Group="Hosts" ID="204" Image="resources/Entities/204.0.0 - Mobile Host.png" Kind="Enemies" Name="Mobile Host" Subtype="0" Variant="0" />
-	<entity BaseHP="20" Champion="1" Group="Mulligans" ID="205" Image="resources/Entities/205.0.0 - Nest.png" Kind="Enemies" Name="Nest" Subtype="0" Variant="0" />
-	<entity BaseHP="16" Champion="1" Group="Spiders" ID="206" Image="resources/Entities/206.0.0 - Baby Long Legs.png" Kind="Enemies" Name="Baby Long Legs" Subtype="0" Variant="0" />
-	<entity BaseHP="12" Champion="1" Group="Spiders" ID="206" Image="resources/Entities/206.1.0 - Small Baby Long Legs.png" Kind="Enemies" Name="Small Baby Long Legs" Subtype="0" Variant="1" />
-	<entity BaseHP="16" Champion="1" Group="Spiders" ID="207" Image="resources/Entities/207.0.0 - Crazy Long Legs.png" Kind="Enemies" Name="Crazy Long Legs" Subtype="0" Variant="0" />
-	<entity BaseHP="12" Champion="1" Group="Spiders" ID="207" Image="resources/Entities/207.1.0 - Small Crazy Long Legs.png" Kind="Enemies" Name="Small Crazy Long Legs" Subtype="0" Variant="1" />
-	<entity BaseHP="20" Group="Fatties" ID="208" Image="resources/Entities/208.0.0 - Fatty.png" Kind="Enemies" Name="Fatty" Subtype="0" Variant="0" />
-	<entity BaseHP="20" Group="Fatties" ID="208" Image="resources/Entities/208.1.0 - Pale Fatty.png" Kind="Enemies" Name="Pale Fatty" Subtype="0" Variant="1" />
-	<entity BaseHP="16" Champion="1" Group="Fatties" ID="209" Image="resources/Entities/209.0.0 - Fat Sack.png" Kind="Enemies" Name="Fat Sack" Subtype="0" Variant="0" />
-	<entity BaseHP="16" Champion="1" Group="Fatties" ID="210" Image="resources/Entities/210.0.0 - Blubber.png" Kind="Enemies" Name="Blubber" Subtype="0" Variant="0" />
-	<entity BaseHP="10" Champion="1" Group="Fatties" ID="211" Image="resources/Entities/211.0.0 - Half Sack.png" Kind="Enemies" Name="Half Sack" Subtype="0" Variant="0" />
-	<entity BaseHP="20" Group="Maws" ID="212" Image="resources/Entities/212.0.0 - Death's Head.png" Kind="Enemies" Name="Death's Head" Subtype="0" Variant="0" />
-	<entity BaseHP="20" Group="Organs" ID="213" Image="resources/Entities/213.0.0 - Mom's Hand.png" Kind="Enemies" Name="Mom's Hand" Subtype="0" Variant="0" />
-	<entity BaseHP="10" Group="Flies" ID="214" Image="resources/Entities/214.0.0 - lvl2 Fly.png" Kind="Enemies" Name="lvl2 Fly" Subtype="0" Variant="0" />
-	<entity BaseHP="13" Group="Spiders" ID="215" Image="resources/Entities/215.0.0 - lvl2 Spider.png" Kind="Enemies" Name="lvl2 Spider" Subtype="0" Variant="0" />
-	<entity BaseHP="38" Group="Maws" ID="216" Image="resources/Entities/216.0.0 - Swinger.png" Kind="Enemies" Name="Swinger" Subtype="0" Variant="0" />
-	<entity BaseHP="3" Group="Poop" ID="217" Image="resources/Entities/217.0.0 - Dip.png" Kind="Enemies" Name="Dip" Subtype="0" Variant="0" />
-	<entity BaseHP="100" Group="Spikes" ID="218" Image="resources/Entities/218.0.0 - Wall Hugger.png" Kind="Enemies" Name="Wall Hugger (Nearest)" Subtype="0" Variant="0" />
-	<entity BaseHP="100" Group="Spikes" ID="218" Image="resources/Entities/218.0.0 - Wall Hugger.png" Kind="Enemies" Name="Wall Hugger (Left)" Subtype="1" Variant="0" />
-	<entity BaseHP="100" Group="Spikes" ID="218" Image="resources/Entities/218.0.0 - Wall Hugger.png" Kind="Enemies" Name="Wall Hugger (Up)" Subtype="2" Variant="0" />
-	<entity BaseHP="100" Group="Spikes" ID="218" Image="resources/Entities/218.0.0 - Wall Hugger.png" Kind="Enemies" Name="Wall Hugger (Right)" Subtype="3" Variant="0" />
-	<entity BaseHP="100" Group="Spikes" ID="218" Image="resources/Entities/218.0.0 - Wall Hugger.png" Kind="Enemies" Name="Wall Hugger (Down)" Subtype="4" Variant="0" />
-	<entity BaseHP="25" Group="Other" ID="219" Image="resources/Entities/219.0.0 - Wizoob.png" Kind="Enemies" Name="Wizoob" Subtype="0" Variant="0" />
-	<entity BaseHP="15" Group="Poop" ID="220" Image="resources/Entities/220.0.0 - Squirt.png" Kind="Enemies" Name="Squirt" Subtype="0" Variant="0" />
-	<entity BaseHP="20" Champion="1" Group="Worms" ID="221" Image="resources/Entities/221.0.0 - Cod Worm.png" Kind="Enemies" Name="Cod Worm" Subtype="0" Variant="0" />
-	<entity BaseHP="5" Group="Flies" ID="222" Image="resources/Entities/222.0.0 - Ring Fly.png" Kind="Enemies" Name="Ring Fly" Subtype="0" Variant="0" />
-	<entity BaseHP="62" Group="Poop" ID="223" Image="resources/Entities/223.0.0 - Dinga.png" Kind="Enemies" Name="Dinga" Subtype="0" Variant="0" />
-	<entity BaseHP="100" Group="Other" ID="224" Image="resources/Entities/224.0.0 - Oob.png" Kind="Enemies" Name="Oob" Subtype="0" Variant="0" />
-	<entity BaseHP="20" Group="Maws" ID="225" Image="resources/Entities/225.0.0 - Black Maw.png" Kind="Enemies" Name="Black Maw" Subtype="0" Variant="0" />
-	<entity BaseHP="10" Group="Gapers" ID="226" Image="resources/Entities/226.0.0 - Skinny.png" Kind="Enemies" Name="Skinny" Subtype="0" Variant="0" />
-	<entity BaseHP="16" Group="Gapers" ID="226" Image="resources/Entities/226.1.0 - Rotty.png" Kind="Enemies" Name="Rotty" Subtype="0" Variant="1" />
-	<entity BaseHP="8" Group="Gapers" ID="227" Image="resources/Entities/227.0.0 - Boney Head.png" Kind="Enemies" Name="Boney" Subtype="0" Variant="0" />
-	<entity BaseHP="36" Group="Other" ID="228" Image="resources/Entities/228.0.0 - Homunculus.png" Kind="Enemies" Name="Homunculus" Subtype="0" Variant="0" />
-	<entity BaseHP="20" Group="Organs" ID="229" Image="resources/Entities/229.0.0 - Tumor.png" Kind="Enemies" Name="Tumor" Subtype="0" Variant="0" />
-	<entity BaseHP="32" Group="Organs" ID="230" Image="resources/Entities/230.0.0 - Camillo Jr.png" Kind="Enemies" Name="Camillo Jr." Subtype="0" Variant="0" />
-	<entity BaseHP="20" Group="Organs" ID="231" Image="resources/Entities/231.0.0 - Nerve Ending.png" Kind="Enemies" Name="Nerve Ending" Subtype="0" Variant="0" />
-	<entity BaseHP="20" Group="Other" ID="234" Image="resources/Entities/234.0.0 - One Tooth.png" Kind="Enemies" Name="One Tooth" Subtype="0" Variant="0" />
-	<entity BaseHP="100" Group="Stones" ID="235" Image="resources/Entities/235.0.0 - Gaping Maw.png" Kind="Enemies" Name="Gaping Maw" Subtype="0" Variant="0" />
-	<entity BaseHP="24" Champion="1" Group="Other" ID="237" Image="resources/Entities/237.0.0 - Gurgling.png" Kind="Enemies" Name="Gurgling" Subtype="0" Variant="0" />
-	<entity BaseHP="90" Boss="1" Group="Boss Rooms" ID="237" Image="resources/Entities/237.1.0 - Gurgling (boss).png" Kind="Bosses" Name="Gurgling (boss)" Subtype="0" Variant="1" />
-	<entity BaseHP="10" Group="Gapers" ID="238" Image="resources/Entities/238.0.0 - Splasher.png" Kind="Enemies" Name="Splasher" Subtype="0" Variant="0" />
-	<entity BaseHP="10" Group="Worms" ID="239" Image="resources/Entities/239.0.0 - Grub.png" Kind="Enemies" Name="Grub" Subtype="0" Variant="0" />
-	<entity BaseHP="10" Group="Spiders" ID="240" Image="resources/Entities/240.0.0 - Wall Creep.png" Kind="Enemies" Name="Wall Creep" Subtype="0" Variant="0" />
-	<entity BaseHP="10" Group="Spiders" ID="241" Image="resources/Entities/241.0.0 - Rage Creep.png" Kind="Enemies" Name="Rage Creep" Subtype="0" Variant="0" />
-	<entity BaseHP="10" Group="Spiders" ID="242" Image="resources/Entities/242.0.0 - Blind Creep.png" Kind="Enemies" Name="Blind Creep" Subtype="0" Variant="0" />
-	<entity BaseHP="18" Group="Worms" ID="243" Image="resources/Entities/243.0.0 - Conjoined Spitty.png" Kind="Enemies" Name="Conjoined Spitty" Subtype="0" Variant="0" />
-	<entity BaseHP="10" Group="Worms" ID="244" Image="resources/Entities/244.0.0 - Round Worm.png" Kind="Enemies" Name="Round Worm" Subtype="0" Variant="0" />
-	<entity Group="Props" ID="245" Image="resources/Entities/1500.0.0 - Poop.png" Kind="Stage" Name="Pushable Poop" Subtype="0" Variant="0" />
-	<entity BaseHP="13" Champion="1" Group="Spiders" ID="246" Image="resources/Entities/246.0.0 - Ragling.png" Kind="Enemies" Name="Ragling" Subtype="0" Variant="0" />
-	<entity BaseHP="27" Champion="1" Group="Hosts" ID="247" Image="resources/Entities/247.0.0 - Flesh Mobile Host.png" Kind="Enemies" Name="Flesh Mobile Host" Subtype="0" Variant="0" />
-	<entity BaseHP="10" Champion="1" Group="Maws" ID="248" Image="resources/Entities/248.0.0 - Psychic Horf.png" Kind="Enemies" Name="Psychic Horf" Subtype="0" Variant="0" />
-	<entity BaseHP="10" Group="Flies" ID="249" Image="resources/Entities/249.0.0 - Full Fly.png" Kind="Enemies" Name="Full Fly" Subtype="0" Variant="0" />
-	<entity BaseHP="13" Group="Spiders" ID="250" Image="resources/Entities/250.0.0 - Ticking Spider.png" Kind="Enemies" Name="Ticking Spider" Subtype="0" Variant="0" />
-	<entity BaseHP="60" Group="Other" ID="251" Image="resources/Entities/251.0.0 - Begotten.png" Kind="Enemies" Name="Begotten" Subtype="0" Variant="0" />
-	<entity BaseHP="30" Champion="1" Group="Gapers" ID="252" Image="resources/Entities/252.0.0 - Null.png" Kind="Enemies" Name="Null" Subtype="0" Variant="0" />
-	<entity BaseHP="40" Group="Organs" ID="253" Image="resources/Entities/253.0.0 - Psy Tumor.png" Kind="Enemies" Name="Psy Tumor" Subtype="0" Variant="0" />
-	<entity BaseHP="20" Champion="1" Group="Knights" ID="254" Image="resources/Entities/254.0.0 - Floating Knight.png" Kind="Enemies" Name="Floating Knight" Subtype="0" Variant="0" />
-	<entity BaseHP="35" Group="Worms" ID="255" Image="resources/Entities/255.0.0 - Night Crawler.png" Kind="Enemies" Name="Night Crawler" Subtype="0" Variant="0" />
-	<entity BaseHP="200" Boss="1" Group="Boss Rooms" ID="260" Image="resources/Entities/260.0.0 - Haunt.png" Kind="Bosses" Name="Haunt" Subtype="0" Variant="0" />
-	<entity BaseHP="25" Group="Other" ID="260" Image="resources/Entities/260.10.0 - Lil' Haunt.png" Kind="Enemies" Name="Lil' Haunt" Subtype="0" Variant="10" />
-	<entity BaseHP="300" Boss="1" Group="Boss Rooms" ID="261" Image="resources/Entities/261.0.0 - Dingle.png" Kind="Bosses" Name="Dingle" Subtype="0" Variant="0" />
-	<entity BaseHP="350" Boss="1" Group="Boss Rooms" ID="262" Image="resources/Entities/262.0.0 - Mega Maw.png" Kind="Bosses" Name="Mega Maw" Subtype="0" Variant="0" />
-	<entity BaseHP="500" Boss="1" Group="Boss Rooms" ID="263" Image="resources/Entities/263.0.0 - The Gate.png" Kind="Bosses" Name="The Gate" Subtype="0" Variant="0" />
-	<entity BaseHP="600" Boss="1" Group="Boss Rooms" ID="264" Image="resources/Entities/264.0.0 - Mega Fatty.png" Kind="Bosses" Name="Mega Fatty" Subtype="0" Variant="0" />
-	<entity BaseHP="800" Boss="1" Group="Boss Rooms" ID="265" Image="resources/Entities/265.0.0 - The Cage.png" Kind="Bosses" Name="The Cage" Subtype="0" Variant="0" />
-	<entity BaseHP="750" Boss="1" Group="Boss Rooms" ID="266" Image="resources/Entities/266.0.0 - Mama Gurdy.png" Kind="Bosses" Name="Mama Gurdy" Subtype="0" Variant="0" />
-	<entity BaseHP="400" Boss="1" Group="Boss Rooms" ID="267" Image="resources/Entities/267.0.0 - Dark One.png" Kind="Bosses" Name="Dark One" Subtype="0" Variant="0" />
-	<entity BaseHP="520" Boss="1" Group="Boss Rooms" ID="268" Image="resources/Entities/268.0.0 - The Adversary.png" Kind="Bosses" Name="The Adversary" Subtype="0" Variant="0" />
-	<entity BaseHP="200" Boss="1" Group="Boss Rooms" ID="269" Image="resources/Entities/269.0.0 - Polycephalus.png" Kind="Bosses" Name="Polycephalus" Subtype="0" Variant="0" />
-	<entity BaseHP="500" Boss="1" Group="Boss Rooms" ID="270" Image="resources/Entities/270.0.0 - Mr. Fred.png" Kind="Bosses" Name="Mr. Fred" Subtype="0" Variant="0" />
-	<entity Boss="1" Group="Heaven and Hell" ID="271" Image="resources/Entities/271.0.0 - Uriel.png" Kind="Bosses" Name="Uriel" Subtype="0" Variant="0" />
-	<entity Boss="1" Group="Heaven and Hell" ID="271" Image="resources/Entities/271.0.1 - Fallen Uriel.png" Kind="Bosses" Name="Fallen Uriel" Subtype="0" Variant="1" />
-	<entity Boss="1" Group="Heaven and Hell" ID="272" Image="resources/Entities/272.0.0 - Gabriel.png" Kind="Bosses" Name="Gabriel" Subtype="0" Variant="0" />
-	<entity Boss="1" Group="Heaven and Hell" ID="272" Image="resources/Entities/272.0.1 - Fallen Gabriel.png" Kind="Bosses" Name="Fallen Gabriel" Subtype="0" Variant="1" />
-	<entity BaseHP="2000" Boss="1" Group="Heaven and Hell" ID="273" Image="resources/Entities/273.0.0 - The Lamb.png" Kind="Bosses" Name="The Lamb" Subtype="0" Variant="0" />
-	<entity BaseHP="3000" Boss="1" Group="Heaven and Hell" ID="274" Image="resources/Entities/274.0.0 - Mega Satan's Head.png" Kind="Bosses" Name="Mega Satan's Head" Subtype="0" Variant="0" />
-	<entity BaseHP="600" Boss="1" Group="Heaven and Hell" ID="274" Image="resources/Entities/274.1.0 - Mega Satan's Right Hand.png" Kind="Bosses" Name="Mega Satan's Right Hand" Subtype="0" Variant="1" />
-	<entity BaseHP="600" Boss="1" Group="Heaven and Hell" ID="274" Image="resources/Entities/274.2.0 - Mega Satan's Left Hand.png" Kind="Bosses" Name="Mega Satan's Left Hand" Subtype="0" Variant="2" />
+	<!--——— Pickups ———-->
+	<group Name="Pickups">
+		<defaults>
+			<entity>
+				<tag>InNonCombatRooms</tag>
+			</entity>
+		</defaults>
+		<group Name="(Pickups) Random" Label="Random">
+			<group Name="Random Collectibles">
+				<entity ID="5" Variant="100" Subtype="0" Name="Random Collectible" Image="Entities/Items/5.100.0 - Random.png"/>
+				<entity ID="5" Variant="150" Subtype="0" Name="Random Shop Item" Image="Entities/Items/5.150.0 - Random.png"/>
+				<entity ID="5" Variant="350" Subtype="0" Name="Random Trinket" Image="Entities/5.350.0 - Trinket.png"/>
+			</group>
+			<group Name="Random All Pickups">
+				<entity ID="5" Variant="0" Subtype="0" Name="Pickup" Image="Entities/5.0.0 - Pickup.png"/>
+				<entity ID="5" Variant="0" Subtype="1" Name="Pickup (not chest or item)" Image="Entities/5.0.1 - Pickup.png"/>
+				<entity ID="5" Variant="0" Subtype="2" Name="Pickup (not item)" Image="Entities/5.0.2 - Pickup.png"/>
+				<entity ID="5" Variant="0" Subtype="3" Name="Greed Pickup (no chest, item, or coin)" Image="Entities/5.0.3 - Pickup.png"/>
+				<entity ID="5" Variant="0" Subtype="4" Name="Pickup (no chest, item, or trinket)" Image="Entities/5.0.4 - Pickup.png"/>
+			</group>
+			<entity ID="5" Image="Entities/5.10.0 - RHeart.png" Name="Random Heart" Subtype="0" Variant="10"/>
+			<entity ID="5" Image="Entities/5.20.0 - RCoin.png" Name="Random Coin" Subtype="0" Variant="20"/>
+			<entity ID="5" Image="Entities/5.30.0 - RKey.png" Name="Random Key" Subtype="0" Variant="30"/>
+			<entity ID="5" Image="Entities/5.40.0 - RBomb.png" Name="Random Bomb" Subtype="0" Variant="40"/>
+			<entity ID="5" Image="Entities/5.90.1 - Lil' Battery.png" Name="Lil' Battery" Subtype="0" Variant="90"/>
+			<entity ID="5" Image="Entities/5.70.0 - Random Pill.png" Name="Random Pill" Subtype="0" Variant="70"/>
+			<entity ID="5" Image="Entities/5.301.0 - Random Rune.png" Name="Random Rune" Subtype="0" Variant="301"/>
+			<entity ID="5" Image="Entities/5.300.0 - Random Card.png" Name="Random Card" Subtype="0" Variant="300"/>
+		</group>
+		<group Label="Hearts">
+			<entity Name="Random Heart"/>
+			<group Name="Red Hearts">
+				<entity ID="5" Image="Entities/5.10.1 - Heart.png" Name="Heart" Subtype="1" Variant="10"/>
+				<entity ID="5" Image="Entities/5.10.2 - Heart (half).png" Name="Heart (half)" Subtype="2" Variant="10"/>
+				<entity ID="5" Image="Entities/5.10.5 - Heart (double).png" Name="Heart (double)" Subtype="5" Variant="10"/>
+			</group>
+			<group Name="Soul Hearts">
+				<entity ID="5" Image="Entities/5.10.3 - Heart (soul).png" Name="Heart (soul)" Subtype="3" Variant="10"/>
+			</group>
+			<entity ID="5" Image="Entities/5.10.6 - Black Heart.png" Name="Black Heart" Subtype="6" Variant="10"/>
+			<entity ID="5" Image="Entities/5.10.4 - Heart (eternal).png" Name="Heart (eternal)" Subtype="4" Variant="10"/>
+		</group>
+		<group Label="Coins">
+			<entity Name="Random Coin"/>
+			<entity ID="5" Image="Entities/5.20.1 - Penny.png" Name="Penny" Subtype="1" Variant="20"/>
+			<entity ID="5" Image="Entities/5.20.4 - Double Penny.png" Name="Double Penny" Subtype="4" Variant="20"/>
+			<entity ID="5" Image="Entities/5.20.2 - Nickel.png" Name="Nickel" Subtype="2" Variant="20"/>
+			<entity ID="5" Image="Entities/5.20.3 - Dime.png" Name="Dime" Subtype="3" Variant="20"/>
+		</group>
+		<group Label="Keys">
+			<entity Name="Random Key"/>
+			<entity ID="5" Image="Entities/5.30.1 - Key.png" Name="Key" Subtype="1" Variant="30"/>
+			<entity ID="5" Image="Entities/5.30.3 - Key Ring.png" Name="Key Ring" Subtype="3" Variant="30"/>
+			<entity ID="5" Image="Entities/5.30.2 - Golden Key.png" Name="Golden Key" Subtype="2" Variant="30"/>
+		</group>
+		<group Label="Bombs">
+			<entity Name="Random Bomb"/>
+			<entity ID="5" Image="Entities/5.40.1 - Bomb.png" Name="Bomb" Subtype="1" Variant="40"/>
+			<entity ID="5" Image="Entities/5.40.2 - Double Bomb.png" Name="Double Bomb" Subtype="2" Variant="40"/>
+		</group>
+		<group Label="Batteries"/>
+		<group Name="Pickup Containers" Label="Chests">
+			<group Name="Chests">
+				<entity ID="5" Image="Entities/5.50.0 - Chest.png" Name="Chest" Subtype="0" Variant="50"/>
+				<entity ID="5" Image="Entities/5.60.0 - Locked Chest.png" Name="Locked Chest" Subtype="0" Variant="60"/>
+				<entity ID="5" Image="Entities/5.360.0 - Red Chest.png" Name="Red Chest" Subtype="0" Variant="360"/>
+				<entity ID="5" Image="Entities/5.51.0 - Bomb Chest.png" Name="Bomb Chest" Subtype="0" Variant="51"/>
+			</group>
+		</group>
+		<group Label="Pills">
+			<entity Name="Random Pill"/>
+			<group Name="Pill Colors">
+				<entity ID="5" Image="Entities/5.70.1 - Blue Pill.png" Name="Blue Pill" Subtype="1" Variant="70" />
+				<entity ID="5" Image="Entities/5.70.2 - White-Blue Pill.png" Name="White-Blue Pill" Subtype="2" Variant="70" />
+				<entity ID="5" Image="Entities/5.70.3 - Orange Pill.png" Name="Orange Pill" Subtype="3" Variant="70" />
+				<entity ID="5" Image="Entities/5.70.4 - White Pill.png" Name="White Pill" Subtype="4" Variant="70" />
+				<entity ID="5" Image="Entities/5.70.5 - Dots-Red Pill.png" Name="Dots-Red Pill" Subtype="5" Variant="70" />
+				<entity ID="5" Image="Entities/5.70.6 - Pink-Red Pill.png" Name="Pink-Red Pill" Subtype="6" Variant="70" />
+				<entity ID="5" Image="Entities/5.70.7 - Blue-Cadetblue Pill.png" Name="Blue-Cadetblue Pill" Subtype="7" Variant="70" />
+				<entity ID="5" Image="Entities/5.70.8 - Yellow-Orange Pill.png" Name="Yellow-Orange Pill" Subtype="8" Variant="70" />
+				<entity ID="5" Image="Entities/5.70.9 - Dots-White Pill.png" Name="Dots-White Pill" Subtype="9" Variant="70" />
+			</group>
+		</group>
+		<group Label="Cards">
+			<entity Name="Random Card"/>
+			<group Name="Tarot Cards">
+				<entity ID="5" Image="Entities/5.300.1 - The Fool.png" Name="The Fool" Subtype="1" Variant="300" />
+				<entity ID="5" Image="Entities/5.300.2 - The Magician.png" Name="The Magician" Subtype="2" Variant="300" />
+				<entity ID="5" Image="Entities/5.300.3 - The High Priestess.png" Name="The High Priestess" Subtype="3" Variant="300" />
+				<entity ID="5" Image="Entities/5.300.4 - The Empress.png" Name="The Empress" Subtype="4" Variant="300" />
+				<entity ID="5" Image="Entities/5.300.5 - The Emperor.png" Name="The Emperor" Subtype="5" Variant="300" />
+				<entity ID="5" Image="Entities/5.300.6 - The Hierophant.png" Name="The Hierophant" Subtype="6" Variant="300" />
+				<entity ID="5" Image="Entities/5.300.7 - The Lovers.png" Name="The Lovers" Subtype="7" Variant="300" />
+				<entity ID="5" Image="Entities/5.300.8 - The Chariot.png" Name="The Chariot" Subtype="8" Variant="300" />
+				<entity ID="5" Image="Entities/5.300.9 - Justice.png" Name="Justice" Subtype="9" Variant="300" />
+				<entity ID="5" Image="Entities/5.300.10 - The Hermit.png" Name="The Hermit" Subtype="10" Variant="300" />
+				<entity ID="5" Image="Entities/5.300.11 - Wheel of Fortune.png" Name="Wheel of Fortune" Subtype="11" Variant="300" />
+				<entity ID="5" Image="Entities/5.300.12 - Strength.png" Name="Strength" Subtype="12" Variant="300" />
+				<entity ID="5" Image="Entities/5.300.13 - The Hanged Man.png" Name="The Hanged Man" Subtype="13" Variant="300" />
+				<entity ID="5" Image="Entities/5.300.14 - Death.png" Name="Death" Subtype="14" Variant="300" />
+				<entity ID="5" Image="Entities/5.300.15 - Temperance.png" Name="Temperance" Subtype="15" Variant="300" />
+				<entity ID="5" Image="Entities/5.300.16 - The Devil.png" Name="The Devil" Subtype="16" Variant="300" />
+				<entity ID="5" Image="Entities/5.300.17 - The Tower.png" Name="The Tower" Subtype="17" Variant="300" />
+				<entity ID="5" Image="Entities/5.300.18 - The Stars.png" Name="The Stars" Subtype="18" Variant="300" />
+				<entity ID="5" Image="Entities/5.300.19 - The Moon.png" Name="The Moon" Subtype="19" Variant="300" />
+				<entity ID="5" Image="Entities/5.300.20 - The Sun.png" Name="The Sun" Subtype="20" Variant="300" />
+				<entity ID="5" Image="Entities/5.300.21 - Judgement.png" Name="Judgement" Subtype="21" Variant="300" />
+				<entity ID="5" Image="Entities/5.300.22 - The World.png" Name="The World" Subtype="22" Variant="300" />
+			</group>
+			<group Name="Playing Cards">
+				<entity ID="5" Image="Entities/5.300.23 - 2 of Clubs.png" Name="2 of Clubs" Subtype="23" Variant="300" />
+				<entity ID="5" Image="Entities/5.300.24 - 2 of Diamonds.png" Name="2 of Diamonds" Subtype="24" Variant="300" />
+				<entity ID="5" Image="Entities/5.300.25 - 2 of Spades.png"  Name="2 of Spades" Subtype="25" Variant="300" />
+				<entity ID="5" Image="Entities/5.300.26 - 2 of Hearts.png" Name="2 of Hearts" Subtype="26" Variant="300" />
+			</group>
+			<entity ID="5" Image="Entities/5.300.31 - Joker.png" Name="Joker" Subtype="27" Variant="300" />
+			<entity ID="5" Image="Entities/5.300.42 - Chaos Card.png" Name="Chaos Card" Subtype="36" Variant="300" />
+			<entity ID="5" Image="Entities/5.300.43 - Credit Card.png" Name="Credit Card" Subtype="37" Variant="300" />
+			<entity ID="5" Image="Entities/5.300.44 - Rules Card.png" Name="Rules Card" Subtype="38" Variant="300" />
+			<entity ID="5" Image="Entities/5.300.45 - A Card Against Humanity.png" Name="A Card Against Humanity" Subtype="39" Variant="300" />
+			<entity ID="5" Image="Entities/5.300.46 - Suicide King.png" Name="Suicide King" Subtype="40" Variant="300" />
+		</group>
+		<group Label="Runes">
+			<entity Name="Random Rune"/>
+			<entity ID="5" Image="Entities/5.300.32 - Hagalaz.png" Name="Hagalaz" Subtype="28" Variant="300" />
+			<entity ID="5" Image="Entities/5.300.33 - Jera.png" Name="Jera" Subtype="29" Variant="300" />
+			<entity ID="5" Image="Entities/5.300.34 - Ehwaz.png" Name="Ehwaz" Subtype="30" Variant="300" />
+			<entity ID="5" Image="Entities/5.300.35 - Dagaz.png" Name="Dagaz" Subtype="31" Variant="300" />
+			<entity ID="5" Image="Entities/5.300.36 - Ansuz.png" Name="Ansuz" Subtype="32" Variant="300" />
+			<entity ID="5" Image="Entities/5.300.37 - Perthro.png" Name="Perthro" Subtype="33" Variant="300" />
+			<entity ID="5" Image="Entities/5.300.38 - Berkano.png" Name="Berkano" Subtype="34" Variant="300" />
+			<entity ID="5" Image="Entities/5.300.39 - Algiz.png" Name="Algiz" Subtype="35" Variant="300" />
+		</group>
+	</group>
 
-	<entity Group="Obstacles" ID="1000" Image="resources/Entities/1000.0.0 - Rock.png" Kind="Stage" Name="Rock" Subtype="0" Variant="0" InEmptyRooms="1" IsGrid="1" UseRockTiling="1" />
-	<entity Group="Traps" ID="1001" Image="resources/Entities/1001.0.0 - Bomb Rock.png" Kind="Stage" Name="Bomb Rock" Subtype="0" Variant="0" InEmptyRooms="1" IsGrid="1" />
-	<entity Group="Obstacles" ID="1002" Image="resources/Entities/1002.0.0 - Pot.png" Kind="Stage" Name="Pot" Subtype="0" Variant="0" InEmptyRooms="1" IsGrid="1" />
-	<entity Group="Traps" ID="1300" Image="resources/Entities/1300.0.0 - TNT.png" Kind="Stage" Name="TNT" Subtype="0" Variant="0" InEmptyRooms="1" IsGrid="1" />
-	<entity Group="Fireplaces" ID="1400" Image="resources/Entities/33.0.0 - Fire Place.png" Kind="Stage" Name="Fire" Subtype="0" Variant="0" InEmptyRooms="1" IsGrid="1" />
-	<entity Group="Fireplaces" ID="1410" Image="resources/Entities/33.1.0 - Red Fire Place.png" Kind="Stage" Name="Red Fire" Subtype="0" Variant="0" InEmptyRooms="1" IsGrid="1" />
-	<entity Group="Poop" ID="1490" Image="resources/Entities/1490.0.0 - Red Poop.png" Kind="Stage" Name="Red Poop" Subtype="0" Variant="0" />
-	<entity Group="Poop" ID="1494" Image="resources/Entities/1494.0.0 - Rainbow Poop.png" Kind="Stage" Name="Rainbow Poop" Subtype="0" Variant="0" />
-	<entity Group="Poop" ID="1495" Image="resources/Entities/1495.0.0 - Chunky Poop.png" Kind="Stage" Name="Chunky Poop" Subtype="0" Variant="0" />
-	<entity Group="Poop" ID="1496" Image="resources/Entities/1496.0.0 - Golden Poop.png" Kind="Stage" Name="Golden Poop" Subtype="0" Variant="0" />
-	<entity Group="Poop" ID="1500" Image="resources/Entities/1500.0.0 - Poop.png" Kind="Stage" Name="Poop" Subtype="0" Variant="0" InEmptyRooms="1" IsGrid="1" />
-	<entity Group="Obstacles" ID="1900" Image="resources/Entities/1900.0.0 - Block.png" Kind="Stage" Name="Block" Subtype="0" Variant="0" InEmptyRooms="1" IsGrid="1" />
-	<entity Group="Traps" ID="1930" Image="resources/Entities/1930.0.0 - Spikes.png" Kind="Stage" Name="Spikes" Subtype="0" Variant="0" InEmptyRooms="1" IsGrid="1" />
-	<entity Group="Traps" ID="1931" Image="resources/Entities/1931.0.0 - Retracting Spikes.png" Kind="Stage" Name="Retracting Spikes" Subtype="0" Variant="0" InEmptyRooms="1" IsGrid="1" />
-	<entity Group="Traps" ID="1940" Image="resources/Entities/1940.0.0 - Cobweb.png" Kind="Stage" Name="Cobweb" Subtype="0" Variant="0" InEmptyRooms="1" IsGrid="1" />
-	<entity Group="Obstacles" ID="3000" Image="resources/Entities/3000.0.0 - Pit.png" Kind="Stage" Name="Pit" Subtype="0" Variant="0" InEmptyRooms="1" IsGrid="1" UsePitTiling="1" />
-	<entity Group="Traps" ID="4000" Image="resources/Entities/4000.0.0 - Key Block.png" Kind="Stage" Name="Key Block" Subtype="0" Variant="0" InEmptyRooms="1" IsGrid="1" />
-	<entity Group="Traps" ID="4500" Image="resources/Entities/4500.0.0 - Pressure Plate.png" Kind="Stage" Name="Pressure Plate" Subtype="0" Variant="0" />
-	<entity Group="Special Exits" ID="9000" Image="resources/Entities/9000.0.0 - Trap Door.png" Kind="Stage" Name="Trap Door" Subtype="0" Variant="0" />
-	<entity Group="Special Exits" ID="9100" Image="resources/Entities/9100.0.0 - Ladder Door.png" Kind="Stage" Name="Ladder Door" Subtype="0" Variant="0" />
-	<entity Group="Traps" ID="10000" Image="resources/Entities/10000.0.0 - Gravity.png" Kind="Stage" Name="Gravity" Subtype="0" Variant="0" />
+	<!--——— Global ———-->
+	<group Name="Global">
+		<group Name="Top Grids">
+			<group Label="Grids">
+				<defaults>
+					<entity>
+						<tag>Grid</tag>
+						<tag>InEmptyRooms</tag>
+						<tag>InNonCombatRooms</tag>
+					</entity>
+				</defaults>
+				<group Name="Rocks">
+					<group Name="Basic Rock">
+						<entity ID="1000" Image="Entities/1000.0.0 - Rock.png" Name="Rock" Subtype="0" Variant="0" EditorImage="Backgrounds/rocks_generic.png" UseRockTiling="1" />
+					</group>
+					<entity ID="1001" Image="Entities/1001.0.0 - Bomb Rock.png" Name="Bomb Rock" Subtype="0" Variant="0" />
+				</group>
+				<group Name="Alt Rocks">
+					<entity ID="1002" Image="Entities/1002.0.0 - Pot.png" Name="Pot" Subtype="0" Variant="0" />
+				</group>
+				<group Name="Metal Blocks">
+					<entity ID="1900" Image="Entities/1900.0.0 - Block.png" Name="Block" Subtype="0" Variant="0" />
+					<entity ID="4000" Image="Entities/4000.0.0 - Key Block.png" Name="Key Block" Subtype="0" Variant="0" />
+				</group>
+				<entity ID="3000" Image="Entities/3000.0.0 - Pit.png" Name="Pit" Subtype="0" Variant="0" EditorImage="Backgrounds/pit_generic.png" UsePitTiling="1" />
+				<group Name="TNT">
+					<entity ID="1300" Image="Entities/1300.0.0 - TNT.png" Name="TNT" Subtype="0" Variant="0" />
+				</group>
+				<entity ID="1940" Image="Entities/1940.0.0 - Cobweb.png" Name="Cobweb" Subtype="0" Variant="0">
+					<tag>NoBlockDoors</tag>
+				</entity>
+			</group>
+		</group>
+		<group Name="Miscellaneous Global Grids">
+			<group Label="Poops">
+				<defaults>
+					<entity>
+						<tag>Grid</tag>
+						<tag>InEmptyRooms</tag>
+						<tag>InNonCombatRooms</tag>
+					</entity>
+				</defaults>
+				<group Name="Normal Poops">
+					<entity ID="1500" Image="Entities/1500.0.0 - Poop.png" Name="Poop" Subtype="0" Variant="0" />
+				</group>
+				<group Name="Chunky Poops">
+					<entity ID="1495" Image="Entities/1495.0.0 - Chunky Poop.png" Name="Chunky Poop" Subtype="0" Variant="0" />
+				</group>
+				<entity ID="1490" Image="Entities/1490.0.0 - Red Poop.png" Name="Red Poop" Subtype="0" Variant="0" />
+				<entity ID="1496" Image="Entities/1496.0.0 - Golden Poop.png" Name="Golden Poop" Subtype="0" Variant="0" />
+				<entity ID="1494" Image="Entities/1494.0.0 - Rainbow Poop.png" Name="Rainbow Poop" Subtype="0" Variant="0" />
+			</group>
+			<group Label="Fireplaces">
+				<defaults>
+					<entity>
+						<tag>Grid</tag>
+						<tag>InEmptyRooms</tag>
+						<tag>InNonCombatRooms</tag>
+					</entity>
+				</defaults>
+				<entity BaseHP="5" ID="33" Image="Entities/33.0.0 - Fire Place.png" Name="Fire Place" Subtype="0" Variant="0" />
+				<entity BaseHP="5" ID="33" Image="Entities/33.1.0 - Red Fire Place.png" Name="Red Fire Place" Subtype="0" Variant="1" />
+				<entity BaseHP="5" ID="33" Image="Entities/33.2.0 - Blue Fire Place.png" Name="Blue Fire Place" Subtype="0" Variant="2" />
+				<entity BaseHP="5" ID="33" Image="Entities/33.3.0 - Purple Fire Place.png" Name="Purple Fire Place" Subtype="0" Variant="3" />
+				<entity ID="1400" Image="Entities/1400.0.0 - Fire (non-replaceable).png" Name="Fire (non-replaceable)" Subtype="0" Variant="0"/>
+				<entity ID="1410" Image="Entities/1410.0.0 - Red Fire (redundant).png" Name="Red Fire (redundant)" Subtype="0" Variant="0"/>
+			</group>
+			<group Label="Spikes">
+				<defaults>
+					<entity>
+						<tag>Grid</tag>
+						<tag>InEmptyRooms</tag>
+						<tag>InNonCombatRooms</tag>
+					</entity>
+				</defaults>
+				<entity ID="1930" Image="Entities/1930.0.0 - Spikes.png" Name="Spikes" Subtype="0" Variant="0" />
+				<group Name="Retracting Spikes">
+					<defaults>
+						<entity>
+							<tag>RetractingSpikes</tag>
+						</entity>
+					</defaults>
+					<entity ID="1931" Image="Entities/1931.0.0 - Retracting Spikes.png" Name="Retracting Spikes" Subtype="0" Variant="0" />
+				</group>
+			</group>
+			<group Label="Wall Huggers">
+				<defaults>
+					<entity>
+						<tag>InNonCombatRooms</tag>
+						<tag>WallHuggers</tag>
+					</entity>
+				</defaults>
+				<entity BaseHP="100" ID="218" Image="Entities/218.0.0 - Wall Hugger.png" PlaceVisual="0,0.5" Name="Wall Hugger (Random)" Subtype="0" Variant="0" />
+				<entity BaseHP="100" ID="218" Image="Entities/218.0.1 - Wall Hugger (Left).png" PlaceVisual="0,0.3" Name="Wall Hugger (Left)" Subtype="1" Variant="0" MirrorX="218.0.3" />
+				<entity BaseHP="100" ID="218" Image="Entities/218.0.2 - Wall Hugger (Up).png" PlaceVisual="0,0.5" Name="Wall Hugger (Up)" Subtype="2" Variant="0" MirrorY="218.0.4" />
+				<entity BaseHP="100" ID="218" Image="Entities/218.0.3 - Wall Hugger (Right).png" PlaceVisual="0,0.3" Name="Wall Hugger (Right)" Subtype="3" Variant="0" MirrorX="218.0.1" />
+				<entity BaseHP="100" ID="218" Image="Entities/218.0.4 - Wall Hugger (Down).png" PlaceVisual="0,0.25" Name="Wall Hugger (Down)" Subtype="4" Variant="0" MirrorY="218.0.2" />
+			</group>
+			<group Label="Troll Bombs">
+				<entity ID="5" Image="Entities/4.0.3 - Troll Bomb.png" Name="Troll Bomb" Subtype="3" Variant="40" />
+				<entity ID="5" Image="Entities/4.0.4 - Megatroll Bomb.png" Name="Megatroll Bomb" Subtype="5" Variant="40" />
+			</group>
+			<group Label="Bums">
+				<defaults>
+					<entity>
+						<tag>InNonCombatRooms</tag>
+					</entity>
+				</defaults>
+				<group Name="Beggars">
+					<entity ID="6" Image="Entities/6.4.0 - Beggar.png" Name="Beggar" Subtype="0" Variant="4" />
+					<entity ID="6" Image="Entities/6.5.0 - Devil Beggar.png" Name="Devil Beggar" Subtype="0" Variant="5" />
+					<entity ID="6" Image="Entities/6.7.0 - Key Master.png" Name="Key Master" Subtype="0" Variant="7" />
+				</group>
+				<group Name="Shell Game">
+					<entity ID="6" Image="Entities/6.6.0 - Shell Game.png" Name="Shell Game" Subtype="0" Variant="6" />
+				</group>
+			</group>
+			<group Label="Machines">
+				<defaults>
+					<entity>
+						<tag>InNonCombatRooms</tag>
+					</entity>
+				</defaults>
+				<entity ID="6" Image="Entities/6.1.0 - Slot Machine.png" Name="Slot Machine" Subtype="0" Variant="1" />
+				<entity ID="6" Image="Entities/6.2.0 - Blood Donation Machine.png" Name="Blood Donation Machine" Subtype="0" Variant="2" />
+				<entity ID="6" Image="Entities/6.3.0 - Fortune Telling Machine.png" Name="Fortune Telling Machine" Subtype="0" Variant="3" />
+				<entity ID="6" Image="Entities/6.8.0 - Donation Machine.png" Name="Donation Machine" Subtype="0" Variant="8" />
+			</group>
+			<group Label="Props">
+				<defaults>
+					<entity>
+						<tag>Grid</tag>
+						<tag>InEmptyRooms</tag>
+						<tag>InNonCombatRooms</tag>
+						<tag>NoBlockDoors</tag>
+						<tag>RandomProps</tag>
+					</entity>
+				</defaults>
+				<entity ID="0" Image="Entities/0.10.0 - Random Props A.png" Name="Random Props A" Subtype="0" Variant="10"/>
+				<entity ID="0" Image="Entities/0.20.0 - Random Props B.png" Name="Random Props B" Subtype="0" Variant="20"/>
+				<entity ID="0" Image="Entities/0.30.0 - Random Props C.png" Name="Random Props C" Subtype="0" Variant="30"/>
+			</group>
+			<group Label="Exits">
+				<defaults>
+					<entity>
+						<tag>InNonCombatRooms</tag>
+					</entity>
+				</defaults>
+				<entity ID="5" Image="Entities/5.340.0 - Big Chest.png" Name="Big Chest" Subtype="0" Variant="340" />
+				<entity ID="5" Image="Entities/5.370.0 - Trophy.png" Name="Trophy" Subtype="0" Variant="370" />
+				<entity ID="9000" Image="Entities/9000.0.0 - Trap Door.png" Name="Trap Door" Subtype="0" Variant="0" PlaceVisual="0,0.1">
+					<tag>Grid</tag>
+				</entity>
+				<entity ID="9100" Image="Entities/9100.0.0 - Ladder Door.png" Name="Ladder Door" Subtype="0" Variant="0" PlaceVisual="0,0.1">
+					<tag>Grid</tag>
+				</entity>
+			</group>
+		</group>
+		<group Label="Special Grids">
+			<defaults>
+				<entity>
+					<tag>Grid</tag>
+				</entity>
+			</defaults>
+			<entity ID="10000" Image="Entities/10000.0.0 - Gravity.png" Name="Gravity" Subtype="0" Variant="0"/>
+		</group>
+		<group Label="Special Props">
+			<defaults>
+				<entity>
+					<tag>InNonCombatRooms</tag>
+				</entity>
+			</defaults>
+			<entity ID="5" Image="Entities/5.380.0 - Isaac's Bed.png" PlaceVisual="0,1" Name="Isaac's Bed" Subtype="0" Variant="380">
+				<tag>Grid</tag>
+			</entity>
+			<entity Image="Entities/1000.74.0 - Isaacs Carpet.png" ID="999" Name="Isaac's Carpet" Variant="74" Subtype="0" PlaceVisual="0,1.5">
+				<tag>Grid</tag>
+				<tag>NoBlockDoors</tag>
+			</entity>
+			<group Name="Shopkeepers">
+				<entity BaseHP="5" ID="17" Image="Entities/17.0.0 - Keeper.png" Name="Keeper" Subtype="0" Variant="0" />
+				<entity BaseHP="5" ID="17" Image="Entities/17.1.0 - Hanging Keeper.png" Name="Hanging Keeper" Subtype="0" Variant="1" />
+				<entity BaseHP="5" ID="17" Image="Entities/17.2.0 - Error Room Keeper.png" Name="Error Room Keeper" Subtype="0" Variant="2" />
+			</group>
+			<entity ID="5000" Image="Entities/5000.0.0 - Devil Statue.png" Name="Devil Statue" Subtype="0" Variant="0">
+				<tag>Grid</tag>
+			</entity>
+			<entity ID="5001" Image="Entities/5001.0.0 - Angel Statue.png" Name="Angel Statue" Subtype="0" Variant="0">
+				<tag>Grid</tag>
+			</entity>
+			<entity Image="Entities/1000.76.0 - Dice Floor.png" ID="999" Name="Dice Room Floor" Variant="76" Subtype="0" PlaceVisual="0,2.5">
+				<tag>Grid</tag>
+				<tag>NoBlockDoors</tag>
+			</entity>
+		</group>
+	</group>
 
-	<entity Group="Trinkets" ID="5" Image="resources/Entities/Trinkets/5.350.001 - Swallowed Penny.png" Kind="Collect" Name="Swallowed Penny" Subtype="1" Variant="350" />
-	<entity Group="Trinkets" ID="5" Image="resources/Entities/Trinkets/5.350.002 - Petrified Poop.png" Kind="Collect" Name="Petrified Poop" Subtype="2" Variant="350" />
-	<entity Group="Trinkets" ID="5" Image="resources/Entities/Trinkets/5.350.003 - AAA Battery.png" Kind="Collect" Name="AAA Battery" Subtype="3" Variant="350" />
-	<entity Group="Trinkets" ID="5" Image="resources/Entities/Trinkets/5.350.004 - Broken Remote.png" Kind="Collect" Name="Broken Remote" Subtype="4" Variant="350" />
-	<entity Group="Trinkets" ID="5" Image="resources/Entities/Trinkets/5.350.005 - Purple Heart.png" Kind="Collect" Name="Purple Heart" Subtype="5" Variant="350" />
-	<entity Group="Trinkets" ID="5" Image="resources/Entities/Trinkets/5.350.006 - Broken Magnet.png" Kind="Collect" Name="Broken Magnet" Subtype="6" Variant="350" />
-	<entity Group="Trinkets" ID="5" Image="resources/Entities/Trinkets/5.350.007 - Rosary Bead.png" Kind="Collect" Name="Rosary Bead" Subtype="7" Variant="350" />
-	<entity Group="Trinkets" ID="5" Image="resources/Entities/Trinkets/5.350.008 - cartridge.png" Kind="Collect" Name="Cartridge" Subtype="8" Variant="350" />
-	<entity Group="Trinkets" ID="5" Image="resources/Entities/Trinkets/5.350.009 - Pulse Worm.png" Kind="Collect" Name="Pulse Worm" Subtype="9" Variant="350" />
-	<entity Group="Trinkets" ID="5" Image="resources/Entities/Trinkets/5.350.010 - Wiggle Worm.png" Kind="Collect" Name="Wiggle Worm" Subtype="10" Variant="350" />
-	<entity Group="Trinkets" ID="5" Image="resources/Entities/Trinkets/5.350.011 - Ring Worm.png" Kind="Collect" Name="Ring Worm" Subtype="11" Variant="350" />
-	<entity Group="Trinkets" ID="5" Image="resources/Entities/Trinkets/5.350.012 - Flat Worm.png" Kind="Collect" Name="Flat Worm" Subtype="12" Variant="350" />
-	<entity Group="Trinkets" ID="5" Image="resources/Entities/Trinkets/5.350.013 - Store Credit.png" Kind="Collect" Name="Store Credit" Subtype="13" Variant="350" />
-	<entity Group="Trinkets" ID="5" Image="resources/Entities/Trinkets/5.350.014 - callus.png" Kind="Collect" Name="Callus" Subtype="14" Variant="350" />
-	<entity Group="Trinkets" ID="5" Image="resources/Entities/Trinkets/5.350.015 - Lucky Rock.png" Kind="Collect" Name="Lucky Rock" Subtype="15" Variant="350" />
-	<entity Group="Trinkets" ID="5" Image="resources/Entities/Trinkets/5.350.016 - Mom's Toenail.png" Kind="Collect" Name="Mom's Toenail" Subtype="16" Variant="350" />
-	<entity Group="Trinkets" ID="5" Image="resources/Entities/Trinkets/5.350.017 - Black Lipstick.png" Kind="Collect" Name="Black Lipstick" Subtype="17" Variant="350" />
-	<entity Group="Trinkets" ID="5" Image="resources/Entities/Trinkets/5.350.018 - Bible Tract.png" Kind="Collect" Name="Bible Tract" Subtype="18" Variant="350" />
-	<entity Group="Trinkets" ID="5" Image="resources/Entities/Trinkets/5.350.019 - Paper Clip.png" Kind="Collect" Name="Paper Clip" Subtype="19" Variant="350" />
-	<entity Group="Trinkets" ID="5" Image="resources/Entities/Trinkets/5.350.020 - Monkey Paw.png" Kind="Collect" Name="Monkey Paw" Subtype="20" Variant="350" />
-	<entity Group="Trinkets" ID="5" Image="resources/Entities/Trinkets/5.350.021 - Mysterious Paper.png" Kind="Collect" Name="Mysterious Paper" Subtype="21" Variant="350" />
-	<entity Group="Trinkets" ID="5" Image="resources/Entities/Trinkets/5.350.022 - Daemon's Tail.png" Kind="Collect" Name="Daemon's Tail" Subtype="22" Variant="350" />
-	<entity Group="Trinkets" ID="5" Image="resources/Entities/Trinkets/5.350.023 - Missing Poster.png" Kind="Collect" Name="Missing Poster" Subtype="23" Variant="350" />
-	<entity Group="Trinkets" ID="5" Image="resources/Entities/Trinkets/5.350.024 - Butt Penny.png" Kind="Collect" Name="Butt Penny" Subtype="24" Variant="350" />
-	<entity Group="Trinkets" ID="5" Image="resources/Entities/Trinkets/5.350.025 - Mysterious Candy.png" Kind="Collect" Name="Mysterious Candy" Subtype="25" Variant="350" />
-	<entity Group="Trinkets" ID="5" Image="resources/Entities/Trinkets/5.350.026 - Hook Worm.png" Kind="Collect" Name="Hook Worm" Subtype="26" Variant="350" />
-	<entity Group="Trinkets" ID="5" Image="resources/Entities/Trinkets/5.350.027 - Whip Worm.png" Kind="Collect" Name="Whip Worm" Subtype="27" Variant="350" />
-	<entity Group="Trinkets" ID="5" Image="resources/Entities/Trinkets/5.350.028 - Broken Ankh.png" Kind="Collect" Name="Broken Ankh" Subtype="28" Variant="350" />
-	<entity Group="Trinkets" ID="5" Image="resources/Entities/Trinkets/5.350.029 - Fish Head.png" Kind="Collect" Name="Fish Head" Subtype="29" Variant="350" />
-	<entity Group="Trinkets" ID="5" Image="resources/Entities/Trinkets/5.350.030 - Pinky Eye.png" Kind="Collect" Name="Pinky Eye" Subtype="30" Variant="350" />
-	<entity Group="Trinkets" ID="5" Image="resources/Entities/Trinkets/5.350.031 - Push Pin.png" Kind="Collect" Name="Push Pin" Subtype="31" Variant="350" />
-	<entity Group="Trinkets" ID="5" Image="resources/Entities/Trinkets/5.350.032 - Liberty Cap.png" Kind="Collect" Name="Liberty Cap" Subtype="32" Variant="350" />
-	<entity Group="Trinkets" ID="5" Image="resources/Entities/Trinkets/5.350.033 - Umbilical Cord.png" Kind="Collect" Name="Umbilical Cord" Subtype="33" Variant="350" />
-	<entity Group="Trinkets" ID="5" Image="resources/Entities/Trinkets/5.350.034 - Child's Heart.png" Kind="Collect" Name="Child's Heart" Subtype="34" Variant="350" />
-	<entity Group="Trinkets" ID="5" Image="resources/Entities/Trinkets/5.350.035 - Curved Horn.png" Kind="Collect" Name="Curved Horn" Subtype="35" Variant="350" />
-	<entity Group="Trinkets" ID="5" Image="resources/Entities/Trinkets/5.350.036 - Rusted Key.png" Kind="Collect" Name="Rusted Key" Subtype="36" Variant="350" />
-	<entity Group="Trinkets" ID="5" Image="resources/Entities/Trinkets/5.350.037 - Goat Hoof.png" Kind="Collect" Name="Goat Hoof" Subtype="37" Variant="350" />
-	<entity Group="Trinkets" ID="5" Image="resources/Entities/Trinkets/5.350.038 - Mom's Pearl.png" Kind="Collect" Name="Mom's Pearl" Subtype="38" Variant="350" />
-	<entity Group="Trinkets" ID="5" Image="resources/Entities/Trinkets/5.350.039 - cancer.png" Kind="Collect" Name="Cancer" Subtype="39" Variant="350" />
-	<entity Group="Trinkets" ID="5" Image="resources/Entities/Trinkets/5.350.040 - Red Patch.png" Kind="Collect" Name="Red Patch" Subtype="40" Variant="350" />
-	<entity Group="Trinkets" ID="5" Image="resources/Entities/Trinkets/5.350.041 - Match Stick.png" Kind="Collect" Name="Match Stick" Subtype="41" Variant="350" />
-	<entity Group="Trinkets" ID="5" Image="resources/Entities/Trinkets/5.350.042 - Lucky Toe.png" Kind="Collect" Name="Lucky Toe" Subtype="42" Variant="350" />
-	<entity Group="Trinkets" ID="5" Image="resources/Entities/Trinkets/5.350.043 - Cursed Skull.png" Kind="Collect" Name="Cursed Skull" Subtype="43" Variant="350" />
-	<entity Group="Trinkets" ID="5" Image="resources/Entities/Trinkets/5.350.044 - Safety Cap.png" Kind="Collect" Name="Safety Cap" Subtype="44" Variant="350" />
-	<entity Group="Trinkets" ID="5" Image="resources/Entities/Trinkets/5.350.045 - Ace of Spades.png" Kind="Collect" Name="Ace of Spades" Subtype="45" Variant="350" />
-	<entity Group="Trinkets" ID="5" Image="resources/Entities/Trinkets/5.350.046 - Isaac's Fork.png" Kind="Collect" Name="Isaac's Fork" Subtype="46" Variant="350" />
-	<entity Group="Trinkets" ID="5" Image="resources/Entities/Trinkets/5.350.048 - A Missing Page.png" Kind="Collect" Name="A Missing Page" Subtype="48" Variant="350" />
-	<entity Group="Trinkets" ID="5" Image="resources/Entities/Trinkets/5.350.049 - Bloody Penny.png" Kind="Collect" Name="Bloody Penny" Subtype="49" Variant="350" />
-	<entity Group="Trinkets" ID="5" Image="resources/Entities/Trinkets/5.350.050 - Burnt Penny.png" Kind="Collect" Name="Burnt Penny" Subtype="50" Variant="350" />
-	<entity Group="Trinkets" ID="5" Image="resources/Entities/Trinkets/5.350.051 - Flat Penny.png" Kind="Collect" Name="Flat Penny" Subtype="51" Variant="350" />
-	<entity Group="Trinkets" ID="5" Image="resources/Entities/Trinkets/5.350.052 - Counterfeit Penny.png" Kind="Collect" Name="Counterfeit Penny" Subtype="52" Variant="350" />
-	<entity Group="Trinkets" ID="5" Image="resources/Entities/Trinkets/5.350.053 - tick.png" Kind="Collect" Name="Tick" Subtype="53" Variant="350" />
-	<entity Group="Trinkets" ID="5" Image="resources/Entities/Trinkets/5.350.054 - Isaac's Head.png" Kind="Collect" Name="Isaac's Head" Subtype="54" Variant="350" />
-	<entity Group="Trinkets" ID="5" Image="resources/Entities/Trinkets/5.350.055 - Maggy's Faith.png" Kind="Collect" Name="Maggy's Faith" Subtype="55" Variant="350" />
-	<entity Group="Trinkets" ID="5" Image="resources/Entities/Trinkets/5.350.056 - Judas' Tongue.png" Kind="Collect" Name="Judas' Tongue" Subtype="56" Variant="350" />
-	<entity Group="Trinkets" ID="5" Image="resources/Entities/Trinkets/5.350.057 - Blue Baby's Soul.png" Kind="Collect" Name="???'s Soul" Subtype="57" Variant="350" />
-	<entity Group="Trinkets" ID="5" Image="resources/Entities/Trinkets/5.350.058 - Samson's Lock.png" Kind="Collect" Name="Samson's Lock" Subtype="58" Variant="350" />
-	<entity Group="Trinkets" ID="5" Image="resources/Entities/Trinkets/5.350.059 - Cain's Eye.png" Kind="Collect" Name="Cain's Eye" Subtype="59" Variant="350" />
-	<entity Group="Trinkets" ID="5" Image="resources/Entities/Trinkets/5.350.060 - Eve's Bird Foot.png" Kind="Collect" Name="Eve's Bird Foot" Subtype="60" Variant="350" />
-	<entity Group="Trinkets" ID="5" Image="resources/Entities/Trinkets/5.350.061 - The Left Hand.png" Kind="Collect" Name="The Left Hand" Subtype="61" Variant="350" />
+	<!--——— Floors ———-->
+	<group Name="Floors">
+		<group Name="Chapter 1">
+			<group Label="Chapter 1 (Main Path)">
+				<group Name="Chapter 1 (Main Path) Shared" Label="- Shared -">
+					<group Name="Chapter 1 (Main Path) Events" Label="Events"/>
+					<group Name="Chapter 1 (Main Path) Obstacles" Label="Obstacles"/>
+					<group Name="Chapter 1 (Main Path) Enemies" Label="Enemies"/>
+				</group>
+				<group Name="Basement" Label="- Basement -">
+					<group Name="Basement Events" Label="Events"/>
+					<group Name="Basement Obstacles" Label="Obstacles"/>
+					<group Name="Basement Enemies" Label="Enemies"/>
+				</group>
+				<group Name="Cellar" Label="- Cellar -">
+					<group Name="Cellar Events" Label="Events"/>
+					<group Name="Cellar Obstacles" Label="Obstacles"/>
+					<group Name="Cellar Enemies" Label="Enemies"/>
+				</group>
+			</group>
+		</group>
+		<group Name="Chapter 2">
+			<group Label="Chapter 2 (Main Path)">
+				<group Name="Chapter 2 (Main Path) Shared" Label="- Shared -">
+					<group Name="Chapter 2 (Main Path) Events" Label="Events"/>
+					<group Name="Chapter 2 (Main Path) Obstacles" Label="Obstacles"/>
+					<group Name="Chapter 2 (Main Path) Enemies" Label="Enemies"/>
+				</group>
+				<group Name="Caves" Label="- Caves -">
+					<group Name="Caves Events" Label="Events"/>
+					<group Name="Caves Obstacles" Label="Obstacles"/>
+					<group Name="Caves Enemies" Label="Enemies"/>
+				</group>
+				<group Name="Catacombs" Label="- Catacombs -">
+					<group Name="Catacombs Events" Label="Events"/>
+					<group Name="Catacombs Obstacles" Label="Obstacles"/>
+					<group Name="Catacombs Enemies" Label="Enemies"/>
+				</group>
+			</group>
+		</group>
+		<group Name="Chapter 3">
+			<group Label="Chapter 3 (Main Path)">
+				<group Name="Chapter 3 (Main Path) Shared" Label="- Shared -">
+					<group Name="Chapter 3 (Main Path) Events" Label="Events"/>
+					<group Name="Chapter 3 (Main Path) Obstacles" Label="Obstacles"/>
+					<group Name="Chapter 3 (Main Path) Enemies" Label="Enemies"/>
+				</group>
+				<group Name="Depths" Label="- Depths -">
+					<group Name="Depths Events" Label="Events"/>
+					<group Name="Depths Obstacles" Label="Obstacles"/>
+					<group Name="Depths Enemies" Label="Enemies"/>
+				</group>
+				<group Name="Necropolis" Label="- Necropolis -">
+					<group Name="Necropolis Events" Label="Events"/>
+					<group Name="Necropolis Obstacles" Label="Obstacles"/>
+					<group Name="Necropolis Enemies" Label="Enemies"/>
+				</group>
+			</group>
+		</group>
+		<group Name="Chapter 4">
+			<group Label="Chapter 4 (Main Path)">
+				<group Name="Chapter 4 (Main Path) Shared" Label="- Shared -">
+					<group Name="Chapter 4 (Main Path) Events" Label="Events"/>
+					<group Name="Chapter 4 (Main Path) Obstacles" Label="Obstacles"/>
+					<group Name="Chapter 4 (Main Path) Enemies" Label="Enemies"/>
+				</group>
+				<group Name="Womb" Label="- Womb -">
+					<group Name="Womb Events" Label="Events"/>
+					<group Name="Womb Obstacles" Label="Obstacles"/>
+					<group Name="Womb Enemies" Label="Enemies"/>
+				</group>
+				<group Name="Utero" Label="- Utero -">
+					<group Name="Utero Events" Label="Events"/>
+					<group Name="Utero Obstacles" Label="Obstacles"/>
+					<group Name="Utero Enemies" Label="Enemies"/>
+				</group>
+			</group>
+		</group>
+		<group Name="Chapter 5">
+			<group Label="Chapter 5 (Main Path)">
+				<group Name="Chapter 5 (Main Path) Shared" Label="- Shared -">
+					<group Name="Chapter 5 (Main Path) Events" Label="Events"/>
+					<group Name="Chapter 5 (Main Path) Obstacles" Label="Obstacles"/>
+					<group Name="Chapter 5 (Main Path) Enemies" Label="Enemies"/>
+				</group>
+				<group Name="Sheol" Label="- Sheol -">
+					<group Name="Sheol Events" Label="Events"/>
+					<group Name="Sheol Obstacles" Label="Obstacles"/>
+					<group Name="Sheol Enemies" Label="Enemies"/>
+				</group>
+				<group Name="Cathedral" Label="- Cathedral -">
+					<group Name="Cathedral Events" Label="Events"/>
+					<group Name="Cathedral Obstacles" Label="Obstacles"/>
+					<group Name="Cathedral Enemies" Label="Enemies"/>
+				</group>
+			</group>
+		</group>
+		<group Name="Chapter 6">
+			<group Label="Chapter 6 (Main Path)">
+				<group Name="Chapter 6 (Main Path) Shared" Label="- Shared -">
+					<group Name="Chapter 6 (Main Path) Events" Label="Events"/>
+					<group Name="Chapter 6 (Main Path) Obstacles" Label="Obstacles"/>
+					<group Name="Chapter 6 (Main Path) Enemies" Label="Enemies"/>
+				</group>
+				<group Name="Dark Room" Label="- Dark Room -">
+					<group Name="Dark Room Events" Label="Events"/>
+					<group Name="Dark Room Obstacles" Label="Obstacles"/>
+					<group Name="Dark Room Enemies" Label="Enemies"/>
+				</group>
+				<group Name="Chest" Label="- Chest -">
+					<group Name="Chest Events" Label="Events"/>
+					<group Name="Chest Obstacles" Label="Obstacles"/>
+					<group Name="Chest Enemies" Label="Enemies"/>
+				</group>
+			</group>
+		</group>
+	</group>
 
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.1 - The Sad Onion.png" Kind="Collect" Name="The Sad Onion" Subtype="1" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.2 - The Inner Eye.png" Kind="Collect" Name="The Inner Eye" Subtype="2" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.3 - Spoon Bender.png" Kind="Collect" Name="Spoon Bender" Subtype="3" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.4 - Cricket's Head.png" Kind="Collect" Name="Cricket's Head" Subtype="4" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.5 - My Reflection.png" Kind="Collect" Name="My Reflection" Subtype="5" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.6 - Number One.png" Kind="Collect" Name="Number One" Subtype="6" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.7 - Blood of the Martyr.png" Kind="Collect" Name="Blood of the Martyr" Subtype="7" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.9 - Skatole.png" Kind="Collect" Name="Skatole" Subtype="9" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.12 - Magic Mushroom.png" Kind="Collect" Name="Magic Mushroom" Subtype="12" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.13 - The Virus.png" Kind="Collect" Name="The Virus" Subtype="13" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.14 - Roid Rage.png" Kind="Collect" Name="Roid Rage" Subtype="14" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.15 - Heart.png" Kind="Collect" Name="&lt;3" Subtype="15" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.16 - Raw Liver.png" Kind="Collect" Name="Raw Liver" Subtype="16" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.17 - Skeleton Key.png" Kind="Collect" Name="Skeleton Key" Subtype="17" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.18 - A Dollar.png" Kind="Collect" Name="A Dollar" Subtype="18" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.19 - Boom!.png" Kind="Collect" Name="Boom!" Subtype="19" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.20 - Transcendence.png" Kind="Collect" Name="Transcendence" Subtype="20" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.21 - The Compass.png" Kind="Collect" Name="The Compass" Subtype="21" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.22 - Lunch.png" Kind="Collect" Name="Lunch" Subtype="22" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.23 - Dinner.png" Kind="Collect" Name="Dinner" Subtype="23" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.24 - Dessert.png" Kind="Collect" Name="Dessert" Subtype="24" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.25 - Breakfast.png" Kind="Collect" Name="Breakfast" Subtype="25" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.26 - Rotten Meat.png" Kind="Collect" Name="Rotten Meat" Subtype="26" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.27 - Wooden Spoon.png" Kind="Collect" Name="Wooden Spoon" Subtype="27" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.28 - The Belt.png" Kind="Collect" Name="The Belt" Subtype="28" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.29 - Mom's Underwear.png" Kind="Collect" Name="Mom's Underwear" Subtype="29" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.30 - Mom's Heels.png" Kind="Collect" Name="Mom's Heels" Subtype="30" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.31 - Mom's Lipstick.png" Kind="Collect" Name="Mom's Lipstick" Subtype="31" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.32 - Wire Coat Hanger.png" Kind="Collect" Name="Wire Coat Hanger" Subtype="32" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.46 - Lucky Foot.png" Kind="Collect" Name="Lucky Foot" Subtype="46" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.48 - Cupid's Arrow.png" Kind="Collect" Name="Cupid's Arrow" Subtype="48" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.50 - Steven.png" Kind="Collect" Name="Steven" Subtype="50" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.51 - Pentagram.png" Kind="Collect" Name="Pentagram" Subtype="51" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.52 - Dr. Fetus.png" Kind="Collect" Name="Dr. Fetus" Subtype="52" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.53 - Magneto.png" Kind="Collect" Name="Magneto" Subtype="53" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.54 - Treasure Map.png" Kind="Collect" Name="Treasure Map" Subtype="54" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.55 - Mom's Eye.png" Kind="Collect" Name="Mom's Eye" Subtype="55" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.60 - The Ladder.png" Kind="Collect" Name="The Ladder" Subtype="60" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.62 - Charm of the Vampire.png" Kind="Collect" Name="Charm of the Vampire" Subtype="62" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.63 - The Battery.png" Kind="Collect" Name="The Battery" Subtype="63" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.64 - Steam Sale.png" Kind="Collect" Name="Steam Sale" Subtype="64" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.68 - Technology.png" Kind="Collect" Name="Technology" Subtype="68" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.69 - Chocolate Milk.png" Kind="Collect" Name="Chocolate Milk" Subtype="69" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.70 - Growth Hormones.png" Kind="Collect" Name="Growth Hormones" Subtype="70" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.71 - Mini Mush.png" Kind="Collect" Name="Mini Mush" Subtype="71" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.72 - Rosary.png" Kind="Collect" Name="Rosary" Subtype="72" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.74 - A Quarter.png" Kind="Collect" Name="A Quarter" Subtype="74" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.75 - PHD.png" Kind="Collect" Name="PHD" Subtype="75" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.76 - X-Ray Vision.png" Kind="Collect" Name="X-Ray Vision" Subtype="76" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.79 - The Mark.png" Kind="Collect" Name="The Mark" Subtype="79" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.80 - The Pact.png" Kind="Collect" Name="The Pact" Subtype="80" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.82 - Lord of the Pit.png" Kind="Collect" Name="Lord of the Pit" Subtype="82" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.87 - Loki's Horns.png" Kind="Collect" Name="Loki's Horns" Subtype="87" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.89 - Spider Bite.png" Kind="Collect" Name="Spider Bite" Subtype="89" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.90 - The Small Rock.png" Kind="Collect" Name="The Small Rock" Subtype="90" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.91 - Spelunker Hat.png" Kind="Collect" Name="Spelunker Hat" Subtype="91" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.92 - Super Bandage.png" Kind="Collect" Name="Super Bandage" Subtype="92" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.101 - The Halo.png" Kind="Collect" Name="The Halo" Subtype="101" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.103 - The Common Cold.png" Kind="Collect" Name="The Common Cold" Subtype="103" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.104 - The Parasite.png" Kind="Collect" Name="The Parasite" Subtype="104" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.106 - Mr. Mega.png" Kind="Collect" Name="Mr. Mega" Subtype="106" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.108 - The Wafer.png" Kind="Collect" Name="The Wafer" Subtype="108" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.109 - Money = Power.png" Kind="Collect" Name="Money = Power" Subtype="109" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.110 - Mom's Contacts.png" Kind="Collect" Name="Mom's Contacts" Subtype="110" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.114 - Mom's Knife.png" Kind="Collect" Name="Mom's Knife" Subtype="114" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.115 - Ouija Board.png" Kind="Collect" Name="Ouija Board" Subtype="115" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.116 - 9 Volt.png" Kind="Collect" Name="9 Volt" Subtype="116" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.117 - Dead Bird.png" Kind="Collect" Name="Dead Bird" Subtype="117" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.118 - Brimstone.png" Kind="Collect" Name="Brimstone" Subtype="118" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.119 - Blood Bag.png" Kind="Collect" Name="Blood Bag" Subtype="119" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.120 - Odd Mushroom.png" Kind="Collect" Name="Odd Mushroom" Subtype="120" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.121 - Odd Mushroom.png" Kind="Collect" Name="Odd Mushroom" Subtype="121" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.122 - Whore of Babylon.png" Kind="Collect" Name="Whore of Babylon" Subtype="122" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.125 - Bobby-Bomb.png" Kind="Collect" Name="Bobby-Bomb" Subtype="125" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.129 - Bucket of Lard.png" Kind="Collect" Name="Bucket of Lard" Subtype="129" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.132 - A Lump of Coal.png" Kind="Collect" Name="A Lump of Coal" Subtype="132" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.134 - Guppy's Tail.png" Kind="Collect" Name="Guppy's Tail" Subtype="134" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.138 - Stigmata.png" Kind="Collect" Name="Stigmata" Subtype="138" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.139 - Mom's Purse.png" Kind="Collect" Name="Mom's Purse" Subtype="139" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.140 - Bobs Curse.png" Kind="Collect" Name="Bobs Curse" Subtype="140" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.141 - Pageant Boy.png" Kind="Collect" Name="Pageant Boy" Subtype="141" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.142 - Scapular.png" Kind="Collect" Name="Scapular" Subtype="142" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.143 - Speed Ball.png" Kind="Collect" Name="Speed Ball" Subtype="143" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.148 - Infestation.png" Kind="Collect" Name="Infestation" Subtype="148" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.149 - Ipecac.png" Kind="Collect" Name="Ipecac" Subtype="149" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.150 - Tough Love.png" Kind="Collect" Name="Tough Love" Subtype="150" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.151 - The Mulligan.png" Kind="Collect" Name="The Mulligan" Subtype="151" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.152 - Technology 2.png" Kind="Collect" Name="Technology 2" Subtype="152" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.153 - Mutant Spider.png" Kind="Collect" Name="Mutant Spider" Subtype="153" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.154 - Chemical Peel.png" Kind="Collect" Name="Chemical Peel" Subtype="154" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.156 - Habit.png" Kind="Collect" Name="Habit" Subtype="156" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.157 - Bloody Lust.png" Kind="Collect" Name="Bloody Lust" Subtype="157" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.159 - Spirit of the Night.png" Kind="Collect" Name="Spirit of the Night" Subtype="159" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.161 - Ankh.png" Kind="Collect" Name="Ankh" Subtype="161" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.162 - Celtic Cross.png" Kind="Collect" Name="Celtic Cross" Subtype="162" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.165 - Cat-o-nine-tails.png" Kind="Collect" Name="Cat-o-nine-tails" Subtype="165" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.168 - Epic Fetus.png" Kind="Collect" Name="Epic Fetus" Subtype="168" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.169 - Polyphemus.png" Kind="Collect" Name="Polyphemus" Subtype="169" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.173 - Mitre.png" Kind="Collect" Name="Mitre" Subtype="173" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.176 - Stem Cells.png" Kind="Collect" Name="Stem Cells" Subtype="176" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.179 - Fate.png" Kind="Collect" Name="Fate" Subtype="179" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.180 - The Black Bean.png" Kind="Collect" Name="The Black Bean" Subtype="180" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.182 - Sacred Heart.png" Kind="Collect" Name="Sacred Heart" Subtype="182" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.183 - Tooth Picks.png" Kind="Collect" Name="Tooth Picks" Subtype="183" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.184 - Holy Grail.png" Kind="Collect" Name="Holy Grail" Subtype="184" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.185 - Dead Dove.png" Kind="Collect" Name="Dead Dove" Subtype="185" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.189 - SMB Super Fan.png" Kind="Collect" Name="SMB Super Fan" Subtype="189" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.190 - Pyro.png" Kind="Collect" Name="Pyro" Subtype="190" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.191 - 3 Dollar Bill.png" Kind="Collect" Name="3 Dollar Bill" Subtype="191" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.193 - MEAT!.png" Kind="Collect" Name="MEAT!" Subtype="193" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.194 - Magic 8 Ball.png" Kind="Collect" Name="Magic 8 Ball" Subtype="194" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.195 - Mom's Coin Purse.png" Kind="Collect" Name="Mom's Coin Purse" Subtype="195" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.196 - Squeezy.png" Kind="Collect" Name="Squeezy" Subtype="196" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.197 - Jesus Juice.png" Kind="Collect" Name="Jesus Juice" Subtype="197" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.198 - Box.png" Kind="Collect" Name="Box" Subtype="198" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.199 - Mom's Key.png" Kind="Collect" Name="Mom's Key" Subtype="199" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.200 - Mom's Eyeshadow.png" Kind="Collect" Name="Mom's Eyeshadow" Subtype="200" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.201 - Iron Bar.png" Kind="Collect" Name="Iron Bar" Subtype="201" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.202 - Midas' Touch.png" Kind="Collect" Name="Midas' Touch" Subtype="202" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.203 - Humbleing Bundle.png" Kind="Collect" Name="Humbleing Bundle" Subtype="203" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.204 - Fanny Pack.png" Kind="Collect" Name="Fanny Pack" Subtype="204" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.205 - Sharp Plug.png" Kind="Collect" Name="Sharp Plug" Subtype="205" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.208 - Champion Belt.png" Kind="Collect" Name="Champion Belt" Subtype="208" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.209 - Butt Bombs.png" Kind="Collect" Name="Butt Bombs" Subtype="209" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.210 - Gnawed Leaf.png" Kind="Collect" Name="Gnawed Leaf" Subtype="210" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.211 - Spiderbaby.png" Kind="Collect" Name="Spiderbaby" Subtype="211" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.212 - Guppy's Collar.png" Kind="Collect" Name="Guppy's Collar" Subtype="212" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.213 - Lost Contact.png" Kind="Collect" Name="Lost Contact" Subtype="213" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.214 - Anemic.png" Kind="Collect" Name="Anemic" Subtype="214" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.215 - Goat Head.png" Kind="Collect" Name="Goat Head" Subtype="215" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.216 - Ceremonial Robes.png" Kind="Collect" Name="Ceremonial Robes" Subtype="216" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.217 - Mom's Wig.png" Kind="Collect" Name="Mom's Wig" Subtype="217" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.218 - Placenta.png" Kind="Collect" Name="Placenta" Subtype="218" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.219 - Old Bandage.png" Kind="Collect" Name="Old Bandage" Subtype="219" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.220 - Sad Bombs.png" Kind="Collect" Name="Sad Bombs" Subtype="220" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.221 - Rubber Cement.png" Kind="Collect" Name="Rubber Cement" Subtype="221" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.222 - Anti-Gravity.png" Kind="Collect" Name="Anti-Gravity" Subtype="222" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.223 - Pyromaniac.png" Kind="Collect" Name="Pyromaniac" Subtype="223" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.224 - Cricket's Body.png" Kind="Collect" Name="Cricket's Body" Subtype="224" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.225 - Gimpy.png" Kind="Collect" Name="Gimpy" Subtype="225" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.226 - Black Lotus.png" Kind="Collect" Name="Black Lotus" Subtype="226" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.227 - Piggy Bank.png" Kind="Collect" Name="Piggy Bank" Subtype="227" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.228 - Mom's Perfume.png" Kind="Collect" Name="Mom's Perfume" Subtype="228" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.229 - Monstro's Lung.png" Kind="Collect" Name="Monstro's Lung" Subtype="229" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.230 - Abaddon.png" Kind="Collect" Name="Abaddon" Subtype="230" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.231 - Ball of Tar.png" Kind="Collect" Name="Ball of Tar" Subtype="231" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.232 - Stop Watch.png" Kind="Collect" Name="Stop Watch" Subtype="232" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.233 - Tiny Planet.png" Kind="Collect" Name="Tiny Planet" Subtype="233" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.234 - Infestation 2.png" Kind="Collect" Name="Infestation 2" Subtype="234" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.236 - E. Coli.png" Kind="Collect" Name="E. Coli" Subtype="236" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.237 - Death's Touch.png" Kind="Collect" Name="Death's Touch" Subtype="237" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.240 - Experimental Treatment.png" Kind="Collect" Name="Experimental Treatment" Subtype="240" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.241 - Contract from Below.png" Kind="Collect" Name="Contract from Below" Subtype="241" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.242 - Infamy.png" Kind="Collect" Name="Infamy" Subtype="242" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.243 - Trinity Shield.png" Kind="Collect" Name="Trinity Shield" Subtype="243" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.244 - Tech.5.png" Kind="Collect" Name="Tech.5" Subtype="244" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.245 - 20-20.png" Kind="Collect" Name="20-20" Subtype="245" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.246 - Blue Map.png" Kind="Collect" Name="Blue Map" Subtype="246" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.247 - BFFS!.png" Kind="Collect" Name="BFFS!" Subtype="247" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.248 - Hive Mind.png" Kind="Collect" Name="Hive Mind" Subtype="248" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.249 - There's Options.png" Kind="Collect" Name="There's Options" Subtype="249" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.250 - BOGO Bombs.png" Kind="Collect" Name="BOGO Bombs" Subtype="250" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.251 - Starter Deck.png" Kind="Collect" Name="Starter Deck" Subtype="251" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.252 - Little Baggy.png" Kind="Collect" Name="Little Baggy" Subtype="252" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.253 - Magic Scab.png" Kind="Collect" Name="Magic Scab" Subtype="253" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.254 - Blood Clot.png" Kind="Collect" Name="Blood Clot" Subtype="254" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.255 - Screw.png" Kind="Collect" Name="Screw" Subtype="255" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.256 - Hot Bombs.png" Kind="Collect" Name="Hot Bombs" Subtype="256" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.257 - Fire Mind.png" Kind="Collect" Name="Fire Mind" Subtype="257" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.258 - Missing No..png" Kind="Collect" Name="Missing No." Subtype="258" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.259 - Dark Matter.png" Kind="Collect" Name="Dark Matter" Subtype="259" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.260 - Black Candle.png" Kind="Collect" Name="Black Candle" Subtype="260" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.261 - Proptosis.png" Kind="Collect" Name="Proptosis" Subtype="261" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.262 - Missing Page 2.png" Kind="Collect" Name="Missing Page 2" Subtype="262" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.299 - Taurus.png" Kind="Collect" Name="Taurus" Subtype="299" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.300 - Aries.png" Kind="Collect" Name="Aries" Subtype="300" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.301 - Cancer.png" Kind="Collect" Name="Cancer" Subtype="301" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.302 - Leo.png" Kind="Collect" Name="Leo" Subtype="302" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.303 - Virgo.png" Kind="Collect" Name="Virgo" Subtype="303" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.304 - Libra.png" Kind="Collect" Name="Libra" Subtype="304" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.305 - Scorpio.png" Kind="Collect" Name="Scorpio" Subtype="305" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.306 - Sagittarius.png" Kind="Collect" Name="Sagittarius" Subtype="306" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.307 - Capricorn.png" Kind="Collect" Name="Capricorn" Subtype="307" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.308 - Aquarius.png" Kind="Collect" Name="Aquarius" Subtype="308" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.309 - Pisces.png" Kind="Collect" Name="Pisces" Subtype="309" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.310 - Eve's Mascara.png" Kind="Collect" Name="Eve's Mascara" Subtype="310" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.311 - Judas' Shadow.png" Kind="Collect" Name="Judas' Shadow" Subtype="311" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.312 - Maggy's Bow.png" Kind="Collect" Name="Maggy's Bow" Subtype="312" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.313 - Holy Mantle.png" Kind="Collect" Name="Holy Mantle" Subtype="313" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.314 - Thunder Thighs.png" Kind="Collect" Name="Thunder Thighs" Subtype="314" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.315 - Strange Attractor.png" Kind="Collect" Name="Strange Attractor" Subtype="315" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.316 - Cursed Eye.png" Kind="Collect" Name="Cursed Eye" Subtype="316" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.317 - Mysterious Liquid.png" Kind="Collect" Name="Mysterious Liquid" Subtype="317" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.327 - The Polaroid.png" Kind="Collect" Name="The Polaroid" Subtype="327" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.328 - The Negative.png" Kind="Collect" Name="The Negative" Subtype="328" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.329 - The Ludovico Technique.png" Kind="Collect" Name="The Ludovico Technique" Subtype="329" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.330 - Soy Milk.png" Kind="Collect" Name="Soy Milk" Subtype="330" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.331 - Godhead.png" Kind="Collect" Name="Godhead" Subtype="331" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.332 - Lazarus' Rags.png" Kind="Collect" Name="Lazarus' Rags" Subtype="332" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.333 - The Mind.png" Kind="Collect" Name="The Mind" Subtype="333" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.334 - The Body.png" Kind="Collect" Name="The Body" Subtype="334" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.335 - The Soul.png" Kind="Collect" Name="The Soul" Subtype="335" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.336 - Dead Onion.png" Kind="Collect" Name="Dead Onion" Subtype="336" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.337 - Broken Watch.png" Kind="Collect" Name="Broken Watch" Subtype="337" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.339 - Safety Pin.png" Kind="Collect" Name="Safety Pin" Subtype="339" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.340 - Caffeine Pill.png" Kind="Collect" Name="Caffeine Pill" Subtype="340" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.341 - Torn Photo.png" Kind="Collect" Name="Torn Photo" Subtype="341" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.342 - Blue Cap.png" Kind="Collect" Name="Blue Cap" Subtype="342" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.343 - Latch Key.png" Kind="Collect" Name="Latch Key" Subtype="343" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.344 - Match Book.png" Kind="Collect" Name="Match Book" Subtype="344" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.345 - Synthoil.png" Kind="Collect" Name="Synthoil" Subtype="345" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.346 - A Snack.png" Kind="Collect" Name="A Snack" Subtype="346" Variant="100" />
+	<group Name="Chapter 1 (Main Path) Enemies">
+		<group Name="Default Gapers">
+			<defaults>
+				<entity>
+					<tag>Champion</tag>
+					<tag>DefaultGaper</tag>
+				</entity>
+			</defaults>
+			<entity BaseHP="10" ID="10" Image="Entities/10.1.0 - Gaper.png" Name="Gaper" Subtype="0" Variant="1"/>
+			<entity BaseHP="10" ID="10" Image="Entities/10.0.0 - Frowning Gaper.png" Name="Frowning Gaper" Subtype="0" Variant="0"/>
+		</group>
+		<group Name="Default Gushers">
+			<defaults>
+				<entity>
+					<tag>Champion</tag>
+					<tag>DefaultGusher</tag>
+				</entity>
+			</defaults>
+			<entity BaseHP="10" ID="11" Image="Entities/11.1.0 - Pacer.png" Name="Pacer" Subtype="0" Variant="1"/>
+			<entity BaseHP="10" ID="11" Image="Entities/11.0.0 - Gusher.png" Name="Gusher" Subtype="0" Variant="0"/>
+		</group>
+		<entity BaseHP="10" ID="226" Image="Entities/226.0.0 - Skinny.png" Name="Skinny" Subtype="0" Variant="0"/>
+		<entity BaseHP="10" Tags="Champion" ID="12" Image="Entities/12.0.0 - Horf.png" Name="Horf" Subtype="0" Variant="0" />
+		<entity BaseHP="20" ID="208" Image="Entities/208.0.0 - Fatty.png" Name="Fatty" Subtype="0" Variant="0"/>
+		<entity BaseHP="13" Tags="Champion" ID="16" Image="Entities/16.0.0 - Mulligan.png" Name="Mulligan" Subtype="0" Variant="0" />
+		<entity BaseHP="13" Tags="Champion" ID="16" Image="Entities/16.1.0 - Mulligoon.png" Name="Mulligoon" Subtype="0" Variant="1" />
+		<entity BaseHP="3" ID="13" Image="Entities/13.0.0 - Fly.png" Name="Fly" Subtype="0" Variant="0"/>
+		<entity BaseHP="5" ID="18" Image="Entities/18.0.0 - Attack Fly.png" Name="Attack Fly" Subtype="0" Variant="0"/>
+		<entity BaseHP="10" ID="80" Image="Entities/80.0.0 - Moter.png" Name="Moter" Subtype="0" Variant="0"/>
+		<entity BaseHP="5" ID="222" Image="Entities/222.0.0 - Ring Fly.png" Name="Ring Fly" Subtype="0" Variant="0"/>
+		<entity BaseHP="10" ID="214" Image="Entities/214.0.0 - Level 2 Fly.png" Name="Level 2 Fly" Subtype="0" Variant="0"/>
+		<entity BaseHP="10" ID="249" Image="Entities/249.0.0 - Full Fly.png" Name="Full Fly" Subtype="0" Variant="0"/>
+		<entity BaseHP="10" Tags="Champion" ID="61" Image="Entities/61.0.0 - Sucker.png" Name="Sucker" Subtype="0" Variant="0"/>
+		<entity BaseHP="8" Tags="Champion" ID="14" Image="Entities/14.0.0 - Pooter.png" Name="Pooter" Subtype="0" Variant="0"/>
+		<entity BaseHP="8" Tags="Champion" ID="14" Image="Entities/14.1.0 - Super Pooter.png" Name="Super Pooter" Subtype="0" Variant="1"/>
+		<entity BaseHP="15" Tags="Champion" ID="15" Image="Entities/15.0.0 - Clotty.png" Name="Clotty" Subtype="0" Variant="0" />
+		<entity BaseHP="15" Tags="Champion" ID="15" Image="Entities/15.1.0 - Clot.png" Name="Clot" Subtype="0" Variant="1" />
+		<entity BaseHP="15" Tags="Champion" ID="15" Image="Entities/15.2.0 - I.Blob.png" Name="I.Blob" Subtype="0" Variant="2" />
+		<entity BaseHP="3" ID="217" Image="Entities/217.0.0 - Dip.png" Name="Dip" Subtype="0" Variant="0" />
+		<entity BaseHP="15" ID="220" Image="Entities/220.0.0 - Squirt.png" Name="Squirt" Subtype="0" Variant="0" />
+		<entity BaseHP="12" ID="77" Image="Entities/77.0.0 - Embryo.png" Name="Embryo" Subtype="0" Variant="0" />
+		<entity BaseHP="10" ID="244" Image="Entities/244.0.0 - Round Worm.png" Name="Round Worm" Subtype="0" Variant="0" />
+	</group>
 
-	<entity Group="Active Items" ID="5" Image="resources/Entities/Items/5.100.33 - The Bible.png" Kind="Collect" Name="The Bible" Subtype="33" Variant="100" />
-	<entity Group="Active Items" ID="5" Image="resources/Entities/Items/5.100.34 - The Book of Belial.png" Kind="Collect" Name="The Book of Belial" Subtype="34" Variant="100" />
-	<entity Group="Active Items" ID="5" Image="resources/Entities/Items/5.100.35 - The Necronomicon.png" Kind="Collect" Name="The Necronomicon" Subtype="35" Variant="100" />
-	<entity Group="Active Items" ID="5" Image="resources/Entities/Items/5.100.36 - The Poop.png" Kind="Collect" Name="The Poop" Subtype="36" Variant="100" />
-	<entity Group="Active Items" ID="5" Image="resources/Entities/Items/5.100.37 - Mr. Boom.png" Kind="Collect" Name="Mr. Boom" Subtype="37" Variant="100" />
-	<entity Group="Active Items" ID="5" Image="resources/Entities/Items/5.100.38 - Tammy's Head.png" Kind="Collect" Name="Tammy's Head" Subtype="38" Variant="100" />
-	<entity Group="Active Items" ID="5" Image="resources/Entities/Items/5.100.39 - Mom's Bra.png" Kind="Collect" Name="Mom's Bra" Subtype="39" Variant="100" />
-	<entity Group="Active Items" ID="5" Image="resources/Entities/Items/5.100.40 - Kamikaze!.png" Kind="Collect" Name="Kamikaze!" Subtype="40" Variant="100" />
-	<entity Group="Active Items" ID="5" Image="resources/Entities/Items/5.100.41 - Mom's Pad.png" Kind="Collect" Name="Mom's Pad" Subtype="41" Variant="100" />
-	<entity Group="Active Items" ID="5" Image="resources/Entities/Items/5.100.42 - Bob's Rotten Head.png" Kind="Collect" Name="Bob's Rotten Head" Subtype="42" Variant="100" />
-	<entity Group="Active Items" ID="5" Image="resources/Entities/Items/5.100.44 - Teleport!.png" Kind="Collect" Name="Teleport!" Subtype="44" Variant="100" />
-	<entity Group="Active Items" ID="5" Image="resources/Entities/Items/5.100.45 - Yum Heart.png" Kind="Collect" Name="Yum Heart" Subtype="45" Variant="100" />
-	<entity Group="Active Items" ID="5" Image="resources/Entities/Items/5.100.47 - Doctor's Remote.png" Kind="Collect" Name="Doctor's Remote" Subtype="47" Variant="100" />
-	<entity Group="Active Items" ID="5" Image="resources/Entities/Items/5.100.49 - Shoop da Whoop!.png" Kind="Collect" Name="Shoop da Whoop!" Subtype="49" Variant="100" />
-	<entity Group="Active Items" ID="5" Image="resources/Entities/Items/5.100.56 - Lemon Mishap.png" Kind="Collect" Name="Lemon Mishap" Subtype="56" Variant="100" />
-	<entity Group="Active Items" ID="5" Image="resources/Entities/Items/5.100.58 - Book of Shadows.png" Kind="Collect" Name="Book of Shadows" Subtype="58" Variant="100" />
-	<entity Group="Active Items" ID="5" Image="resources/Entities/Items/5.100.65 - Anarchist Cookbook.png" Kind="Collect" Name="Anarchist Cookbook" Subtype="65" Variant="100" />
-	<entity Group="Active Items" ID="5" Image="resources/Entities/Items/5.100.66 - The Hourglass.png" Kind="Collect" Name="The Hourglass" Subtype="66" Variant="100" />
-	<entity Group="Active Items" ID="5" Image="resources/Entities/Items/5.100.77 - My Little Unicorn.png" Kind="Collect" Name="My Little Unicorn" Subtype="77" Variant="100" />
-	<entity Group="Active Items" ID="5" Image="resources/Entities/Items/5.100.78 - Book of Revelations.png" Kind="Collect" Name="Book of Revelations" Subtype="78" Variant="100" />
-	<entity Group="Active Items" ID="5" Image="resources/Entities/Items/5.100.83 - The Nail.png" Kind="Collect" Name="The Nail" Subtype="83" Variant="100" />
-	<entity Group="Active Items" ID="5" Image="resources/Entities/Items/5.100.84 - We Need To Go Deeper!.png" Kind="Collect" Name="We Need To Go Deeper!" Subtype="84" Variant="100" />
-	<entity Group="Active Items" ID="5" Image="resources/Entities/Items/5.100.85 - Deck of Cards.png" Kind="Collect" Name="Deck of Cards" Subtype="85" Variant="100" />
-	<entity Group="Active Items" ID="5" Image="resources/Entities/Items/5.100.86 - Monstro's Tooth.png" Kind="Collect" Name="Monstro's Tooth" Subtype="86" Variant="100" />
-	<entity Group="Active Items" ID="5" Image="resources/Entities/Items/5.100.93 - The Gamekid.png" Kind="Collect" Name="The Gamekid" Subtype="93" Variant="100" />
-	<entity Group="Active Items" ID="5" Image="resources/Entities/Items/5.100.97 - The Book of Sin.png" Kind="Collect" Name="The Book of Sin" Subtype="97" Variant="100" />
-	<entity Group="Active Items" ID="5" Image="resources/Entities/Items/5.100.102 - Mom's Bottle of Pills.png" Kind="Collect" Name="Mom's Bottle of Pills" Subtype="102" Variant="100" />
-	<entity Group="Active Items" ID="5" Image="resources/Entities/Items/5.100.105 - The D6.png" Kind="Collect" Name="The D6" Subtype="105" Variant="100" />
-	<entity Group="Active Items" ID="5" Image="resources/Entities/Items/5.100.107 - The Pinking Shears.png" Kind="Collect" Name="The Pinking Shears" Subtype="107" Variant="100" />
-	<entity Group="Active Items" ID="5" Image="resources/Entities/Items/5.100.111 - The Bean.png" Kind="Collect" Name="The Bean" Subtype="111" Variant="100" />
-	<entity Group="Active Items" ID="5" Image="resources/Entities/Items/5.100.123 - Monster Manual.png" Kind="Collect" Name="Monster Manual" Subtype="123" Variant="100" />
-	<entity Group="Active Items" ID="5" Image="resources/Entities/Items/5.100.124 - Dead Sea Scrolls.png" Kind="Collect" Name="Dead Sea Scrolls" Subtype="124" Variant="100" />
-	<entity Group="Active Items" ID="5" Image="resources/Entities/Items/5.100.126 - Razor Blade.png" Kind="Collect" Name="Razor Blade" Subtype="126" Variant="100" />
-	<entity Group="Active Items" ID="5" Image="resources/Entities/Items/5.100.127 - Forget Me Now.png" Kind="Collect" Name="Forget Me Now" Subtype="127" Variant="100" />
-	<entity Group="Active Items" ID="5" Image="resources/Entities/Items/5.100.130 - A Pony.png" Kind="Collect" Name="A Pony" Subtype="130" Variant="100" />
-	<entity Group="Active Items" ID="5" Image="resources/Entities/Items/5.100.133 - Guppy's Paw.png" Kind="Collect" Name="Guppy's Paw" Subtype="133" Variant="100" />
-	<entity Group="Active Items" ID="5" Image="resources/Entities/Items/5.100.135 - IV Bag.png" Kind="Collect" Name="IV Bag" Subtype="135" Variant="100" />
-	<entity Group="Active Items" ID="5" Image="resources/Entities/Items/5.100.136 - Best Friend.png" Kind="Collect" Name="Best Friend" Subtype="136" Variant="100" />
-	<entity Group="Active Items" ID="5" Image="resources/Entities/Items/5.100.137 - Remote Detonator.png" Kind="Collect" Name="Remote Detonator" Subtype="137" Variant="100" />
-	<entity Group="Active Items" ID="5" Image="resources/Entities/Items/5.100.145 - Guppy's Head.png" Kind="Collect" Name="Guppy's Head" Subtype="145" Variant="100" />
-	<entity Group="Active Items" ID="5" Image="resources/Entities/Items/5.100.146 - Prayer Card.png" Kind="Collect" Name="Prayer Card" Subtype="146" Variant="100" />
-	<entity Group="Active Items" ID="5" Image="resources/Entities/Items/5.100.147 - Notched Axe.png" Kind="Collect" Name="Notched Axe" Subtype="147" Variant="100" />
-	<entity Group="Active Items" ID="5" Image="resources/Entities/Items/5.100.158 - Crystal Ball.png" Kind="Collect" Name="Crystal Ball" Subtype="158" Variant="100" />
-	<entity Group="Active Items" ID="5" Image="resources/Entities/Items/5.100.160 - Crack the Sky.png" Kind="Collect" Name="Crack the Sky" Subtype="160" Variant="100" />
-	<entity Group="Active Items" ID="5" Image="resources/Entities/Items/5.100.164 - The Candle.png" Kind="Collect" Name="The Candle" Subtype="164" Variant="100" />
-	<entity Group="Active Items" ID="5" Image="resources/Entities/Items/5.100.166 - D20.png" Kind="Collect" Name="D20" Subtype="166" Variant="100" />
-	<entity Group="Active Items" ID="5" Image="resources/Entities/Items/5.100.171 - Spider Butt.png" Kind="Collect" Name="Spider Butt" Subtype="171" Variant="100" />
-	<entity Group="Active Items" ID="5" Image="resources/Entities/Items/5.100.175 - Dad's Key.png" Kind="Collect" Name="Dad's Key" Subtype="175" Variant="100" />
-	<entity Group="Active Items" ID="5" Image="resources/Entities/Items/5.100.177 - Portable Slot.png" Kind="Collect" Name="Portable Slot" Subtype="177" Variant="100" />
-	<entity Group="Active Items" ID="5" Image="resources/Entities/Items/5.100.181 - White Pony.png" Kind="Collect" Name="White Pony" Subtype="181" Variant="100" />
-	<entity Group="Active Items" ID="5" Image="resources/Entities/Items/5.100.186 - Blood Rights.png" Kind="Collect" Name="Blood Rights" Subtype="186" Variant="100" />
-	<entity Group="Active Items" ID="5" Image="resources/Entities/Items/5.100.192 - Telepathy For Dummies.png" Kind="Collect" Name="Telepathy For Dummies" Subtype="192" Variant="100" />
-	<entity Group="Active Items" ID="5" Image="resources/Entities/Items/5.100.282 - How to Jump.png" Kind="Collect" Name="How to Jump" Subtype="282" Variant="100" />
-	<entity Group="Active Items" ID="5" Image="resources/Entities/Items/5.100.283 - D100.png" Kind="Collect" Name="D100" Subtype="283" Variant="100" />
-	<entity Group="Active Items" ID="5" Image="resources/Entities/Items/5.100.284 - D4.png" Kind="Collect" Name="D4" Subtype="284" Variant="100" />
-	<entity Group="Active Items" ID="5" Image="resources/Entities/Items/5.100.285 - D10.png" Kind="Collect" Name="D10" Subtype="285" Variant="100" />
-	<entity Group="Active Items" ID="5" Image="resources/Entities/Items/5.100.286 - Blank Card.png" Kind="Collect" Name="Blank Card" Subtype="286" Variant="100" />
-	<entity Group="Active Items" ID="5" Image="resources/Entities/Items/5.100.287 - Book of Secrets.png" Kind="Collect" Name="Book of Secrets" Subtype="287" Variant="100" />
-	<entity Group="Active Items" ID="5" Image="resources/Entities/Items/5.100.288 - Box of Spiders.png" Kind="Collect" Name="Box of Spiders" Subtype="288" Variant="100" />
-	<entity Group="Active Items" ID="5" Image="resources/Entities/Items/5.100.289 - Red Candle.png" Kind="Collect" Name="Red Candle" Subtype="289" Variant="100" />
-	<entity Group="Active Items" ID="5" Image="resources/Entities/Items/5.100.290 - The Jar.png" Kind="Collect" Name="The Jar" Subtype="290" Variant="100" />
-	<entity Group="Active Items" ID="5" Image="resources/Entities/Items/5.100.291 - Flush!.png" Kind="Collect" Name="Flush!" Subtype="291" Variant="100" />
-	<entity Group="Active Items" ID="5" Image="resources/Entities/Items/5.100.292 - Satanic Bible.png" Kind="Collect" Name="Satanic Bible" Subtype="292" Variant="100" />
-	<entity Group="Active Items" ID="5" Image="resources/Entities/Items/5.100.293 - Head of Krampus.png" Kind="Collect" Name="Head of Krampus" Subtype="293" Variant="100" />
-	<entity Group="Active Items" ID="5" Image="resources/Entities/Items/5.100.294 - Butter Bean.png" Kind="Collect" Name="Butter Bean" Subtype="294" Variant="100" />
-	<entity Group="Active Items" ID="5" Image="resources/Entities/Items/5.100.295 - Magic Fingers.png" Kind="Collect" Name="Magic Fingers" Subtype="295" Variant="100" />
-	<entity Group="Active Items" ID="5" Image="resources/Entities/Items/5.100.296 - Converter.png" Kind="Collect" Name="Converter" Subtype="296" Variant="100" />
-	<entity Group="Active Items" ID="5" Image="resources/Entities/Items/5.100.297 - Pandora's Box.png" Kind="Collect" Name="Pandora's Box" Subtype="297" Variant="100" />
-	<entity Group="Active Items" ID="5" Image="resources/Entities/Items/5.100.298 - Unicorn Stump.png" Kind="Collect" Name="Unicorn Stump" Subtype="298" Variant="100" />
-	<entity Group="Active Items" ID="5" Image="resources/Entities/Items/5.100.323 - Isaac's Tears.png" Kind="Collect" Name="Isaac's Tears" Subtype="323" Variant="100" />
-	<entity Group="Active Items" ID="5" Image="resources/Entities/Items/5.100.324 - Undefined.png" Kind="Collect" Name="Undefined" Subtype="324" Variant="100" />
-	<entity Group="Active Items" ID="5" Image="resources/Entities/Items/5.100.325 - Scissors.png" Kind="Collect" Name="Scissors" Subtype="325" Variant="100" />
-	<entity Group="Active Items" ID="5" Image="resources/Entities/Items/5.100.326 - Breath of Life.png" Kind="Collect" Name="Breath of Life" Subtype="326" Variant="100" />
-	<entity Group="Active Items" ID="5" Image="resources/Entities/Items/5.100.338 - The Boomerang.png" Kind="Collect" Name="The Boomerang" Subtype="338" Variant="100" />
+	<group Name="Basement Enemies">
+		<entity BaseHP="10" Tags="Champion" ID="29" Image="Entities/29.0.0 - Hopper.png" Name="Hopper" Subtype="0" Variant="0"/>
+		<entity BaseHP="10" Tags="Champion" ID="248" Image="Entities/248.0.0 - Psychic Horf.png" Name="Psychic Horf" Subtype="0" Variant="0" />
+	</group>
 
-	<entity Group="Familiars" ID="5" Image="resources/Entities/Items/5.100.8 - Brother Bobby.png" Kind="Collect" Name="Brother Bobby" Subtype="8" Variant="100" />
-	<entity Group="Familiars" ID="5" Image="resources/Entities/Items/5.100.10 - Halo of Flies.png" Kind="Collect" Name="Halo of Flies" Subtype="10" Variant="100" />
-	<entity Group="Familiars" ID="5" Image="resources/Entities/Items/5.100.11 - 1up!.png" Kind="Collect" Name="1up!" Subtype="11" Variant="100" />
-	<entity Group="Familiars" ID="5" Image="resources/Entities/Items/5.100.57 - Distant Admiration.png" Kind="Collect" Name="Distant Admiration" Subtype="57" Variant="100" />
-	<entity Group="Familiars" ID="5" Image="resources/Entities/Items/5.100.67 - Sister Maggy.png" Kind="Collect" Name="Sister Maggy" Subtype="67" Variant="100" />
-	<entity Group="Familiars" ID="5" Image="resources/Entities/Items/5.100.73 - Cube of Meat.png" Kind="Collect" Name="Cube of Meat" Subtype="73" Variant="100" />
-	<entity Group="Familiars" ID="5" Image="resources/Entities/Items/5.100.81 - Dead Cat.png" Kind="Collect" Name="Dead Cat" Subtype="81" Variant="100" />
-	<entity Group="Familiars" ID="5" Image="resources/Entities/Items/5.100.88 - Little Chubby.png" Kind="Collect" Name="Little Chubby" Subtype="88" Variant="100" />
-	<entity Group="Familiars" ID="5" Image="resources/Entities/Items/5.100.94 - Sack of Pennies.png" Kind="Collect" Name="Sack of Pennies" Subtype="94" Variant="100" />
-	<entity Group="Familiars" ID="5" Image="resources/Entities/Items/5.100.95 - Robo-Baby.png" Kind="Collect" Name="Robo-Baby" Subtype="95" Variant="100" />
-	<entity Group="Familiars" ID="5" Image="resources/Entities/Items/5.100.96 - Little C.H.A.D..png" Kind="Collect" Name="Little C.H.A.D." Subtype="96" Variant="100" />
-	<entity Group="Familiars" ID="5" Image="resources/Entities/Items/5.100.98 - The Relic.png" Kind="Collect" Name="The Relic" Subtype="98" Variant="100" />
-	<entity Group="Familiars" ID="5" Image="resources/Entities/Items/5.100.99 - Little Gish.png" Kind="Collect" Name="Little Gish" Subtype="99" Variant="100" />
-	<entity Group="Familiars" ID="5" Image="resources/Entities/Items/5.100.100 - Little Steven.png" Kind="Collect" Name="Little Steven" Subtype="100" Variant="100" />
-	<entity Group="Familiars" ID="5" Image="resources/Entities/Items/5.100.112 - Guardian Angel.png" Kind="Collect" Name="Guardian Angel" Subtype="112" Variant="100" />
-	<entity Group="Familiars" ID="5" Image="resources/Entities/Items/5.100.113 - Demon Baby.png" Kind="Collect" Name="Demon Baby" Subtype="113" Variant="100" />
-	<entity Group="Familiars" ID="5" Image="resources/Entities/Items/5.100.128 - Forever alone.png" Kind="Collect" Name="Forever alone" Subtype="128" Variant="100" />
-	<entity Group="Familiars" ID="5" Image="resources/Entities/Items/5.100.131 - Bomb Bag.png" Kind="Collect" Name="Bomb Bag" Subtype="131" Variant="100" />
-	<entity Group="Familiars" ID="5" Image="resources/Entities/Items/5.100.144 - Bum Friend.png" Kind="Collect" Name="Bum Friend" Subtype="144" Variant="100" />
-	<entity Group="Familiars" ID="5" Image="resources/Entities/Items/5.100.155 - The Peeper.png" Kind="Collect" Name="The Peeper" Subtype="155" Variant="100" />
-	<entity Group="Familiars" ID="5" Image="resources/Entities/Items/5.100.163 - Ghost Baby.png" Kind="Collect" Name="Ghost Baby" Subtype="163" Variant="100" />
-	<entity Group="Familiars" ID="5" Image="resources/Entities/Items/5.100.167 - Harlequin Baby.png" Kind="Collect" Name="Harlequin Baby" Subtype="167" Variant="100" />
-	<entity Group="Familiars" ID="5" Image="resources/Entities/Items/5.100.170 - Daddy Longlegs.png" Kind="Collect" Name="Daddy Longlegs" Subtype="170" Variant="100" />
-	<entity Group="Familiars" ID="5" Image="resources/Entities/Items/5.100.172 - Sacrificial Dagger.png" Kind="Collect" Name="Sacrificial Dagger" Subtype="172" Variant="100" />
-	<entity Group="Familiars" ID="5" Image="resources/Entities/Items/5.100.174 - Rainbow Baby.png" Kind="Collect" Name="Rainbow Baby" Subtype="174" Variant="100" />
-	<entity Group="Familiars" ID="5" Image="resources/Entities/Items/5.100.178 - Holy Water.png" Kind="Collect" Name="Holy Water" Subtype="178" Variant="100" />
-	<entity Group="Familiars" ID="5" Image="resources/Entities/Items/5.100.187 - Guppy's Hairball.png" Kind="Collect" Name="Guppy's Hairball" Subtype="187" Variant="100" />
-	<entity Group="Familiars" ID="5" Image="resources/Entities/Items/5.100.188 - Abel.png" Kind="Collect" Name="Abel" Subtype="188" Variant="100" />
-	<entity Group="Familiars" ID="5" Image="resources/Entities/Items/5.100.206 - Guillotine.png" Kind="Collect" Name="Guillotine" Subtype="206" Variant="100" />
-	<entity Group="Familiars" ID="5" Image="resources/Entities/Items/5.100.207 - Ball of Bandages.png" Kind="Collect" Name="Ball of Bandages" Subtype="207" Variant="100" />
-	<entity Group="Familiars" ID="5" Image="resources/Entities/Items/5.100.238 - Key Piece 1.png" Kind="Collect" Name="Key Piece 1" Subtype="238" Variant="100" />
-	<entity Group="Familiars" ID="5" Image="resources/Entities/Items/5.100.239 - Key Piece 2.png" Kind="Collect" Name="Key Piece 2" Subtype="239" Variant="100" />
-	<entity Group="Familiars" ID="5" Image="resources/Entities/Items/5.100.264 - Smart Fly.png" Kind="Collect" Name="Smart Fly" Subtype="264" Variant="100" />
-	<entity Group="Familiars" ID="5" Image="resources/Entities/Items/5.100.265 - Dry Baby.png" Kind="Collect" Name="Dry Baby" Subtype="265" Variant="100" />
-	<entity Group="Familiars" ID="5" Image="resources/Entities/Items/5.100.266 - Juicy Sack.png" Kind="Collect" Name="Juicy Sack" Subtype="266" Variant="100" />
-	<entity Group="Familiars" ID="5" Image="resources/Entities/Items/5.100.267 - Robo-Baby 2.0.png" Kind="Collect" Name="Robo-Baby 2.0" Subtype="267" Variant="100" />
-	<entity Group="Familiars" ID="5" Image="resources/Entities/Items/5.100.268 - Rotten Baby.png" Kind="Collect" Name="Rotten Baby" Subtype="268" Variant="100" />
-	<entity Group="Familiars" ID="5" Image="resources/Entities/Items/5.100.269 - Headless Baby.png" Kind="Collect" Name="Headless Baby" Subtype="269" Variant="100" />
-	<entity Group="Familiars" ID="5" Image="resources/Entities/Items/5.100.270 - Leech.png" Kind="Collect" Name="Leech" Subtype="270" Variant="100" />
-	<entity Group="Familiars" ID="5" Image="resources/Entities/Items/5.100.271 - Mystery Sack.png" Kind="Collect" Name="Mystery Sack" Subtype="271" Variant="100" />
-	<entity Group="Familiars" ID="5" Image="resources/Entities/Items/5.100.272 - BBF.png" Kind="Collect" Name="BBF" Subtype="272" Variant="100" />
-	<entity Group="Familiars" ID="5" Image="resources/Entities/Items/5.100.273 - Bob's Brain.png" Kind="Collect" Name="Bob's Brain" Subtype="273" Variant="100" />
-	<entity Group="Familiars" ID="5" Image="resources/Entities/Items/5.100.274 - Best Bud.png" Kind="Collect" Name="Best Bud" Subtype="274" Variant="100" />
-	<entity Group="Familiars" ID="5" Image="resources/Entities/Items/5.100.275 - Lil' Brimstone.png" Kind="Collect" Name="Lil' Brimstone" Subtype="275" Variant="100" />
-	<entity Group="Familiars" ID="5" Image="resources/Entities/Items/5.100.276 - Isaac's Heart.png" Kind="Collect" Name="Isaac's Heart" Subtype="276" Variant="100" />
-	<entity Group="Familiars" ID="5" Image="resources/Entities/Items/5.100.277 - Lil' Haunt.png" Kind="Collect" Name="Lil' Haunt" Subtype="277" Variant="100" />
-	<entity Group="Familiars" ID="5" Image="resources/Entities/Items/5.100.278 - Dark Bum.png" Kind="Collect" Name="Dark Bum" Subtype="278" Variant="100" />
-	<entity Group="Familiars" ID="5" Image="resources/Entities/Items/5.100.279 - Big Fan.png" Kind="Collect" Name="Big Fan" Subtype="279" Variant="100" />
-	<entity Group="Familiars" ID="5" Image="resources/Entities/Items/5.100.280 - Sissy Longlegs.png" Kind="Collect" Name="Sissy Longlegs" Subtype="280" Variant="100" />
-	<entity Group="Familiars" ID="5" Image="resources/Entities/Items/5.100.281 - Punching Bag.png" Kind="Collect" Name="Punching Bag" Subtype="281" Variant="100" />
-	<entity Group="Familiars" ID="5" Image="resources/Entities/Items/5.100.318 - Gemini.png" Kind="Collect" Name="Gemini" Subtype="318" Variant="100" />
-	<entity Group="Familiars" ID="5" Image="resources/Entities/Items/5.100.319 - Cain's Other Eye.png" Kind="Collect" Name="Cain's Other Eye" Subtype="319" Variant="100" />
-	<entity Group="Familiars" ID="5" Image="resources/Entities/Items/5.100.320 - Blue Baby's Only Friend.png" Kind="Collect" Name="???'s Only Friend" Subtype="320" Variant="100" />
-	<entity Group="Familiars" ID="5" Image="resources/Entities/Items/5.100.321 - Samson's Chains.png" Kind="Collect" Name="Samson's Chains" Subtype="321" Variant="100" />
-	<entity Group="Familiars" ID="5" Image="resources/Entities/Items/5.100.322 - Mongo Baby.png" Kind="Collect" Name="Mongo Baby" Subtype="322" Variant="100" />
+	<group Name="Cellar Enemies">
+		<entity BaseHP="13" Tags="Champion" ID="16" Image="Entities/16.2.0 - Mulliboom.png" Name="Mulliboom" Subtype="0" Variant="2" />
+		<entity BaseHP="20" Tags="Champion" ID="205" Image="Entities/205.0.0 - Nest.png" Name="Nest" Subtype="0" Variant="0" />
+		<entity BaseHP="10" Tags="Champion" ID="61" Image="Entities/61.1.0 - Spit.png" Name="Spit" Subtype="0" Variant="1"/>
+		<entity BaseHP="10" Tags="Champion" ID="29" Image="Entities/29.1.0 - Trite.png" Name="Trite" Subtype="0" Variant="1"/>
+		<entity BaseHP="13" Tags="Champion" ID="246" Image="Entities/246.0.0 - Ragling.png" Name="Ragling" Subtype="0" Variant="0"/>
+		<entity BaseHP="20" Tags="Champion" ID="30" Image="Entities/30.2.0 - Sack.png" Name="Sack" Subtype="0" Variant="2" />
+		<entity BaseHP="20" Tags="Champion" ID="88" Image="Entities/88.2.0 - Walking Sack.png" Name="Walking Sack" Subtype="0" Variant="2" />
+		<entity BaseHP="6.5" ID="85" Image="Entities/85.0.0 - Spider.png" Name="Spider" Subtype="0" Variant="0"/>
+		<entity BaseHP="20" ID="94" Image="Entities/94.0.0 - Big Spider.png" Name="Big Spider" Subtype="0" Variant="0"/>
+		<entity BaseHP="13" ID="215" Image="Entities/215.0.0 - Level 2 Spider.png" Name="Level 2 Spider" Subtype="0" Variant="0"/>
+		<entity BaseHP="13" ID="250" Image="Entities/250.0.0 - Ticking Spider.png" Name="Ticking Spider" Subtype="0" Variant="0"/>
+		<entity BaseHP="12" Tags="Champion" ID="206" Image="Entities/206.1.0 - Small Baby Long Legs.png" Name="Small Baby Long Legs" Subtype="0" Variant="1"/>
+		<entity BaseHP="16" Tags="Champion" ID="206" Image="Entities/206.0.0 - Baby Long Legs.png" Name="Baby Long Legs" Subtype="0" Variant="0"/>
+		<entity BaseHP="12" Tags="Champion" ID="207" Image="Entities/207.1.0 - Small Crazy Long Legs.png" Name="Small Crazy Long Legs" Subtype="0" Variant="1"/>
+		<entity BaseHP="16" Tags="Champion" ID="207" Image="Entities/207.0.0 - Crazy Long Legs.png" Name="Crazy Long Legs" Subtype="0" Variant="0"/>
+		<entity BaseHP="10" ID="240" Image="Entities/240.0.0 - Wall Creep.png" PlaceVisual="WallSnap" Name="Wall Creep" Subtype="0" Variant="0"/>
+		<entity BaseHP="10" ID="242" Image="Entities/242.0.0 - Blind Creep.png" PlaceVisual="WallSnap" Name="Blind Creep" Subtype="0" Variant="0"/>
+		<entity BaseHP="35" ID="255" Image="Entities/255.0.0 - Night Crawler.png" Name="Night Crawler" Subtype="0" Variant="0" />
+	</group>
+
+	<group Name="Chapter 2 (Main Path) Enemies">
+		<entity BaseHP="33" Tags="Champion" ID="24" Image="Entities/24.0.0 - Globin.png" Name="Globin" Subtype="0" Variant="0"/>
+		<entity BaseHP="33" Tags="Champion" ID="24" Image="Entities/24.1.0 - Gazing Globin.png" Name="Gazing Globin" Subtype="0" Variant="1"/>
+		<entity Name="Skinny"/>
+		<entity BaseHP="16" ID="226" Image="Entities/226.1.0 - Rotty.png" Name="Rotty" Subtype="0" Variant="1"/>
+		<entity BaseHP="8" ID="227" Image="Entities/227.0.0 - Bony.png" Name="Bony" Subtype="0" Variant="0"/>
+		<entity BaseHP="10" ID="238" Image="Entities/238.0.0 - Splasher.png" Name="Splasher" Subtype="0" Variant="0"/>
+		<entity Name="Psychic Horf"/>
+		<entity BaseHP="20" Tags="Champion" ID="26" Image="Entities/26.0.0 - Maw.png" Name="Maw" Subtype="0" Variant="0" />
+		<entity BaseHP="20" Tags="Champion" ID="26" Image="Entities/26.1.0 - Red Maw.png" Name="Red Maw" Subtype="0" Variant="1" />
+		<entity Name="Fatty"/>
+		<entity BaseHP="20" ID="208" Image="Entities/208.1.0 - Pale Fatty.png" Name="Pale Fatty" Subtype="0" Variant="1"/>
+		<entity BaseHP="16" Tags="Champion" ID="210" Image="Entities/210.0.0 - Blubber.png" Name="Blubber" Subtype="0" Variant="0"/>
+		<entity BaseHP="10" Tags="Champion" ID="211" Image="Entities/211.0.0 - Half Sack.png" Name="Half Sack" Subtype="0" Variant="0"/>
+		<entity BaseHP="20" Tags="Champion" ID="22" Image="Entities/22.0.0 - Hive.png" Name="Hive" Subtype="0" Variant="0" />
+		<entity Name="Nest"/>
+		<entity Name="Attack Fly"/>
+		<entity Name="Moter"/>
+		<entity Name="Ring Fly"/>
+		<entity Name="Full Fly"/>
+		<entity Name="Sucker"/>
+		<entity Name="Pooter"/>
+		<entity Name="Super Pooter"/>
+		<entity BaseHP="20" Tags="Champion" ID="25" Image="Entities/25.0.0 - Boom Fly.png" Name="Boom Fly" Subtype="0" Variant="0"/>
+		<entity BaseHP="20" Tags="Champion" ID="25" Image="Entities/25.1.0 - Red Boom Fly.png" Name="Red Boom Fly" Subtype="0" Variant="1"/>
+		<entity Name="Spider"/>
+		<entity Name="Big Spider"/>
+		<entity Name="Ticking Spider"/>
+		<entity Name="Small Baby Long Legs"/>
+		<entity Name="Baby Long Legs"/>
+		<entity Name="Small Crazy Long Legs"/>
+		<entity Name="Crazy Long Legs"/>
+		<entity Name="Wall Creep"/>
+		<entity Name="Blind Creep"/>
+		<entity BaseHP="20" ID="229" Image="Entities/229.0.0 - Tumor.png" Name="Tumor" Subtype="0" Variant="0" />
+		<entity Name="Clot"/>
+		<entity Name="Dip"/>
+		<entity Name="Squirt"/>
+		<entity BaseHP="20" ID="234" Image="Entities/234.0.0 - One Tooth.png" Name="One Tooth" Subtype="0" Variant="0" />
+		<entity BaseHP="20" Tags="Champion" ID="30" Image="Entities/30.0.0 - Boil.png" Name="Boil" Subtype="0" Variant="0" />
+		<entity BaseHP="15" Tags="Champion" ID="27" Image="Entities/27.0.0 - Host.png" Name="Host" Subtype="0" Variant="0" />
+		<entity BaseHP="20" Tags="Champion" ID="204" Image="Entities/204.0.0 - Mobile Host.png" Name="Mobile Host" Subtype="0" Variant="0" />
+		<entity BaseHP="15" Tags="Champion" ID="27" Image="Entities/27.1.0 - Red Host.png" Name="Red Host" Subtype="0" Variant="1" />
+		<entity BaseHP="27" Tags="Champion" ID="247" Image="Entities/247.0.0 - Flesh Mobile Host.png" Name="Flesh Mobile Host" Subtype="0" Variant="0" />
+		<entity BaseHP="15" Tags="Champion" ID="21" Image="Entities/21.0.0 - Maggot.png" Name="Maggot" Subtype="0" Variant="0" />
+		<entity BaseHP="20" Tags="Champion" ID="23" Image="Entities/23.0.0 - Charger.png" Name="Charger" Subtype="0" Variant="0" />
+		<entity BaseHP="10" Tags="Champion" ID="31" Image="Entities/31.0.0 - Spitty.png" Name="Spitty" Subtype="0" Variant="0" />
+		<entity BaseHP="18" ID="243" Image="Entities/243.0.0 - Conjoined Spitty.png" Name="Conjoined Spitty" Subtype="0" Variant="0" />
+		<entity Name="Embryo"/>
+		<entity BaseHP="20" ID="89" Image="Entities/89.0.0 - Buttlicker.png" Name="Buttlicker" Subtype="0" Variant="0" />
+		<entity BaseHP="10" ID="239" Image="Entities/239.0.0 - Grub.png" Name="Grub" Subtype="0" Variant="0" />
+		<entity Name="Round Worm"/>
+		<entity Name="Night Crawler"/>
+	</group>
+
+	<group Name="Chapter 2 (Main Path) Obstacles">
+		<entity BaseHP="20" ID="42" Image="Entities/42.0.0 - Stone Grimace.png" Name="Stone Grimace" Subtype="0" Variant="0" />
+		<group Name="Constant Stone Shooter">
+			<defaults>
+				<entity>
+					<tag>ConstantStoneShooters</tag>
+				</entity>
+			</defaults>
+			<entity BaseHP="1" ID="202" Image="Entities/202.0.3 - Constant Stone Shooter.png" Name="Constant Stone Shooter (Left)" Subtype="0" Variant="0" MirrorX="202.0.2" />
+			<entity BaseHP="1" ID="202" Image="Entities/202.0.1 - Constant Stone Shooter.png" Name="Constant Stone Shooter (Up)" Subtype="1" Variant="0" MirrorY="202.0.3" />
+			<entity BaseHP="1" ID="202" Image="Entities/202.0.2 - Constant Stone Shooter.png" Name="Constant Stone Shooter (Right)" Subtype="2" Variant="0" MirrorX="202.0.0" />
+			<entity BaseHP="1" ID="202" Image="Entities/202.0.0 - Constant Stone Shooter.png" Name="Constant Stone Shooter (Down)" Subtype="3" Variant="0" MirrorY="202.0.1" />
+		</group>
+	</group>
+
+	<group Name="Caves Enemies">
+		<entity Name="Clotty"/>
+	</group>
+
+	<group Name="Catacombs Enemies">
+		<entity BaseHP="40" Tags="Champion" ID="87" Image="Entities/87.0.0 - Gurgle.png" Name="Gurgle" Subtype="0" Variant="0"/>
+		<entity Name="Mulliboom"/>
+		<entity BaseHP="25" Tags="Champion" ID="39" Image="Entities/39.2.0 - Chubber.png" Name="Chubber" Subtype="0" Variant="2" />
+		<entity Name="Spit"/>
+		<entity Name="Trite"/>
+		<entity Name="Ragling"/>
+		<entity Name="Level 2 Spider"/>
+		<entity BaseHP="36" Tags="Champion" ID="86" Image="Entities/86.0.0 - Keeper.png" Name="Keeper" Subtype="0" Variant="0" />
+		<entity BaseHP="20" Tags="Champion" ID="30" Image="Entities/30.1.0 - Gut.png" Name="Gut" Subtype="0" Variant="1" />
+		<entity Name="Sack"/>
+		<entity BaseHP="20" Tags="Champion" ID="88" Image="Entities/88.0.0 - Walking Boil.png" Name="Walking Boil" Subtype="0" Variant="0" />
+		<entity BaseHP="20" Tags="Champion" ID="88" Image="Entities/88.1.0 - Walking Gut.png" Name="Walking Gut" Subtype="0" Variant="1" />
+		<entity Name="Walking Sack"/>
+	</group>
+
+	<group Name="Catacombs Obstacles">
+		<entity BaseHP="20" ID="42" Image="Entities/42.1.0 - Vomit Grimace.png" Name="Vomit Grimace" Subtype="0" Variant="1" />
+	</group>
+
+	<group Name="Chapter 3 (Main Path) Enemies">
+		<entity Name="Globin"/>
+		<entity Name="Gazing Globin"/>
+		<entity Name="Rotty"/>
+		<entity Name="Bony"/>
+		<entity BaseHP="25" Tags="Champion" ID="34" Image="Entities/34.0.0 - Leaper.png" Name="Leaper" Subtype="0" Variant="0"/>
+		<entity BaseHP="30" Tags="Champion" ID="252" Image="Entities/252.0.0 - Nulls.png" Name="Nulls" Subtype="0" Variant="0"/>
+		<entity BaseHP="60" ID="251" Image="Entities/251.0.0 - Begotten.png" Name="Begotten" Subtype="0" Variant="0" />
+		<entity BaseHP="20" Tags="Champion" ID="41" Image="Entities/41.0.0 - Knight.png" Name="Knight" Subtype="0" Variant="0" />
+		<entity BaseHP="20" Tags="Champion" ID="254" Image="Entities/254.0.0 - Floating Knight.png" Name="Floating Knight" Subtype="0" Variant="0" />
+		<entity Name="Psychic Horf"/>
+		<entity Name="Maw"/>
+		<entity Name="Red Maw"/>
+		<entity BaseHP="20" Tags="Champion" ID="26" Image="Entities/26.2.0 - Psychic Maw.png" Name="Psychic Maw" Subtype="0" Variant="2" />
+		<entity BaseHP="25" ID="35" Image="Entities/35.0.0 - Mr. Maw.png" Name="Mr. Maw" Subtype="0" Variant="0" />
+		<entity Name="Pale Fatty"/>
+		<entity BaseHP="16" Tags="Champion" ID="209" Image="Entities/209.0.0 - Fat Sack.png" Name="Fat Sack" Subtype="0" Variant="0"/>
+		<entity Name="Blubber"/>
+		<entity Name="Half Sack"/>
+		<entity Name="Hive"/>
+		<entity BaseHP="25" Tags="Champion" ID="39" Image="Entities/39.0.0 - Vis.png" Name="Vis" Subtype="0" Variant="0" />
+		<entity BaseHP="25" Tags="Champion" ID="38" Image="Entities/38.0.0 - Baby.png" Name="Baby" Subtype="0" Variant="0" />
+		<entity BaseHP="40" Tags="Champion" ID="91" Image="Entities/91.0.0 - Swarmer.png" Name="Swarmer" Subtype="0" Variant="0"/>
+		<entity Name="Attack Fly"/>
+		<entity Name="Moter"/>
+		<entity Name="Ring Fly"/>
+		<entity Name="Sucker"/>
+		<entity Name="Pooter"/>
+		<entity Name="Super Pooter"/>
+		<entity Name="Boom Fly"/>
+		<entity Name="Red Boom Fly"/>
+		<entity Name="Spider"/>
+		<entity Name="Big Spider"/>
+		<entity Name="Wall Creep"/>
+		<entity Name="Blind Creep"/>
+		<entity BaseHP="10" ID="241" Image="Entities/241.0.0 - Rage Creep.png" PlaceVisual="WallSnap" Name="Rage Creep" Subtype="0" Variant="0"/>
+		<entity BaseHP="20" ID="212" Image="Entities/212.0.0 - Death's Head.png" Name="Death's Head" Subtype="0" Variant="0" />
+		<entity BaseHP="20" ID="213" Image="Entities/213.0.0 - Mom's Hand.png" Name="Mom's Hand" Subtype="0" Variant="0" />
+		<entity Name="Tumor"/>
+		<entity BaseHP="20" Tags="Champion" ID="32" Image="Entities/32.0.0 - Brain.png" Name="Brain" Subtype="0" Variant="0" />
+		<entity Name="Dip"/>
+		<entity Name="Squirt"/>
+		<entity BaseHP="62" ID="223" Image="Entities/223.0.0 - Dinga.png" Name="Dinga" Subtype="0" Variant="0" />
+		<entity BaseHP="25" ID="219" Image="Entities/219.0.0 - Wizoob.png" Name="Wizoob" Subtype="0" Variant="0" />
+		<entity BaseHP="25" ID="260" Image="Entities/260.10.0 - Lil' Haunt.png" Name="Lil' Haunt" Subtype="0" Variant="10" />
+		<entity Name="Boil"/>
+		<entity Name="Host"/>
+		<entity Name="Mobile Host"/>
+		<entity Name="Buttlicker"/>
+		<entity Name="Grub"/>
+	</group>
+
+	<group Name="Chapter 3 (Main Path) Obstacles">
+		<entity Name="Stone Grimace"/>
+		<entity BaseHP="100" ID="235" Image="Entities/235.0.0 - Gaping Maw.png" Name="Gaping Maw" Subtype="0" Variant="0" />
+		<entity BaseHP="100" ID="236" Image="Entities/236.0.0 - Broken Gaping Maw.png" Name="Broken Gaping Maw" Subtype="0" Variant="0" />
+		<entity BaseHP="100" ID="44" Image="Entities/44.0.0 - Poky.png" PlaceVisual="0,0.5" Name="Poky" Subtype="0" Variant="0" />
+		<entity BaseHP="100" ID="44" Image="Entities/44.1.0 - Slide.png" PlaceVisual="0,0.5" Name="Slide" Subtype="0" Variant="1" />
+	</group>
+
+	<group Name="Depths Enemies">
+		<group Name="Guts (Enemy)">
+			<defaults>
+				<entity>
+					<tag>Champion</tag>
+					<tag>GutsEnemy</tag>
+				</entity>
+			</defaults>
+			<entity BaseHP="25" ID="40" Image="Entities/40.0.0 - Guts.png" Name="Guts (Random)" Subtype="0" Variant="0" />
+			<entity BaseHP="25" ID="40" Image="Entities/40.0.1 - Guts (Left).png" Name="Guts (Left)" Subtype="1" Variant="0" MirrorX="40.0.3" />
+			<entity BaseHP="25" ID="40" Image="Entities/40.0.2 - Guts (Up).png" Name="Guts (Up)" Subtype="2" Variant="0" MirrorY="40.0.4" />
+			<entity BaseHP="25" ID="40" Image="Entities/40.0.3 - Guts (Right).png" Name="Guts (Right)" Subtype="3" Variant="0" MirrorX="40.0.1" />
+			<entity BaseHP="25" ID="40" Image="Entities/40.0.4 - Guts (Down).png" Name="Guts (Down)" Subtype="4" Variant="0" MirrorY="40.0.2" />
+		</group>
+	</group>
+
+	<group Name="Necropolis Enemies">
+		<entity Name="Nest"/>
+		<entity BaseHP="25" Tags="Champion" ID="39" Image="Entities/39.1.0 - Double Vis.png" Name="Double Vis" Subtype="0" Variant="1" />
+		<entity Name="Chubber"/>
+		<entity Name="Spit"/>
+		<entity Name="Ticking Spider"/>
+		<entity BaseHP="40" ID="92" Image="Entities/92.0.0 - Heart.png" Name="Heart" Subtype="0" Variant="0" />
+		<entity BaseHP="40" ID="93" Image="Entities/93.0.0 - Mask.png" Name="Mask" Subtype="0" Variant="0" />
+		<entity BaseHP="40" ID="253" Image="Entities/253.0.0 - Psy Tumor.png" Name="Psy Tumor" Subtype="0" Variant="0" />
+		<entity Name="Keeper" ID="86"/>
+		<entity BaseHP="40" ID="90" Image="Entities/90.0.0 - Hanger.png" Name="Hanger" Subtype="0" Variant="0" />
+		<entity Name="Gut"/>
+		<entity Name="Sack"/>
+		<entity Name="Walking Boil"/>
+		<entity Name="Walking Gut"/>
+		<entity Name="Walking Sack"/>
+	</group>
+
+	<group Name="Necropolis Obstacles">
+		<entity Name="Vomit Grimace"/>
+	</group>
+
+	<group Name="Chapter 4 (Main Path) Enemies">
+		<entity Name="Globin"/>
+		<entity Name="Gazing Globin"/>
+		<entity BaseHP="36" ID="228" Image="Entities/228.0.0 - Homunculus.png" Name="Homunculus" Subtype="0" Variant="0" />
+		<entity BaseHP="20" Tags="Champion" ID="53" Image="Entities/53.0.0 - Dople.png" Name="Dople" Subtype="0" Variant="0" />
+		<entity Name="Mr. Maw"/>
+		<entity Name="Vis"/>
+		<entity Name="Double Vis"/>
+		<entity Name="Baby"/>
+		<group Name="Guts (Enemy)"/>
+		<entity Name="Sucker"/>
+		<entity Name="Red Boom Fly"/>
+		<entity Name="Rage Creep"/>
+		<entity BaseHP="20" ID="231" Image="Entities/231.0.0 - Nerve Ending.png" Name="Nerve Ending" Subtype="0" Variant="0" />
+		<entity BaseHP="20" Tags="Champion" ID="221" Image="Entities/221.0.0 - Cod Worm.png" Name="Cod Worm" Subtype="0" Variant="0" />
+		<entity BaseHP="30" Tags="Champion" ID="56" Image="Entities/56.0.0 - Lump.png" Name="Lump" Subtype="0" Variant="0" />
+		<entity BaseHP="35" Tags="Champion" ID="58" Image="Entities/58.0.0 - Para-Bite.png" Name="Para-Bite" Subtype="0" Variant="0" />
+		<entity BaseHP="20" Tags="Champion" ID="59" Image="Entities/59.0.0 - Fred.png" Name="Fred" Subtype="0" Variant="0" />
+		<entity Name="Death's Head"/>
+		<entity Name="Tumor"/>
+		<entity BaseHP="20" Tags="Champion" ID="60" Image="Entities/60.0.0 - Eye.png" Name="Eye" Subtype="0" Variant="0" />
+		<entity BaseHP="100" ID="224" Image="Entities/224.0.0 - Oob.png" Name="Oob" Subtype="0" Variant="0" />
+		<entity BaseHP="24" Tags="Champion" ID="237" Image="Entities/237.0.0 - Gurgling.png" Name="Gurgling" Subtype="0" Variant="0" />
+		<entity Name="Brain"/>
+		<entity BaseHP="62" Tags="Champion" ID="57" Image="Entities/57.0.0 - MemBrain.png" Name="MemBrain" Subtype="0" Variant="0" />
+		<entity BaseHP="62" Tags="Champion" ID="57" Image="Entities/57.1.0 - Mama Guts.png" Name="Mama Guts" Subtype="0" Variant="1" />
+		<entity Name="Clotty"/>
+		<entity Name="I.Blob"/>
+		<entity Name="Dip"/>
+		<entity Name="Squirt"/>
+		<entity Name="Dinga"/>
+		<entity Name="Boil"/>
+		<entity Name="Walking Boil"/>
+		<entity Name="Red Host"/>
+		<entity Name="Flesh Mobile Host"/>
+		<entity Name="Embryo"/>
+		<entity Name="Grub"/>
+		<entity BaseHP="38" ID="216" Image="Entities/216.0.0 - Swinger.png" Name="Swinger" Subtype="0" Variant="0" />
+	</group>
+
+	<group Name="Chapter 4 (Main Path) Obstacles">
+		<entity Name="Stone Grimace"/>
+		<entity Name="Gaping Maw"/>
+		<entity Name="Broken Gaping Maw"/>
+		<entity BaseHP="1" ID="201" Image="Entities/201.0.0 - Stone Eye.png" Name="Stone Eye" Subtype="0" Variant="0" />
+	</group>
+
+	<group Name="Womb Enemies">
+		<entity Name="Host"/>
+	</group>
+
+	<group Name="Utero Enemies">
+		<entity Name="Chubber"/>
+		<entity Name="Spit"/>
+		<entity Name="Spider"/>
+		<entity Name="Big Spider"/>
+		<entity Name="Blind Creep"/>
+		<entity BaseHP="25" Tags="Champion" ID="55" Image="Entities/55.0.0 - Leech.png" Name="Leech" Subtype="0" Variant="0" />
+		<entity BaseHP="20" Tags="Champion" ID="60" Image="Entities/60.1.0 - Bloodshot Eye.png" Name="Bloodshot Eye" Subtype="0" Variant="1" />
+		<entity Name="Mobile Host"/>
+	</group>
+
+	<group Name="Utero Obstacles">
+		<entity Name="Vomit Grimace"/>
+	</group>
+
+	<group Name="Scarred Womb Enemies">
+		<entity Name="Chubber"/>
+		<entity Name="Spider"/>
+		<entity Name="Big Spider"/>
+		<entity Name="Leech"/>
+		<entity Name="Host"/>
+	</group>
+
+	<group Name="Chapter 5 (Main Path) Enemies">
+		<entity Name="Mr. Maw"/>
+		<entity Name="Wizoob"/>
+		<entity Name="Lil' Haunt"/>
+		<entity Name="Mobile Host"/>
+	</group>
+
+	<group Name="Sheol Enemies">
+		<entity Name="Nulls"/>
+		<entity Name="Begotten"/>
+		<entity BaseHP="20" Tags="Champion" ID="41" Image="Entities/41.1.0 - Selfless Knight.png" Name="Selfless Knight" Subtype="0" Variant="1" />
+		<entity BaseHP="20" Tags="Champion" ID="53" Image="Entities/53.1.0 - Evil Twin.png" Name="Evil Twin" Subtype="0" Variant="1" />
+		<entity Name="Sucker"/>
+		<entity Name="Big Spider"/>
+		<entity BaseHP="25" Tags="Champion" ID="55" Image="Entities/55.1.0 - Kamikaze Leech.png" Name="Kamikaze Leech" Subtype="0" Variant="1" />
+		<entity Name="Death's Head"/>
+		<entity BaseHP="32" ID="230" Image="Entities/230.0.0 - Camillo Jr.png" Name="Camillo Jr." Subtype="0" Variant="0" />
+		<entity BaseHP="20" ID="225" Image="Entities/225.0.0 - Black Maw.png" Name="Black Maw" Subtype="0" Variant="0" />
+		<entity Name="Host"/>
+	</group>
+
+	<group Name="Sheol Obstacles">
+		<entity Name="Gaping Maw"/>
+		<entity Name="Stone Eye"/>
+		<entity BaseHP="1" ID="203" Image="Entities/203.0.0 - Brimstone Head.png" Name="Brimstone Head (Left)" Subtype="0" Variant="0" MirrorX="203.0.2" />
+		<entity BaseHP="1" ID="203" Image="Entities/203.0.1 - Brimstone Head.png" Name="Brimstone Head (Up)" Subtype="1" Variant="0" MirrorY="203.0.3" />
+		<entity BaseHP="1" ID="203" Image="Entities/203.0.2 - Brimstone Head.png" Name="Brimstone Head (Right)" Subtype="2" Variant="0" MirrorX="203.0.0" />
+		<entity BaseHP="1" ID="203" Image="Entities/203.0.3 - Brimstone Head.png" Name="Brimstone Head (Down)" Subtype="3" Variant="0" MirrorY="203.0.1" />
+	</group>
+
+	<group Name="Cathedral Enemies">
+		<entity Name="Bony"/>
+		<entity Name="Psychic Maw"/>
+		<entity BaseHP="25" Tags="Champion" ID="38" Image="Entities/38.1.0 - Angelic Baby.png" Name="Angelic Baby" Subtype="0" Variant="1" />
+		<entity Name="Spit"/>
+		<entity BaseHP="25" Tags="Champion" ID="55" Image="Entities/55.2.0 - Holy Leech.png" Name="Holy Leech" Subtype="0" Variant="2" />
+		<entity Name="Death's Head"/>
+		<entity Name="I.Blob"/>
+		<entity Name="Clot"/>
+		<entity Name="Keeper" ID="86"/>
+		<entity Name="Hanger"/>
+		<entity Name="Psy Tumor"/>
+	</group>
+
+	<group Name="Cathedral Obstacles">
+		<entity Name="Stone Grimace"/>
+		<entity Name="Poky"/>
+		<entity Name="Slide"/>
+	</group>
+
+	<!--——— Bosses ———-->
+	<group Name="Bosses">
+		<defaults>
+			<entity>
+				<tag>Boss</tag>
+			</entity>
+		</defaults>
+		<group Name="Floor Bosses">
+			<group Name="Chapter 1 Bosses">
+				<group Name="Chapter 1 Bosses (Main Path)" Label="Chapter 1 (Main Path)">
+					<group Name="Chapter 1 Bosses (Main Path) Shared"/>
+					<group Name="Basement Bosses" Label="Basement"/>
+					<group Name="Cellar Bosses" Label="Cellar"/>
+				</group>
+			</group>
+			<group Name="Chapter 2 Bosses">
+				<group Name="Chapter 2 Bosses (Main Path)" Label="Chapter 2 (Main Path)">
+					<group Name="Chapter 2 Bosses (Main Path) Shared"/>
+					<group Name="Caves Bosses" Label="Caves"/>
+					<group Name="Catacombs Bosses" Label="Catacombs"/>
+				</group>
+			</group>
+			<group Name="Chapter 3 Bosses">
+				<group Name="Chapter 3 Bosses (Main Path)" Label="Chapter 3 (Main Path)">
+					<group Name="Chapter 3 Bosses (Main Path) Shared"/>
+					<group Name="Depths Bosses" Label="Depths"/>
+					<group Name="Necropolis Bosses" Label="Necropolis"/>
+				</group>
+			</group>
+			<group Name="Chapter 4 Bosses">
+				<group Name="Chapter 4 Bosses (Main Path)" Label="Chapter 4 (Main Path)">
+					<group Name="Chapter 4 Bosses (Main Path) Shared"/>
+					<group Name="Womb Bosses" Label="Womb"/>
+					<group Name="Utero Bosses" Label="Utero"/>
+				</group>
+			</group>
+		</group>
+		<group Name="Special Bosses">
+			<group Label="The Sins"/>
+			<group Name="Common Bosses" Label="Special"/>
+			<group Label="Story Bosses"/>
+			<group Name="Other Bosses"/>
+		</group>
+	</group>
+
+	<group Name="Chapter 1 Bosses (Main Path) Shared">
+		<entity BaseHP="110" ID="67" Image="Entities/67.0.0 - The Duke of Flies.png" Name="The Duke of Flies" Subtype="0" Variant="0" />
+		<entity BaseHP="240" ID="63" Image="Entities/63.0.0 - Famine.png" Name="Famine" Subtype="0" Variant="0" />
+	</group>
+
+	<group Name="Basement Bosses">
+		<entity BaseHP="250" ID="20" Image="Entities/20.0.0 - Monstro.png" Name="Monstro" Subtype="0" Variant="0" />
+		<group Name="Gemini (Boss)">
+			<entity BaseHP="140" ID="79" Image="Entities/79.0.0 - Gemini.png" Name="Gemini" Subtype="0" Variant="0" />
+			<entity BaseHP="140" ID="79" Image="Entities/79.10.0 - Gemini Baby.png" Name="Suture (Gemini Baby)" Subtype="0" Variant="10" />
+		</group>
+		<group Name="Steven (Boss)">
+			<entity BaseHP="140" ID="79" Image="Entities/79.1.0 - Steven.png" Name="Steven" Subtype="0" Variant="1" />
+			<entity BaseHP="140" ID="79" Image="Entities/79.11.0 - Steven Baby.png" Name="Steven Baby" Subtype="0" Variant="11" />
+		</group>
+		<entity BaseHP="22" ID="19" Image="Entities/19.0.0 - Larry Jr.png" Name="Larry Jr." Subtype="0" Variant="0" />
+		<group Name="Dingle (Boss)">
+			<entity BaseHP="300" ID="261" Image="Entities/261.0.0 - Dingle.png" Name="Dingle" Subtype="0" Variant="0" />
+		</group>
+		<group Name="Gurgling (Boss)">
+			<entity BaseHP="90" ID="237" Image="Entities/237.1.0 - Gurgling (boss).png" Name="Gurgling (boss)" Subtype="0" Variant="1" />
+		</group>
+	</group>
+
+	<group Name="Cellar Bosses">
+		<entity BaseHP="140" ID="79" Image="Entities/79.2.0 - The Blighted Ovum.png" Name="The Blighted Ovum" Subtype="0" Variant="2" />
+		<entity BaseHP="130" ID="100" Image="Entities/100.0.0 - Widow.png" Name="Widow" Subtype="0" Variant="0" />
+		<entity BaseHP="180" ID="62" Image="Entities/62.0.0 - Pin.png" Name="Pin" Subtype="0" Variant="0" />
+		<entity BaseHP="200" ID="260" Image="Entities/260.0.0 - Haunt.png" Name="Haunt" Subtype="0" Variant="0" />
+	</group>
+
+	<group Name="Chapter 2 Bosses (Main Path) Shared">
+		<entity BaseHP="450" ID="68" Image="Entities/68.0.0 - Peep.png" Name="Peep" Subtype="0" Variant="0" />
+		<entity BaseHP="250" ID="99" Image="Entities/99.0.0 - Gurdy Jr.png" Name="Gurdy Jr." Subtype="0" Variant="0" />
+		<entity BaseHP="280" ID="64" Image="Entities/64.0.0 - Pestilence.png" Name="Pestilence" Subtype="0" Variant="0" />
+	</group>
+
+	<group Name="Caves Bosses">
+		<group Name="Chub (Boss)">
+			<entity BaseHP="350" ID="28" Image="Entities/28.0.0 - Chub.png" Name="Chub" Subtype="0" Variant="0" />
+			<entity BaseHP="350" ID="28" Image="Entities/28.1.0 - C.H.A.D..png" Name="C.H.A.D." Subtype="0" Variant="1" />
+		</group>
+		<entity BaseHP="595" ID="36" Image="Entities/36.0.0 - Gurdy.png" PlaceVisual="0,1" Name="Gurdy" Subtype="0" Variant="0" />
+		<group Name="Fistula (Boss)">
+			<entity BaseHP="8" ID="73" Image="Entities/73.0.0 - Fistula Small.png" Name="Fistula Small" Subtype="0" Variant="0" />
+			<entity BaseHP="15" ID="72" Image="Entities/72.0.0 - Fistula Medium.png" Name="Fistula Medium" Subtype="0" Variant="0" />
+			<entity BaseHP="60" ID="71" Image="Entities/71.0.0 - Fistula Big.png" Name="Fistula Big" Subtype="0" Variant="0" />
+		</group>
+		<entity BaseHP="350" ID="262" Image="Entities/262.0.0 - Mega Maw.png" PlaceVisual="0,-2" Name="Mega Maw" Subtype="0" Variant="0" />
+		<entity BaseHP="600" ID="264" Image="Entities/264.0.0 - Mega Fatty.png" Name="Mega Fatty" Subtype="0" Variant="0" />
+	</group>
+
+	<group Name="Catacombs Bosses">
+		<entity BaseHP="350" ID="28" Image="Entities/28.2.0 - The Carrion Queen.png" Name="The Carrion Queen" Subtype="0" Variant="2" />
+		<entity BaseHP="22" ID="19" Image="Entities/19.1.0 - The Hollow.png" Name="The Hollow" Subtype="0" Variant="1" />
+		<entity BaseHP="150" ID="67" Image="Entities/67.1.0 - The Husk.png" Name="The Husk" Subtype="0" Variant="1" />
+		<entity BaseHP="215" ID="100" Image="Entities/100.1.0 - The Wretched.png" Name="The Wretched" Subtype="0" Variant="1" />
+		<entity BaseHP="200" ID="269" Image="Entities/269.0.0 - Polycephalus.png" Name="Polycephalus" Subtype="0" Variant="0" />
+		<entity BaseHP="400" ID="267" Image="Entities/267.0.0 - Dark One.png" Name="Dark One" Subtype="0" Variant="0" />>
+	</group>
+
+	<group Name="Chapter 3 Bosses (Main Path) Shared">
+		<entity BaseHP="350" ID="69" Image="Entities/69.0.0 - Loki.png" Name="Loki" Subtype="0" Variant="0" />
+		<entity BaseHP="500" ID="65" Image="Entities/65.0.0 - War.png" Name="War" Subtype="0" Variant="0" />
+		<entity BaseHP="500" ID="65" Image="Entities/65.10.0 - War without Horse.png" Name="War without Horse" Subtype="0" Variant="10" />
+	</group>
+
+	<group Name="Depths Bosses">
+		<group Name="Monstro II (Boss)">
+			<entity BaseHP="632.5" ID="43" Image="Entities/43.0.0 - Monstro II.png" Name="Monstro II" Subtype="0" Variant="0" />
+			<entity BaseHP="632.5" ID="43" Image="Entities/43.1.0 - Gish.png" Name="Gish" Subtype="0" Variant="1" />
+		</group>
+		<entity BaseHP="800" ID="265" Image="Entities/265.0.0 - The Cage.png" Name="The Cage" Subtype="0" Variant="0" />
+		<entity BaseHP="500" ID="263" Image="Entities/263.0.0 - The Gate.png" PlaceVisual="0,-1" Name="The Gate" Subtype="0" Variant="0" />
+	</group>
+
+	<group Name="Necropolis Bosses">
+		<entity BaseHP="450" ID="68" Image="Entities/68.1.0 - The Bloat.png" Name="The Bloat" Subtype="0" Variant="1" />
+		<entity BaseHP="150" ID="97" Image="Entities/97.0.0 - Mask of Infamy.png" Name="Mask of Infamy" Subtype="0" Variant="0" />
+		<entity BaseHP="200" ID="98" Image="Entities/98.0.0 - Heart of Infamy.png" Name="Heart of Infamy" Subtype="0" Variant="0" />
+		<entity BaseHP="520" ID="268" Image="Entities/268.0.0 - The Adversary.png" Name="The Adversary" Subtype="0" Variant="0" />
+	</group>
+
+	<group Name="Chapter 4 Bosses (Main Path) Shared">
+		<entity BaseHP="350" ID="69" Image="Entities/69.1.0 - Lokii.png" Name="Lokii" Subtype="0" Variant="1" />
+		<entity BaseHP="450" ID="66" Image="Entities/66.0.0 - Death.png" Name="Death" Subtype="0" Variant="0" />
+		<entity BaseHP="150" ID="66" Image="Entities/66.20.0 - Death Horse.png" Name="Death Horse" Subtype="0" Variant="20" />
+		<entity BaseHP="300" ID="66" Image="Entities/66.30.0 - Death without Horse.png" Name="Death without Horse" Subtype="0" Variant="30" />
+		<entity BaseHP="500" ID="65" Image="Entities/65.1.0 - Conquest.png" Name="Conquest" Subtype="0" Variant="1" />
+	</group>
+
+	<group Name="Womb Bosses">
+		<entity BaseHP="300" ID="62" Image="Entities/62.1.0 - Scolex.png" Name="Scolex" Subtype="0" Variant="1" />
+		<group Name="Blastocyst (Boss)">
+			<entity BaseHP="30" ID="76" Image="Entities/76.0.0 - Blastocyst Small.png" Name="Blastocyst Small" Subtype="0" Variant="0" />
+			<entity BaseHP="75" ID="75" Image="Entities/75.0.0 - Blastocyst Medium.png" Name="Blastocyst Medium" Subtype="0" Variant="0" />
+			<entity BaseHP="190" ID="74" Image="Entities/74.0.0 - Blastocyst Big.png" Name="Blastocyst Big" Subtype="0" Variant="0" />
+		</group>
+		<entity BaseHP="750" ID="266" Image="Entities/266.0.0 - Mama Gurdy.png" Name="Mama Gurdy" Subtype="0" Variant="0" />
+		<entity BaseHP="500" ID="270" Image="Entities/270.0.0 - Mr. Fred.png" Name="Mr. Fred" Subtype="0" Variant="0" />
+	</group>
+
+	<group Name="Utero Bosses">
+		<group Name="Teratoma (Boss)">
+			<entity BaseHP="8" ID="73" Image="Entities/73.1.0 - Teratoma Small.png" Name="Teratoma Small" Subtype="0" Variant="1" />
+			<entity BaseHP="15" ID="72" Image="Entities/72.1.0 - Teratoma Medium.png" Name="Teratoma Medium" Subtype="0" Variant="1" />
+			<entity BaseHP="60" ID="71" Image="Entities/71.1.0 - Teratoma Big.png" Name="Teratoma Big" Subtype="0" Variant="1" />
+		</group>
+		<entity BaseHP="300" ID="101" Image="Entities/101.0.0 - Daddy Long Legs.png" Name="Daddy Long Legs" Subtype="0" Variant="0" />
+		<entity BaseHP="300" ID="101" Image="Entities/101.1.0 - Triachnid.png" Name="Triachnid" Subtype="0" Variant="1" />
+		<entity Name="The Bloat"/>
+	</group>
+
+	<group Name="The Sins">
+		<entity BaseHP="60" ID="46" Image="Entities/46.0.0 - Sloth.png" Name="Sloth" Subtype="0" Variant="0" />
+		<entity BaseHP="60" ID="46" Image="Entities/46.1.0 - Super Sloth.png" Name="Super Sloth" Subtype="0" Variant="1" />
+		<entity BaseHP="60" ID="47" Image="Entities/47.0.0 - Lust.png" Name="Lust" Subtype="0" Variant="0" />
+		<entity BaseHP="60" ID="47" Image="Entities/47.1.0 - Super Lust.png" Name="Super Lust" Subtype="0" Variant="1" />
+		<entity BaseHP="60" ID="48" Image="Entities/48.0.0 - Wrath.png" Name="Wrath" Subtype="0" Variant="0" />
+		<entity BaseHP="60" ID="48" Image="Entities/48.1.0 - Super Wrath.png" Name="Super Wrath" Subtype="0" Variant="1" />
+		<entity BaseHP="60" ID="49" Image="Entities/49.0.0 - Gluttony.png" Name="Gluttony" Subtype="0" Variant="0" />
+		<entity BaseHP="60" ID="49" Image="Entities/49.1.0 - Super Gluttony.png" Name="Super Gluttony" Subtype="0" Variant="1" />
+		<entity BaseHP="60" ID="50" Image="Entities/50.0.0 - Greed.png" Name="Greed" Subtype="0" Variant="0" />
+		<entity BaseHP="60" ID="50" Image="Entities/50.1.0 - Super Greed.png" Name="Super Greed" Subtype="0" Variant="1" />
+		<entity BaseHP="60" ID="51" Image="Entities/51.0.0 - Envy.png" Name="Envy" Subtype="0" Variant="0" />
+		<entity BaseHP="60" ID="51" Image="Entities/51.10.0 - Envy (1-2).png" Name="Envy (1/2)" Subtype="0" Variant="10" />
+		<entity BaseHP="60" ID="51" Image="Entities/51.20.0 - Envy (1-4).png" Name="Envy (1/4)" Subtype="0" Variant="20" />
+		<entity BaseHP="60" ID="51" Image="Entities/51.30.0 - Envy (1-8).png" Name="Envy (1/8)" Subtype="0" Variant="30" />
+		<entity BaseHP="60" ID="51" Image="Entities/51.1.0 - Super Envy.png" Name="Super Envy" Subtype="0" Variant="1" />
+		<entity BaseHP="60" ID="51" Image="Entities/51.11.0 - Super Envy (1-2).png" Name="Super Envy (1/2)" Subtype="0" Variant="11" />
+		<entity BaseHP="60" ID="51" Image="Entities/51.21.0 - Super Envy (1-4).png" Name="Super Envy (1/4)" Subtype="0" Variant="21" />
+		<entity BaseHP="60" ID="51" Image="Entities/51.31.0 - Super Envy (1-8).png" Name="Super Envy (1/8)" Subtype="0" Variant="31" />
+		<entity BaseHP="60" ID="52" Image="Entities/52.0.0 - Pride.png" Name="Pride" Subtype="0" Variant="0" />
+		<entity BaseHP="60" ID="52" Image="Entities/52.1.0 - Super Pride.png" Name="Super Pride" Subtype="0" Variant="1" />
+		<entity BaseHP="60" ID="46" Image="Entities/46.2.0 - Ultra Pride.png" Name="Ultra Pride" Subtype="0" Variant="2" />
+		<entity BaseHP="25" ID="38" Image="Entities/38.2.0 - Ultra Pride Baby.png" Name="Ultra Pride Baby" Subtype="0" Variant="2" />
+	</group>
+
+	<group Name="Common Bosses">
+		<entity BaseHP="60" ID="82" Image="Entities/82.0.0 - Headless Horseman Body.png" PlaceVisual="0.5,0" Name="Headless Horseman Body" Subtype="0" Variant="0" />
+		<entity BaseHP="100" ID="83" Image="Entities/83.0.0 - Headless Horsemans Head.png" Name="Headless Horsemans Head" Subtype="0" Variant="0" />
+		<entity BaseHP="60" ID="81" Image="Entities/81.1.0 - Krampus.png" Name="Krampus" Subtype="0" Variant="1" />
+		<entity BaseHP="60" ID="81" Image="Entities/81.0.0 - The Fallen.png" Name="The Fallen" Subtype="0" Variant="0" />
+		<entity ID="271" Image="Entities/271.0.0 - Uriel.png" Name="Uriel" Subtype="0" Variant="0" />
+		<entity ID="271" Image="Entities/271.0.1 - Fallen Uriel.png" Name="Fallen Uriel" Subtype="0" Variant="1" />
+		<entity ID="272" Image="Entities/272.0.0 - Gabriel.png" Name="Gabriel" Subtype="0" Variant="0" />
+		<entity ID="272" Image="Entities/272.0.1 - Fallen Gabriel.png" Name="Fallen Gabriel" Subtype="0" Variant="1" />
+	</group>
+
+	<group Name="Story Bosses">
+		<entity BaseHP="645" ID="45" Image="Entities/45.0.0 - Mom.png" Name="Mom" Subtype="0" Variant="0" />
+		<entity BaseHP="950" ID="78" Image="Entities/78.0.0 - Mom's Heart.png" Name="Mom's Heart" Subtype="0" Variant="0" />
+		<entity BaseHP="950" ID="78" Image="Entities/78.1.0 - It Lives.png" Name="It Lives" Subtype="0" Variant="1" />
+		<entity BaseHP="2000" ID="102" Image="Entities/102.0.0 - Isaac (final boss).png" Name="Isaac (boss)" Subtype="0" Variant="0" />
+		<entity BaseHP="2000" ID="102" Image="Entities/102.1.0 - Blue Baby (final boss).png" Name="??? (boss)" Subtype="0" Variant="1" />
+		<entity BaseHP="600" ID="84" Image="Entities/84.0.0 - Satan.png" PlaceVisual="0,2" Name="Satan" Subtype="0" Variant="0" />
+		<entity BaseHP="600" ID="84" Image="Entities/84.10.0 - Satan Stomp.png" Name="Satan Phase 2 (Stomp)" Subtype="0" Variant="10" />
+		<entity BaseHP="2000" ID="273" Image="Entities/273.0.0 - The Lamb.png" Name="The Lamb" Subtype="0" Variant="0" />
+		<entity BaseHP="3000" ID="274" Image="Entities/274.0.0 - Mega Satan's Head.png" Name="Mega Satan's Head" Subtype="0" Variant="0" />
+		<entity BaseHP="600" ID="274" Image="Entities/274.1.0 - Mega Satan's Right Hand.png" Name="Mega Satan's Right Hand" Subtype="0" Variant="1" />
+		<entity BaseHP="600" ID="274" Image="Entities/274.2.0 - Mega Satan's Left Hand.png" Name="Mega Satan's Left Hand" Subtype="0" Variant="2" />
+	</group>
+
+	<!--——— Unused ———-->
+	<group Name="Unused">
+		<group Name="Unused Jokes" Label="Jokes"/>
+		<group Name="Unused Enemies" Label="Enemies"/>
+		<group Name="Unused Fireplaces" Label="Fireplaces"/>
+		<group Label="Live Bombs">
+			<entity ID="4" Image="Entities/4.0.0 - Bomb.png" Name="Active Bomb" Subtype="0" Variant="0" />
+			<entity ID="4" Image="Entities/4.0.1 - Big Bomb.png" Name="Big Bomb" Subtype="0" Variant="1" />
+			<entity ID="4" Image="Entities/4.0.2 - Decoy Bomb.png" Name="Decoy Bomb" Subtype="0" Variant="2" />
+			<entity ID="4" Image="Entities/4.0.3 - Troll Bomb.png" Name="Troll Bomb (player)" Subtype="0" Variant="3" />
+			<entity ID="4" Image="Entities/4.0.4 - Megatroll Bomb.png" Name="Megatroll Bomb (player)" Subtype="0" Variant="4" />
+			<entity ID="4" Image="Entities/4.0.5 - Poison Bomb.png" Name="Poison Bomb" Subtype="0" Variant="5" />
+			<entity ID="4" Image="Entities/4.0.6 - Big Poison Bomb.png" Name="Big Poison Bomb" Subtype="0" Variant="6" />
+			<entity ID="4" Image="Entities/4.0.7 - Sad Bomb.png" Name="Sad Bomb" Subtype="0" Variant="7" />
+			<entity ID="4" Image="Entities/4.0.8 - Fire Bomb.png" Name="Fire Bomb" Subtype="0" Variant="8" />
+			<entity ID="4" Image="Entities/4.0.9 - Butt Bomb.png" Name="Butt Bomb" Subtype="0" Variant="9" />
+			<entity ID="4" Image="Entities/4.0.10 - Mr Mega Bomb.png" Name="Mr Mega Bomb" Subtype="0" Variant="10" />
+			<entity ID="4" Image="Entities/4.0.11 - Bobby Bomb.png" Name="Bobby Bomb" Subtype="0" Variant="11" />
+		</group>
+		<group Label="Player Tears">
+			<entity ID="2" Image="Entities/2.0.0 - Tear.png" Name="Tear" Subtype="0" Variant="0" />
+			<entity ID="2" Image="Entities/2.1.0 - Blood Tear.png" Name="Blood Tear" Subtype="0" Variant="1" />
+			<entity ID="2" Image="Entities/2.2.0 - Tooth Tear.png" Name="Tooth Tear" Subtype="0" Variant="2" />
+			<entity ID="2" Image="Entities/2.3.0 - Metallic Tear.png" Name="Metallic Tear" Subtype="0" Variant="3" />
+			<entity ID="2" Image="Entities/2.4.0 - Bob's Tear.png" Name="Bob's Tear" Subtype="0" Variant="4" />
+			<entity ID="2" Image="Entities/2.5.0 - Fire Tear.png" Name="Fire Tear" Subtype="0" Variant="5" />
+			<entity ID="2" Image="Entities/2.6.0 - Dark Matter Tear.png" Name="Dark Matter Tear" Subtype="0" Variant="6" />
+			<entity ID="2" Image="Entities/2.7.0 - Mysterious Tear.png" Name="Mysterious Tear" Subtype="0" Variant="7" />
+			<entity ID="2" Image="Entities/2.8.0 - Scythe Tear.png" Name="Scythe Tear" Subtype="0" Variant="8" />
+			<entity ID="2" Image="Entities/2.9.0 - Chaos Tear.png" Name="Chaos Tear" Subtype="0" Variant="9" />
+			<entity ID="2" Image="Entities/2.10.0 - Shield Tear.png" Name="Shield Tear" Subtype="0" Variant="10" />
+			<entity ID="2" Image="Entities/2.11.0 - Cupid Tear.png" Name="Cupid Tear" Subtype="0" Variant="11" />
+		</group>
+		<group Label="Enemy Tears">
+			<entity ID="9" Image="Entities/9.0.0 - Enemy Tear.png" Name="Enemy Tear" Subtype="0" Variant="0" />
+			<entity ID="9" Image="Entities/9.0.1 - Bone.png" Name="Bone" Subtype="0" Variant="1" />
+			<entity ID="9" Image="Entities/9.0.2 - Fire.png" Name="Fire" Subtype="0" Variant="2" />
+			<entity ID="9" Image="Entities/9.0.3 - Puke.png" Name="Puke" Subtype="0" Variant="3" />
+		</group>
+		<group Name="Unused Miscellaneous" Label="Miscellaneous">
+			<entity Image="Entities/216.1.0 - Swinger Head.png" ID="216" Variant="1" Name="Swinger Head" BaseHP="38" />
+			<entity Image="Entities/216.10.0 - Swinger Neck.png" ID="216" Variant="10" Name="Swinger Neck" BaseHP="25" />
+			<entity BaseHP="140" ID="79" Image="Entities/79.20.0 - Umbilical Cord.png" Name="Umbilical Cord" Variant="20" />
+			<entity BaseHP="60" ID="251" Image="Entities/251.10.0 - Begotten Chain.png" Name="Begotten Chain" Subtype="0" Variant="10" />
+			<entity Image="Entities/1500.0.0 - Poop.png" Name="Pushable Poop" ID="245" Subtype="0" Variant="0" />
+		</group>
+		<group Label="Broken">
+			<entity ID="1" Image="Entities/1.0.0 - Player.png" Name="Player (crashes)" Subtype="0" Variant="0" />
+			<entity ID="3" Image="Entities/3.0.0 - Familiar.png" Name="Familiar (No Effect)" Subtype="0" Variant="0" />
+			<entity ID="7" Image="Entities/7.0.0 - Laser.png" Name="Laser (crashes)" Subtype="0" Variant="0" />
+			<entity ID="8" Image="Entities/8.0.0 - Knife.png" Name="Knife" Subtype="0" Variant="0" />
+		</group>
+	</group>
 </data>

--- a/resources/EntitiesRepentance.xml
+++ b/resources/EntitiesRepentance.xml
@@ -1,2447 +1,1172 @@
 <data>
+	<!--——— Sorting Tags ———-->
+	<tag Label="Numbered Events" StatisticsGroup="1">NumberedEvents</tag>
+	<tag Label="Event Plates" StatisticsGroup="1">EventPlates</tag>
+	<tag Label="Deep Gapers" StatisticsGroup="1">DeepGapers</tag>
+	<tag Label="Water Flows" StatisticsGroup="1">WaterFlows</tag>
+	<tag Label="Quake Grimaces" StatisticsGroup="1">QuakeGrimaces</tag>
+	<tag Label="Rails" StatisticsGroup="1">Rails</tag>
+	<tag Label="Dragon Flies" StatisticsGroup="1">DragonFlies</tag>
+	<tag Label="Rock Spiders" StatisticsGroup="1">RockSpiders</tag>
+	<tag Label="Tinted Rock Spiders" StatisticsGroup="1">TintedRockSpiders</tag>
+	<tag Label="Coal Spiders" StatisticsGroup="1">CoalSpiders</tag>
+	<tag Label="Coals" StatisticsGroup="1">Coals</tag>
+	<tag Label="Dusty Death's Heads" StatisticsGroup="1">DustyDeathsHeads</tag>
+	<tag Label="Slogs" StatisticsGroup="1">Slogs</tag>
+	<tag Label="Teleporters" StatisticsGroup="1">Teleporters</tag>
+	<tag Label="1/2 Hearts" StatisticsGroup="1">HalfHeartEnemy</tag>
+	<tag Label="Spikeballs" StatisticsGroup="1">Spikeballs</tag>
+	<tag Label="Rotten Gapers" StatisticsGroup="1">RottenGapers</tag>
+	<tag Label="Cysts" StatisticsGroup="1">Cysts</tag>
+	<tag Label="Small Maggots" StatisticsGroup="1">SmallMaggots</tag>
+
 	<!--——— Pickups ———-->
+	<!-- Overwrite old Lil' Battery and Grab Bag definitions -->
+	<entity ID="5" Image="Entities/5.90.0 - RBattery.png" Name="Random Battery" Subtype="0" Variant="90" Overwrite="1"/>
 
-	<!-- Random -->
-	<entity Group=" Random" ID="5" Image="resources/Entities/5.0.0 - Pickup.png" Kind="Pickups" Name="Pickup" Subtype="0" Variant="0" />
-	<entity Group=" Random" ID="5" Image="resources/Entities/5.0.1 - Pickup.png" Kind="Pickups" Name="Pickup (not chest or item)" Subtype="0" Variant="1" />
-	<entity Group=" Random" ID="5" Image="resources/Entities/5.0.2 - Pickup.png" Kind="Pickups" Name="Pickup (not item)" Subtype="0" Variant="2" />
-	<entity Group=" Random" ID="5" Image="resources/Entities/5.0.3 - Pickup.png" Kind="Pickups" Name="Greed Pickup (no chest, item, or coin)" Subtype="0" Variant="3" />
-	<entity Group=" Random" ID="5" Image="resources/Entities/5.0.4 - Pickup.png" Kind="Pickups" Name="Pickup (no chest, item, or trinket)" Subtype="0" Variant="4" />
-	<entity Group=" Random" ID="5" Image="resources/Entities/5.10.0 - RHeart.png" Kind="Pickups" Name="Random Heart" Subtype="0" Variant="10" />
-	<entity Group=" Random" ID="5" Image="resources/Entities/5.20.0 - RCoin.png" Kind="Pickups" Name="Random Coin" Subtype="0" Variant="20" />
-	<entity Group=" Random" ID="5" Image="resources/Entities/5.30.0 - RKey.png" Kind="Pickups" Name="Random Key" Subtype="0" Variant="30" />
-	<entity Group=" Random" ID="5" Image="resources/Entities/5.40.0 - RBomb.png" Kind="Pickups" Name="Random Bomb" Subtype="0" Variant="40" />
-	<entity Group=" Random" ID="5" Image="resources/Entities/5.70.0 - Random Pill.png" Kind="Pickups" Name="Random Pill" Subtype="0" Variant="70" />
-	<entity Group=" Random" ID="5" Image="resources/Entities/5.301.0 - Random Rune.png" Kind="Pickups" Name="Random Rune" Subtype="0" Variant="301" />
-	<entity Group=" Random" ID="5" Image="resources/Entities/5.300.0 - Random Card.png" Kind="Pickups" Name="Random Card" Subtype="0" Variant="300" />
-	<entity Group=" Random" ID="5" Image="resources/Entities/5.350.0 - Trinket.png" Kind="Pickups" Name="Random Trinket" Subtype="0" Variant="350" />
-	<entity Group=" Random" ID="5" Image="resources/Entities/5.90.0 - RBattery.png" Kind="Pickups" Name="Random Battery" Subtype="0" Variant="90" />
-	<entity Group=" Random" ID="5" Image="resources/Entities/5.69.0 - RGrab Bag.png" Kind="Pickups" Name="Random Grab Bag" Subtype="0" Variant="69" />
+	<group Name="(Pickups) Random">
+		<entity ID="5" Image="Entities/5.69.0 - RGrab Bag.png" Name="Random Grab Bag" Subtype="0" Variant="69" Overwrite="1"/>
+	</group>
 
-	<!-- Bombs -->
-	<entity Group="Bombs" ID="5" Image="resources/Entities/5.40.0 - RBomb.png" Kind="Pickups" Name="Random Bomb" Subtype="0" Variant="40" />
-	<entity Group="Bombs" ID="5" Image="resources/Entities/5.40.1 - Bomb.png" Kind="Pickups" Name="Bomb" Subtype="1" Variant="40" />
-	<entity Group="Bombs" ID="5" Image="resources/Entities/5.40.2 - Double Bomb.png" Kind="Pickups" Name="Double Bomb" Subtype="2" Variant="40" />
-	<entity Group="Bombs" ID="5" Image="resources/Entities/5.40.4 - Golden Bomb.png" Kind="Pickups" Name="Golden Bomb" Subtype="4" Variant="40" />
-	<entity Group="Bombs" ID="5" Image="resources/Entities/5.40.7 - Giga Bomb.png" Kind="Pickups" Name="Giga Bomb" Variant="40" Subtype="7" />
-	<entity Group="Bombs" ID="5" Image="resources/Entities/5.41.0 - Throwable Bomb (pickup).png" Kind="Pickups" Name="Throwable Bomb (pickup)" Variant="41" Subtype="0" />
-	<entity Group="Bombs" ID="5" Image="resources/Entities/5.42.0 - Poop Nugget.png" Kind="Pickups" Name="Poop Nugget" Variant="42" Subtype="0" />
-	<entity Group="Bombs" ID="5" Image="resources/Entities/5.42.1 - Big Poop Nugget.png" Kind="Pickups" Name="Big Poop Nugget" Variant="42" Subtype="1" />
+	<group Name="Hearts">
+		<entity ID="5" Image="Entities/5.10.12 - Rotten Heart.png" Name="Heart (rotten)" Subtype="12" Variant="10"/>
+	</group>
 
-	<!-- Cards -->
-	<entity Group="Cards" ID="5" Image="resources/Entities/5.300.0 - Random Card.png" Kind="Pickups" Name="Random Card" Subtype="0" Variant="300" />
-	<entity Group="Cards" ID="5" Image="resources/Entities/5.300.1 - The Fool.png" Kind="Pickups" Name="The Fool" Subtype="1" Variant="300" />
-	<entity Group="Cards" ID="5" Image="resources/Entities/5.300.2 - The Magician.png" Kind="Pickups" Name="The Magician" Subtype="2" Variant="300" />
-	<entity Group="Cards" ID="5" Image="resources/Entities/5.300.3 - The High Priestess.png" Kind="Pickups" Name="The High Priestess" Subtype="3" Variant="300" />
-	<entity Group="Cards" ID="5" Image="resources/Entities/5.300.4 - The Empress.png" Kind="Pickups" Name="The Empress" Subtype="4" Variant="300" />
-	<entity Group="Cards" ID="5" Image="resources/Entities/5.300.5 - The Emperor.png" Kind="Pickups" Name="The Emperor" Subtype="5" Variant="300" />
-	<entity Group="Cards" ID="5" Image="resources/Entities/5.300.6 - The Hierophant.png" Kind="Pickups" Name="The Hierophant" Subtype="6" Variant="300" />
-	<entity Group="Cards" ID="5" Image="resources/Entities/5.300.7 - The Lovers.png" Kind="Pickups" Name="The Lovers" Subtype="7" Variant="300" />
-	<entity Group="Cards" ID="5" Image="resources/Entities/5.300.8 - The Chariot.png" Kind="Pickups" Name="The Chariot" Subtype="8" Variant="300" />
-	<entity Group="Cards" ID="5" Image="resources/Entities/5.300.9 - Justice.png" Kind="Pickups" Name="Justice" Subtype="9" Variant="300" />
-	<entity Group="Cards" ID="5" Image="resources/Entities/5.300.10 - The Hermit.png" Kind="Pickups" Name="The Hermit" Subtype="10" Variant="300" />
-	<entity Group="Cards" ID="5" Image="resources/Entities/5.300.11 - Wheel of Fortune.png" Kind="Pickups" Name="Wheel of Fortune" Subtype="11" Variant="300" />
-	<entity Group="Cards" ID="5" Image="resources/Entities/5.300.12 - Strength.png" Kind="Pickups" Name="Strength" Subtype="12" Variant="300" />
-	<entity Group="Cards" ID="5" Image="resources/Entities/5.300.13 - The Hanged Man.png" Kind="Pickups" Name="The Hanged Man" Subtype="13" Variant="300" />
-	<entity Group="Cards" ID="5" Image="resources/Entities/5.300.14 - Death.png" Kind="Pickups" Name="Death" Subtype="14" Variant="300" />
-	<entity Group="Cards" ID="5" Image="resources/Entities/5.300.15 - Temperance.png" Kind="Pickups" Name="Temperance" Subtype="15" Variant="300" />
-	<entity Group="Cards" ID="5" Image="resources/Entities/5.300.16 - The Devil.png" Kind="Pickups" Name="The Devil" Subtype="16" Variant="300" />
-	<entity Group="Cards" ID="5" Image="resources/Entities/5.300.17 - The Tower.png" Kind="Pickups" Name="The Tower" Subtype="17" Variant="300" />
-	<entity Group="Cards" ID="5" Image="resources/Entities/5.300.18 - The Stars.png" Kind="Pickups" Name="The Stars" Subtype="18" Variant="300" />
-	<entity Group="Cards" ID="5" Image="resources/Entities/5.300.19 - The Moon.png" Kind="Pickups" Name="The Moon" Subtype="19" Variant="300" />
-	<entity Group="Cards" ID="5" Image="resources/Entities/5.300.20 - The Sun.png" Kind="Pickups" Name="The Sun" Subtype="20" Variant="300" />
-	<entity Group="Cards" ID="5" Image="resources/Entities/5.300.21 - Judgement.png" Kind="Pickups" Name="Judgement" Subtype="21" Variant="300" />
-	<entity Group="Cards" ID="5" Image="resources/Entities/5.300.22 - The World.png" Kind="Pickups" Name="The World" Subtype="22" Variant="300" />
-	<entity Group="Cards" ID="5" Image="resources/Entities/5.300.23 - 2 of Clubs.png" Kind="Pickups" Name="2 of Clubs" Subtype="23" Variant="300" />
-	<entity Group="Cards" ID="5" Image="resources/Entities/5.300.24 - 2 of Diamonds.png" Kind="Pickups" Name="2 of Diamonds" Subtype="24" Variant="300" />
-	<entity Group="Cards" ID="5" Image="resources/Entities/5.300.25 - 2 of Spades.png" Kind="Pickups" Name="2 of Spades" Subtype="25" Variant="300" />
-	<entity Group="Cards" ID="5" Image="resources/Entities/5.300.26 - 2 of Hearts.png" Kind="Pickups" Name="2 of Hearts" Subtype="26" Variant="300" />
-	<entity Group="Cards" ID="5" Image="resources/Entities/5.300.27 - Ace of Clubs.png" Kind="Pickups" Name="Ace of Clubs" Subtype="27" Variant="300" />
-	<entity Group="Cards" ID="5" Image="resources/Entities/5.300.28 - Ace of Diamonds.png" Kind="Pickups" Name="Ace of Diamonds" Subtype="28" Variant="300" />
-	<entity Group="Cards" ID="5" Image="resources/Entities/5.300.29 - Ace of Spades.png" Kind="Pickups" Name="Ace of Spades" Subtype="29" Variant="300" />
-	<entity Group="Cards" ID="5" Image="resources/Entities/5.300.30 - Ace of Hearts.png" Kind="Pickups" Name="Ace of Hearts" Subtype="30" Variant="300" />
-	<entity Group="Cards" ID="5" Image="resources/Entities/5.300.31 - Joker.png" Kind="Pickups" Name="Joker" Subtype="31" Variant="300" />
-	<entity Group="Cards" ID="5" Image="resources/Entities/5.300.42 - Chaos Card.png" Kind="Pickups" Name="Chaos Card" Subtype="42" Variant="300" />
-	<entity Group="Cards" ID="5" Image="resources/Entities/5.300.43 - Credit Card.png" Kind="Pickups" Name="Credit Card" Subtype="43" Variant="300" />
-	<entity Group="Cards" ID="5" Image="resources/Entities/5.300.44 - Rules Card.png" Kind="Pickups" Name="Rules Card" Subtype="44" Variant="300" />
-	<entity Group="Cards" ID="5" Image="resources/Entities/5.300.45 - A Card Against Humanity.png" Kind="Pickups" Name="A Card Against Humanity" Subtype="45" Variant="300" />
-	<entity Group="Cards" ID="5" Image="resources/Entities/5.300.46 - Suicide King.png" Kind="Pickups" Name="Suicide King" Subtype="46" Variant="300" />
-	<entity Group="Cards" ID="5" Image="resources/Entities/5.300.47 - Get Out of Jail Free Card.png" Kind="Pickups" Name="Get Out of Jail Free Card" Subtype="47" Variant="300" />
-	<entity Group="Cards" ID="5" Image="resources/Entities/5.300.48 - Question Card.png" Kind="Pickups" Name="? Card" Subtype="48" Variant="300" />
-	<entity Group="Cards" ID="5" Image="resources/Entities/5.300.49 - Dice Shard.png" Kind="Pickups" Name="Dice Shard" Subtype="49" Variant="300" />
-	<entity Group="Cards" ID="5" Image="resources/Entities/5.300.50 - Emergency Contact.png" Kind="Pickups" Name="Emergency Contact" Subtype="50" Variant="300" />
-	<entity Group="Cards" ID="5" Image="resources/Entities/5.300.51 - Holy Card.png" Kind="Pickups" Name="Holy Card" Subtype="51" Variant="300" />
-	<entity Group="Cards" ID="5" Image="resources/Entities/5.300.52 - Huge Growth.png" Kind="Pickups" Name="Huge Growth" Subtype="52" Variant="300" />
-	<entity Group="Cards" ID="5" Image="resources/Entities/5.300.53 - Ancient Recall.png" Kind="Pickups" Name="Ancient Recall" Subtype="53" Variant="300" />
-	<entity Group="Cards" ID="5" Image="resources/Entities/5.300.54 - Era Walk.png" Kind="Pickups" Name="Era Walk" Subtype="54" Variant="300" />
-	<entity Group="Cards" ID="5" Image="resources/Entities/5.300.56 - The Fool (Reverse).png" Kind="Pickups" Name="The Fool?" Subtype="56" Variant="300" />
-	<entity Group="Cards" ID="5" Image="resources/Entities/5.300.57 - The Magician (Reverse).png" Kind="Pickups" Name="Magician?" Subtype="57" Variant="300" />
-	<entity Group="Cards" ID="5" Image="resources/Entities/5.300.58 - The High Priestess (Reverse).png" Kind="Pickups" Name="The High Priestess?" Subtype="58" Variant="300" />
-	<entity Group="Cards" ID="5" Image="resources/Entities/5.300.59 - The Empress (Reverse).png" Kind="Pickups" Name="The Empress?" Subtype="59" Variant="300" />
-	<entity Group="Cards" ID="5" Image="resources/Entities/5.300.60 - The Emperor (Reverse).png" Kind="Pickups" Name="The Emperor?" Subtype="60" Variant="300" />
-	<entity Group="Cards" ID="5" Image="resources/Entities/5.300.61 - The Hierophant (Reverse).png" Kind="Pickups" Name="The Hierophant?" Subtype="61" Variant="300" />
-	<entity Group="Cards" ID="5" Image="resources/Entities/5.300.62 - The Lovers (Reverse).png" Kind="Pickups" Name="The Lovers?" Subtype="62" Variant="300" />
-	<entity Group="Cards" ID="5" Image="resources/Entities/5.300.63 - The Chariot (Reverse).png" Kind="Pickups" Name="The Chariot?" Subtype="63" Variant="300" />
-	<entity Group="Cards" ID="5" Image="resources/Entities/5.300.64 - Justice (Reverse).png" Kind="Pickups" Name="Justice?" Subtype="64" Variant="300" />
-	<entity Group="Cards" ID="5" Image="resources/Entities/5.300.65 - The Hermit (Reverse).png" Kind="Pickups" Name="The Hermit?" Subtype="65" Variant="300" />
-	<entity Group="Cards" ID="5" Image="resources/Entities/5.300.66 - Wheel of Fortune (Reverse).png" Kind="Pickups" Name="Wheel of Fortune?" Subtype="66" Variant="300" />
-	<entity Group="Cards" ID="5" Image="resources/Entities/5.300.67 - Strength (Reverse).png" Kind="Pickups" Name="Strength?" Subtype="67" Variant="300" />
-	<entity Group="Cards" ID="5" Image="resources/Entities/5.300.68 - The Hanged Man (Reverse).png" Kind="Pickups" Name="The Hanged Man?" Subtype="68" Variant="300" />
-	<entity Group="Cards" ID="5" Image="resources/Entities/5.300.69 - Death (Reverse).png" Kind="Pickups" Name="Death?" Subtype="69" Variant="300" />
-	<entity Group="Cards" ID="5" Image="resources/Entities/5.300.70 - Temperance (Reverse).png" Kind="Pickups" Name="Temperance?" Subtype="70" Variant="300" />
-	<entity Group="Cards" ID="5" Image="resources/Entities/5.300.71 - The Devil (Reverse).png" Kind="Pickups" Name="The Devil?" Subtype="71" Variant="300" />
-	<entity Group="Cards" ID="5" Image="resources/Entities/5.300.72 - The Tower (Reverse).png" Kind="Pickups" Name="The Tower?" Subtype="72" Variant="300" />
-	<entity Group="Cards" ID="5" Image="resources/Entities/5.300.73 - The Stars (Reverse).png" Kind="Pickups" Name="The Stars?" Subtype="73" Variant="300" />
-	<entity Group="Cards" ID="5" Image="resources/Entities/5.300.74 - The Moon (Reverse).png" Kind="Pickups" Name="The Moon?" Subtype="74" Variant="300" />
-	<entity Group="Cards" ID="5" Image="resources/Entities/5.300.75 - The Sun (Reverse).png" Kind="Pickups" Name="The Sun?" Subtype="75" Variant="300" />
-	<entity Group="Cards" ID="5" Image="resources/Entities/5.300.76 - Judgement (Reverse).png" Kind="Pickups" Name="Judgement?" Subtype="76" Variant="300" />
-	<entity Group="Cards" ID="5" Image="resources/Entities/5.300.77 - The World (Reverse).png" Kind="Pickups" Name="The World?" Subtype="77" Variant="300" />
-	<entity Group="Cards" ID="5" Image="resources/Entities/5.300.78 - Cracked Key.png" Kind="Pickups" Name="Cracked Key" Subtype="78" Variant="300" />
-	<entity Group="Cards" ID="5" Image="resources/Entities/5.300.79 - Queen of Hearts.png" Kind="Pickups" Name="Queen of Hearts" Subtype="79" Variant="300" />
-	<entity Group="Cards" ID="5" Image="resources/Entities/5.300.80 - Wild Card.png" Kind="Pickups" Name="Wild Card" Subtype="80" Variant="300" />
+	<group Name="Coins">
+		<entity ID="5" Image="Entities/5.20.7 - Golden Penny.png" Name="Golden Penny" Variant="20" Subtype="7"/>
+	</group>
 
-	<!-- Chests -->
-	<entity Group="Chests" ID="5" Image="resources/Entities/5.50.0 - Chest.png" Kind="Pickups" Name="Chest" Subtype="0" Variant="50" />
-	<entity Group="Chests" ID="5" Image="resources/Entities/5.60.0 - Locked Chest.png" Kind="Pickups" Name="Locked Chest" Subtype="0" Variant="60" />
-	<entity Group="Chests" ID="5" Image="resources/Entities/5.360.0 - Red Chest.png" Kind="Pickups" Name="Red Chest" Subtype="0" Variant="360" />
-	<entity Group="Chests" ID="5" Image="resources/Entities/5.51.0 - Bomb Chest.png" Kind="Pickups" Name="Bomb Chest" Subtype="0" Variant="51" />
-	<entity Group="Chests" ID="5" Image="resources/Entities/5.53.0 - Eternal Chest.png" Kind="Pickups" Name="Eternal Chest" Subtype="0" Variant="53" />
-	<entity Group="Chests" ID="5" Image="resources/Entities/5.52.0 - Spiked Chest.png" Kind="Pickups" Name="Spiked Chest" Subtype="0" Variant="52" />
-	<entity Group="Chests" ID="5" Image="resources/Entities/5.54.0 - Mimic Chest.png" Kind="Pickups" Name="Mimic Chest" Subtype="0" Variant="54" />
-	<entity Group="Chests" ID="5" Image="resources/Entities/5.55.0 - Old Chest.png" Kind="Pickups" Name="Old Chest" Variant="55" Subtype="0" />
-	<entity Group="Chests" ID="5" Image="resources/Entities/5.56.0 - Wooden Chest.png" Kind="Pickups" Name="Wooden Chest" Variant="56" Subtype="0" />
-	<entity Group="Chests" ID="5" Image="resources/Entities/5.57.0 - Mega Chest.png" Kind="Pickups" Name="Mega Chest" Variant="57" Subtype="0" />
-	<entity Group="Chests" ID="5" Image="resources/Entities/5.58.0 - Haunted Chest.png" Kind="Pickups" Name="Haunted Chest" Variant="58" Subtype="0" />
-	<entity Group="Chests" ID="5" Image="resources/Entities/5.69.1 - Grab Bag.png" Kind="Pickups" Name="Grab Bag" Variant="69" Subtype="1" />
-	<entity Group="Chests" ID="5" Image="resources/Entities/5.69.2 - Black Sack.png" Kind="Pickups" Name="Black Sack" Variant="69" Subtype="2" />
+	<group Name="Bombs">
+		<entity ID="5" Image="Entities/5.40.7 - Giga Bomb.png" Name="Giga Bomb" Variant="40" Subtype="7"/>
+		<entity ID="5" Image="Entities/5.41.0 - Throwable Bomb (pickup).png" Name="Throwable Bomb (pickup)" Variant="41" Subtype="0"/>
+		<entity ID="5" Image="Entities/5.42.0 - Poop Nugget.png" Name="Poop Nugget" Variant="42" Subtype="0"/>
+		<entity ID="5" Image="Entities/5.42.1 - Big Poop Nugget.png" Name="Big Poop Nugget" Variant="42" Subtype="1"/>
+	</group>
 
-	<!-- Coins -->
-	<entity Group="Coins" ID="5" Image="resources/Entities/5.20.0 - RCoin.png" Kind="Pickups" Name="Random Coin" Subtype="0" Variant="20" />
-	<entity Group="Coins" ID="5" Image="resources/Entities/5.20.1 - Penny.png" Kind="Pickups" Name="Penny" Subtype="1" Variant="20" />
-	<entity Group="Coins" ID="5" Image="resources/Entities/5.20.4 - Double Penny.png" Kind="Pickups" Name="Double Penny" Subtype="4" Variant="20" />
-	<entity Group="Coins" ID="5" Image="resources/Entities/5.20.2 - Nickel.png" Kind="Pickups" Name="Nickel" Subtype="2" Variant="20" />
-	<entity Group="Coins" ID="5" Image="resources/Entities/5.20.3 - Dime.png" Kind="Pickups" Name="Dime" Subtype="3" Variant="20" />
-	<entity Group="Coins" ID="5" Image="resources/Entities/5.20.5 - Lucky Penny.png" Kind="Pickups" Name="Lucky Penny" Subtype="5" Variant="20" />
-	<entity Group="Coins" ID="5" Image="resources/Entities/5.20.6 - Sticky Nickel.png" Kind="Pickups" Name="Sticky Nickel" Subtype="6" Variant="20" />
-	<entity Group="Coins" ID="5" Image="resources/Entities/5.20.7 - Golden Penny.png" Kind="Pickups" Name="Golden Penny" Variant="20" Subtype="7" />
+	<group Name="Batteries">
+		<entity Name="Random Battery"/>
+		<entity ID="5" Image="Entities/5.90.1 - Lil' Battery.png" Name="Lil' Battery" Variant="90" Subtype="1" />
+		<entity ID="5" Image="Entities/5.90.2 - Micro Battery.png" Name="Micro Battery" Variant="90" Subtype="2" />
+		<entity ID="5" Image="Entities/5.90.3 - Mega Battery.png" Name="Mega Battery" Variant="90" Subtype="3" />
+		<entity ID="5" Image="Entities/5.90.4 - Golden Battery.png" Name="Golden Battery" Variant="90" Subtype="4" />
+	</group>
 
-	<!-- Hearts -->
-	<entity Group="Hearts" ID="5" Image="resources/Entities/5.10.0 - RHeart.png" Kind="Pickups" Name="Random Heart" Subtype="0" Variant="10" />
-	<entity Group="Hearts" ID="5" Image="resources/Entities/5.10.1 - Heart.png" Kind="Pickups" Name="Heart" Subtype="1" Variant="10" />
-	<entity Group="Hearts" ID="5" Image="resources/Entities/5.10.2 - Heart (half).png" Kind="Pickups" Name="Heart (half)" Subtype="2" Variant="10" />
-	<entity Group="Hearts" ID="5" Image="resources/Entities/5.10.5 - Heart (double).png" Kind="Pickups" Name="Heart (double)" Subtype="5" Variant="10" />
-	<entity Group="Hearts" ID="5" Image="resources/Entities/5.10.9 - Scared Heart.png" Kind="Pickups" Name="Scared Heart" Subtype="9" Variant="10" />
-	<entity Group="Hearts" ID="5" Image="resources/Entities/5.10.3 - Heart (soul).png" Kind="Pickups" Name="Heart (soul)" Subtype="3" Variant="10" />
-	<entity Group="Hearts" ID="5" Image="resources/Entities/5.10.8 - Heart (halfsoul).png" Kind="Pickups" Name="Heart (half soul)" Subtype="8" Variant="10" />
-	<entity Group="Hearts" ID="5" Image="resources/Entities/5.10.10 - Blended Heart.png" Kind="Pickups" Name="Blended Heart" Subtype="10" Variant="10" />
-	<entity Group="Hearts" ID="5" Image="resources/Entities/5.10.6 - Black Heart.png" Kind="Pickups" Name="Black Heart" Subtype="6" Variant="10" />
-	<entity Group="Hearts" ID="5" Image="resources/Entities/5.10.4 - Heart (eternal).png" Kind="Pickups" Name="Heart (eternal)" Subtype="4" Variant="10" />
-	<entity Group="Hearts" ID="5" Image="resources/Entities/5.10.7 - Gold Heart.png" Kind="Pickups" Name="Gold Heart" Subtype="7" Variant="10" />
-	<entity Group="Hearts" ID="5" Image="resources/Entities/5.10.11 - Bone Heart.png" Kind="Pickups" Name="Bone Heart" Subtype="11" Variant="10" />
-	<entity Group="Hearts" ID="5" Image="resources/Entities/5.10.12 - Rotten Heart.png" Kind="Pickups" Name="Heart (rotten)" Subtype="12" Variant="10"/>
+	<group Name="Chests">
+		<entity ID="5" Image="Entities/5.55.0 - Old Chest.png" Name="Old Chest" Variant="55" Subtype="0"/>
+		<entity ID="5" Image="Entities/5.56.0 - Wooden Chest.png" Name="Wooden Chest" Variant="56" Subtype="0"/>
+		<entity ID="5" Image="Entities/5.57.0 - Mega Chest.png" Name="Mega Chest" Variant="57" Subtype="0"/>
+		<entity ID="5" Image="Entities/5.58.0 - Haunted Chest.png" Name="Haunted Chest" Variant="58" Subtype="0"/>
+	</group>
 
-	<!-- Keys -->
-	<entity Group="Keys" ID="5" Image="resources/Entities/5.30.0 - RKey.png" Kind="Pickups" Name="Random Key" Subtype="0" Variant="30" />
-	<entity Group="Keys" ID="5" Image="resources/Entities/5.30.1 - Key.png" Kind="Pickups" Name="Key" Subtype="1" Variant="30" />
-	<entity Group="Keys" ID="5" Image="resources/Entities/5.30.3 - Key Ring.png" Kind="Pickups" Name="Key Ring" Subtype="3" Variant="30" />
-	<entity Group="Keys" ID="5" Image="resources/Entities/5.30.2 - Golden Key.png" Kind="Pickups" Name="Golden Key" Subtype="2" Variant="30" />
-	<entity Group="Keys" ID="5" Image="resources/Entities/5.30.4 - Charged Key.png" Kind="Pickups" Name="Charged Key" Subtype="4" Variant="30" />
+	<group Name="Grab Bags">
+		<entity ID="5" Image="Entities/5.69.1 - Grab Bag.png" Name="Grab Bag" Variant="69" Subtype="1"/>
+		<entity ID="5" Image="Entities/5.69.2 - Black Sack.png" Name="Black Sack" Variant="69" Subtype="2"/>
+	</group>
 
-	<!-- Pills -->
-	<entity Group="Pills" ID="5" Image="resources/Entities/5.70.0 - Random Pill.png" Kind="Pickups" Name="Random Pill" Subtype="0" Variant="70" />
-	<entity Group="Pills" ID="5" Image="resources/Entities/5.70.1 - Blue Pill.png" Kind="Pickups" Name="Blue Pill" Subtype="1" Variant="70" />
-	<entity Group="Pills" ID="5" Image="resources/Entities/5.70.2 - White-Blue Pill.png" Kind="Pickups" Name="White-Blue Pill" Subtype="2" Variant="70" />
-	<entity Group="Pills" ID="5" Image="resources/Entities/5.70.3 - Orange Pill.png" Kind="Pickups" Name="Orange Pill" Subtype="3" Variant="70" />
-	<entity Group="Pills" ID="5" Image="resources/Entities/5.70.4 - White Pill.png" Kind="Pickups" Name="White Pill" Subtype="4" Variant="70" />
-	<entity Group="Pills" ID="5" Image="resources/Entities/5.70.5 - Dots-Red Pill.png" Kind="Pickups" Name="Dots-Red Pill" Subtype="5" Variant="70" />
-	<entity Group="Pills" ID="5" Image="resources/Entities/5.70.6 - Pink-Red Pill.png" Kind="Pickups" Name="Pink-Red Pill" Subtype="6" Variant="70" />
-	<entity Group="Pills" ID="5" Image="resources/Entities/5.70.7 - Blue-Cadetblue Pill.png" Kind="Pickups" Name="Blue-Cadetblue Pill" Subtype="7" Variant="70" />
-	<entity Group="Pills" ID="5" Image="resources/Entities/5.70.8 - Yellow-Orange Pill.png" Kind="Pickups" Name="Yellow-Orange Pill" Subtype="8" Variant="70" />
-	<entity Group="Pills" ID="5" Image="resources/Entities/5.70.9 - Dots-White Pill.png" Kind="Pickups" Name="Dots-White Pill" Subtype="9" Variant="70" />
-	<entity Group="Pills" ID="5" Image="resources/Entities/5.70.10 - White-Azure Pill.png" Kind="Pickups" Name="White-Azure Pill" Subtype="10" Variant="70" />
-	<entity Group="Pills" ID="5" Image="resources/Entities/5.70.11 - Black-Yellow Pill.png" Kind="Pickups" Name="Black-Yellow Pill" Subtype="11" Variant="70" />
-	<entity Group="Pills" ID="5" Image="resources/Entities/5.70.12 - White-Black Pill.png" Kind="Pickups" Name="White-Black Pill" Subtype="12" Variant="70" />
-	<entity Group="Pills" ID="5" Image="resources/Entities/5.70.13 - White-Yellow Pill.png" Kind="Pickups" Name="White-Yellow Pill" Subtype="13" Variant="70" />
-	<entity Group="Pills" ID="5" Image="resources/Entities/5.70.14 - Pill Gold-Gold.png" Kind="Pickups" Name="Pill Gold-Gold" Variant="70" Subtype="14" />
-	<entity Group="Pills" ID="5" Image="resources/Entities/5.70.2049 - Horse Pill Blue-Blue.png" Kind="Pickups" Name="Horse Pill Blue-Blue" Variant="70" Subtype="2049" />
-	<entity Group="Pills" ID="5" Image="resources/Entities/5.70.2050 - Horse Pill White-Blue.png" Kind="Pickups" Name="Horse Pill White-Blue" Variant="70" Subtype="2050" />
-	<entity Group="Pills" ID="5" Image="resources/Entities/5.70.2051 - Horse Pill Orange-Orange.png" Kind="Pickups" Name="Horse Pill Orange-Orange" Variant="70" Subtype="2051" />
-	<entity Group="Pills" ID="5" Image="resources/Entities/5.70.2052 - Horse Pill White-White.png" Kind="Pickups" Name="Horse Pill White-White" Variant="70" Subtype="2052" />
-	<entity Group="Pills" ID="5" Image="resources/Entities/5.70.2053 - Horse Pill Dots-Red.png" Kind="Pickups" Name="Horse Pill Dots-Red" Variant="70" Subtype="2053" />
-	<entity Group="Pills" ID="5" Image="resources/Entities/5.70.2054 - Horse Pill Pink-Red.png" Kind="Pickups" Name="Horse Pill Pink-Red" Variant="70" Subtype="2054" />
-	<entity Group="Pills" ID="5" Image="resources/Entities/5.70.2055 - Horse Pill Blue-Cadetblue.png" Kind="Pickups" Name="Horse Pill Blue-Cadetblue" Variant="70" Subtype="2055" />
-	<entity Group="Pills" ID="5" Image="resources/Entities/5.70.2056 - Horse Pill Yellow-Orange.png" Kind="Pickups" Name="Horse Pill Yellow-Orange" Variant="70" Subtype="2056" />
-	<entity Group="Pills" ID="5" Image="resources/Entities/5.70.2057 - Horse Pill Dots-White.png" Kind="Pickups" Name="Horse Pill Dots-White" Variant="70" Subtype="2057" />
-	<entity Group="Pills" ID="5" Image="resources/Entities/5.70.2058 - Horse Pill White-Azure.png" Kind="Pickups" Name="Horse Pill White-Azure" Variant="70" Subtype="2058" />
-	<entity Group="Pills" ID="5" Image="resources/Entities/5.70.2059 - Horse Pill Black-Yellow.png" Kind="Pickups" Name="Horse Pill Black-Yellow" Variant="70" Subtype="2059" />
-	<entity Group="Pills" ID="5" Image="resources/Entities/5.70.2060 - Horse Pill White-Black.png" Kind="Pickups" Name="Horse Pill White-Black" Variant="70" Subtype="2060" />
-	<entity Group="Pills" ID="5" Image="resources/Entities/5.70.2061 - Horse Pill White-Yellow.png" Kind="Pickups" Name="Horse Pill White-Yellow" Variant="70" Subtype="2061" />
-	<entity Group="Pills" ID="5" Image="resources/Entities/5.70.2062 - Horse Pill Gold-Gold.png" Kind="Pickups" Name="Horse Pill Gold-Gold" Variant="70" Subtype="2062" />
+	<group Name="Pill Colors">
+		<entity ID="5" Image="Entities/5.70.14 - Pill Gold-Gold.png" Name="Pill Gold-Gold" Variant="70" Subtype="14" />
+	</group>
 
-	<!-- Runes -->
-	<entity Group="Runes" ID="5" Image="resources/Entities/5.301.0 - Random Rune.png" Kind="Pickups" Name="Random Rune" Subtype="0" Variant="301" />
-	<entity Group="Runes" ID="5" Image="resources/Entities/5.300.32 - Hagalaz.png" Kind="Pickups" Name="Hagalaz" Subtype="32" Variant="300" />
-	<entity Group="Runes" ID="5" Image="resources/Entities/5.300.33 - Jera.png" Kind="Pickups" Name="Jera" Subtype="33" Variant="300" />
-	<entity Group="Runes" ID="5" Image="resources/Entities/5.300.34 - Ehwaz.png" Kind="Pickups" Name="Ehwaz" Subtype="34" Variant="300" />
-	<entity Group="Runes" ID="5" Image="resources/Entities/5.300.35 - Dagaz.png" Kind="Pickups" Name="Dagaz" Subtype="35" Variant="300" />
-	<entity Group="Runes" ID="5" Image="resources/Entities/5.300.36 - Ansuz.png" Kind="Pickups" Name="Ansuz" Subtype="36" Variant="300" />
-	<entity Group="Runes" ID="5" Image="resources/Entities/5.300.37 - Perthro.png" Kind="Pickups" Name="Perthro" Subtype="37" Variant="300" />
-	<entity Group="Runes" ID="5" Image="resources/Entities/5.300.38 - Berkano.png" Kind="Pickups" Name="Berkano" Subtype="38" Variant="300" />
-	<entity Group="Runes" ID="5" Image="resources/Entities/5.300.39 - Algiz.png" Kind="Pickups" Name="Algiz" Subtype="39" Variant="300" />
-	<entity Group="Runes" ID="5" Image="resources/Entities/5.300.40 - Blank Rune.png" Kind="Pickups" Name="Blank Rune" Subtype="40" Variant="300" />
-	<entity Group="Runes" ID="5" Image="resources/Entities/5.300.41 - Black Rune.png" Kind="Pickups" Name="Black Rune" Subtype="41" Variant="300" />
-	<entity Group="Runes" ID="5" Image="resources/Entities/5.300.55 - Rune Shard.png" Kind="Pickups" Name="Rune Shard" Subtype="55" Variant="300" />
-	<entity Group="Runes" ID="5" Image="resources/Entities/5.300.81 - Soul of Isaac.png" Kind="Pickups" Name="Soul of Isaac" Subtype="81" Variant="300" />
-	<entity Group="Runes" ID="5" Image="resources/Entities/5.300.82 - Soul of Magdalene.png" Kind="Pickups" Name="Soul of Magdalene" Subtype="82" Variant="300" />
-	<entity Group="Runes" ID="5" Image="resources/Entities/5.300.83 - Soul of Cain.png" Kind="Pickups" Name="Soul of Cain" Subtype="83" Variant="300" />
-	<entity Group="Runes" ID="5" Image="resources/Entities/5.300.84 - Soul of Judas.png" Kind="Pickups" Name="Soul of Judas" Subtype="84" Variant="300" />
-	<entity Group="Runes" ID="5" Image="resources/Entities/5.300.85 - Soul of Blue Baby.png" Kind="Pickups" Name="Soul of ???" Subtype="85" Variant="300" />
-	<entity Group="Runes" ID="5" Image="resources/Entities/5.300.86 - Soul of Eve.png" Kind="Pickups" Name="Soul of Eve" Subtype="86" Variant="300" />
-	<entity Group="Runes" ID="5" Image="resources/Entities/5.300.87 - Soul of Samson.png" Kind="Pickups" Name="Soul of Samson" Subtype="87" Variant="300" />
-	<entity Group="Runes" ID="5" Image="resources/Entities/5.300.88 - Soul of Azazel.png" Kind="Pickups" Name="Soul of Azazel" Subtype="88" Variant="300" />
-	<entity Group="Runes" ID="5" Image="resources/Entities/5.300.89 - Soul of Lazarus.png" Kind="Pickups" Name="Soul of Lazarus" Subtype="89" Variant="300" />
-	<entity Group="Runes" ID="5" Image="resources/Entities/5.300.90 - Soul of Eden.png" Kind="Pickups" Name="Soul of Eden" Subtype="90" Variant="300" />
-	<entity Group="Runes" ID="5" Image="resources/Entities/5.300.91 - Soul of the Lost.png" Kind="Pickups" Name="Soul of the Lost" Subtype="91" Variant="300" />
-	<entity Group="Runes" ID="5" Image="resources/Entities/5.300.92 - Soul of Lilith.png" Kind="Pickups" Name="Soul of Lilith" Subtype="92" Variant="300" />
-	<entity Group="Runes" ID="5" Image="resources/Entities/5.300.93 - Soul of the Keeper.png" Kind="Pickups" Name="Soul of the Keeper" Subtype="93" Variant="300" />
-	<entity Group="Runes" ID="5" Image="resources/Entities/5.300.94 - Soul of Apollyon.png" Kind="Pickups" Name="Soul of Apollyon" Subtype="94" Variant="300" />
-	<entity Group="Runes" ID="5" Image="resources/Entities/5.300.95 - Soul of the Forgotten.png" Kind="Pickups" Name="Soul of the Forgotten" Subtype="95" Variant="300" />
-	<entity Group="Runes" ID="5" Image="resources/Entities/5.300.96 - Soul of Bethany.png" Kind="Pickups" Name="Soul of Bethany" Subtype="96" Variant="300" />
-	<entity Group="Runes" ID="5" Image="resources/Entities/5.300.97 - Soul of Jacob and Esau.png" Kind="Pickups" Name="Soul of Jacob and Esau" Subtype="97" Variant="300" />
-	
-	<!-- Batteries -->
-	<entity Group="Batteries" ID="5" Image="resources/Entities/5.90.0 - RBattery.png" Kind="Pickups" Name="Random Battery" Subtype="0" Variant="90" />
-	<entity Group="Batteries" ID="5" Image="resources/Entities/5.90.1 - Lil' Battery.png" Kind="Pickups" Name="Lil' Battery" Variant="90" Subtype="1" />
-	<entity Group="Batteries" ID="5" Image="resources/Entities/5.90.2 - Micro Battery.png" Kind="Pickups" Name="Micro Battery" Variant="90" Subtype="2" />
-	<entity Group="Batteries" ID="5" Image="resources/Entities/5.90.3 - Mega Battery.png" Kind="Pickups" Name="Mega Battery" Variant="90" Subtype="3" />
-	<entity Group="Batteries" ID="5" Image="resources/Entities/5.90.4 - Golden Battery.png" Kind="Pickups" Name="Golden Battery" Variant="90" Subtype="4" />
-	
+	<group Name="Pills">
+		<group Name="Pill Colors (Horse)">
+			<entity ID="5" Image="Entities/5.70.2049 - Horse Pill Blue-Blue.png" Name="Horse Pill Blue-Blue" Variant="70" Subtype="2049" />
+			<entity ID="5" Image="Entities/5.70.2050 - Horse Pill White-Blue.png" Name="Horse Pill White-Blue" Variant="70" Subtype="2050" />
+			<entity ID="5" Image="Entities/5.70.2051 - Horse Pill Orange-Orange.png" Name="Horse Pill Orange-Orange" Variant="70" Subtype="2051" />
+			<entity ID="5" Image="Entities/5.70.2052 - Horse Pill White-White.png" Name="Horse Pill White-White" Variant="70" Subtype="2052" />
+			<entity ID="5" Image="Entities/5.70.2053 - Horse Pill Dots-Red.png" Name="Horse Pill Dots-Red" Variant="70" Subtype="2053" />
+			<entity ID="5" Image="Entities/5.70.2054 - Horse Pill Pink-Red.png" Name="Horse Pill Pink-Red" Variant="70" Subtype="2054" />
+			<entity ID="5" Image="Entities/5.70.2055 - Horse Pill Blue-Cadetblue.png" Name="Horse Pill Blue-Cadetblue" Variant="70" Subtype="2055" />
+			<entity ID="5" Image="Entities/5.70.2056 - Horse Pill Yellow-Orange.png" Name="Horse Pill Yellow-Orange" Variant="70" Subtype="2056" />
+			<entity ID="5" Image="Entities/5.70.2057 - Horse Pill Dots-White.png" Name="Horse Pill Dots-White" Variant="70" Subtype="2057" />
+			<entity ID="5" Image="Entities/5.70.2058 - Horse Pill White-Azure.png" Name="Horse Pill White-Azure" Variant="70" Subtype="2058" />
+			<entity ID="5" Image="Entities/5.70.2059 - Horse Pill Black-Yellow.png" Name="Horse Pill Black-Yellow" Variant="70" Subtype="2059" />
+			<entity ID="5" Image="Entities/5.70.2060 - Horse Pill White-Black.png" Name="Horse Pill White-Black" Variant="70" Subtype="2060" />
+			<entity ID="5" Image="Entities/5.70.2061 - Horse Pill White-Yellow.png" Name="Horse Pill White-Yellow" Variant="70" Subtype="2061" />
+			<entity ID="5" Image="Entities/5.70.2062 - Horse Pill Gold-Gold.png" Name="Horse Pill Gold-Gold" Variant="70" Subtype="2062" />
+		</group>
+	</group>
 
-	<!--——— Enemies ———-->
+	<group Name="Cards">
+		<group Name="Reverse Tarot Cards">
+			<entity ID="5" Image="Entities/5.300.56 - The Fool (Reverse).png" Name="The Fool?" Subtype="56" Variant="300" />
+			<entity ID="5" Image="Entities/5.300.57 - The Magician (Reverse).png" Name="Magician?" Subtype="57" Variant="300" />
+			<entity ID="5" Image="Entities/5.300.58 - The High Priestess (Reverse).png" Name="The High Priestess?" Subtype="58" Variant="300" />
+			<entity ID="5" Image="Entities/5.300.59 - The Empress (Reverse).png" Name="The Empress?" Subtype="59" Variant="300" />
+			<entity ID="5" Image="Entities/5.300.60 - The Emperor (Reverse).png" Name="The Emperor?" Subtype="60" Variant="300" />
+			<entity ID="5" Image="Entities/5.300.61 - The Hierophant (Reverse).png" Name="The Hierophant?" Subtype="61" Variant="300" />
+			<entity ID="5" Image="Entities/5.300.62 - The Lovers (Reverse).png" Name="The Lovers?" Subtype="62" Variant="300" />
+			<entity ID="5" Image="Entities/5.300.63 - The Chariot (Reverse).png" Name="The Chariot?" Subtype="63" Variant="300" />
+			<entity ID="5" Image="Entities/5.300.64 - Justice (Reverse).png" Name="Justice?" Subtype="64" Variant="300" />
+			<entity ID="5" Image="Entities/5.300.65 - The Hermit (Reverse).png" Name="The Hermit?" Subtype="65" Variant="300" />
+			<entity ID="5" Image="Entities/5.300.66 - Wheel of Fortune (Reverse).png" Name="Wheel of Fortune?" Subtype="66" Variant="300" />
+			<entity ID="5" Image="Entities/5.300.67 - Strength (Reverse).png" Name="Strength?" Subtype="67" Variant="300" />
+			<entity ID="5" Image="Entities/5.300.68 - The Hanged Man (Reverse).png" Name="The Hanged Man?" Subtype="68" Variant="300" />
+			<entity ID="5" Image="Entities/5.300.69 - Death (Reverse).png" Name="Death?" Subtype="69" Variant="300" />
+			<entity ID="5" Image="Entities/5.300.70 - Temperance (Reverse).png" Name="Temperance?" Subtype="70" Variant="300" />
+			<entity ID="5" Image="Entities/5.300.71 - The Devil (Reverse).png" Name="The Devil?" Subtype="71" Variant="300" />
+			<entity ID="5" Image="Entities/5.300.72 - The Tower (Reverse).png" Name="The Tower?" Subtype="72" Variant="300" />
+			<entity ID="5" Image="Entities/5.300.73 - The Stars (Reverse).png" Name="The Stars?" Subtype="73" Variant="300" />
+			<entity ID="5" Image="Entities/5.300.74 - The Moon (Reverse).png" Name="The Moon?" Subtype="74" Variant="300" />
+			<entity ID="5" Image="Entities/5.300.75 - The Sun (Reverse).png" Name="The Sun?" Subtype="75" Variant="300" />
+			<entity ID="5" Image="Entities/5.300.76 - Judgement (Reverse).png" Name="Judgement?" Subtype="76" Variant="300" />
+			<entity ID="5" Image="Entities/5.300.77 - The World (Reverse).png" Name="The World?" Subtype="77" Variant="300" />
+		</group>
+		<entity ID="5" Image="Entities/5.300.78 - Cracked Key.png" Name="Cracked Key" Subtype="78" Variant="300" />
+		<entity ID="5" Image="Entities/5.300.79 - Queen of Hearts.png" Name="Queen of Hearts" Subtype="79" Variant="300" />
+		<entity ID="5" Image="Entities/5.300.80 - Wild Card.png" Name="Wild Card" Subtype="80" Variant="300" />
+	</group>
 
-	<!-- Babies -->
-	<entity BaseHP="25" Champion="1" Group="Babies" ID="38" Image="resources/Entities/38.0.0 - Baby.png" Kind="Enemies" Name="Baby" Subtype="0" Variant="0" />
-	<entity BaseHP="25" Champion="1" Group="Babies" ID="38" Image="resources/Entities/38.1.0 - Angelic Baby.png" Kind="Enemies" Name="Angelic Baby" Subtype="0" Variant="1" />
-	<entity BaseHP="16" Champion="1" Group="Babies" ID="38" Image="resources/Entities/38.1.1 - Angelic Baby (small).png" Kind="Enemies" Name="Angelic Baby (small)" Variant="1" Subtype="1" />
-	<entity BaseHP="25" Champion="1" Group="Babies" ID="38" Image="resources/Entities/38.3.0 - Wrinkly Baby.png" Kind="Enemies" Name="Wrinkly Baby" Variant="3" Subtype="0" />
-	<entity BaseHP="32" Champion="1" Group="Babies" ID="860" Image="resources/Entities/860.0.0 - Unborn.png" Kind="Enemies" Name="Unborn" Variant="0" Subtype="0" />
-	<entity BaseHP="25" Champion="1" Group="Babies" ID="259" Image="resources/Entities/259.0.0 - Imp.png" Kind="Enemies" Name="Imp" Subtype="0" Variant="0" />
-	<entity BaseHP="18" Champion="1" Group="Babies" ID="883" Image="resources/Entities/883.0.0 - Baby Begotten.png" Kind="Enemies" Name="Baby Begotten" Variant="0" Subtype="0" />
+	<group Name="Runes">
+		<entity ID="5" Image="Entities/5.300.55 - Rune Shard.png" Name="Rune Shard" Subtype="55" Variant="300" />
+		<entity ID="5" Image="Entities/5.300.81 - Soul of Isaac.png" Name="Soul of Isaac" Subtype="81" Variant="300" />
+		<entity ID="5" Image="Entities/5.300.82 - Soul of Magdalene.png" Name="Soul of Magdalene" Subtype="82" Variant="300" />
+		<entity ID="5" Image="Entities/5.300.83 - Soul of Cain.png" Name="Soul of Cain" Subtype="83" Variant="300" />
+		<entity ID="5" Image="Entities/5.300.84 - Soul of Judas.png" Name="Soul of Judas" Subtype="84" Variant="300" />
+		<entity ID="5" Image="Entities/5.300.85 - Soul of Blue Baby.png" Name="Soul of ???" Subtype="85" Variant="300" />
+		<entity ID="5" Image="Entities/5.300.86 - Soul of Eve.png" Name="Soul of Eve" Subtype="86" Variant="300" />
+		<entity ID="5" Image="Entities/5.300.87 - Soul of Samson.png" Name="Soul of Samson" Subtype="87" Variant="300" />
+		<entity ID="5" Image="Entities/5.300.88 - Soul of Azazel.png" Name="Soul of Azazel" Subtype="88" Variant="300" />
+		<entity ID="5" Image="Entities/5.300.89 - Soul of Lazarus.png" Name="Soul of Lazarus" Subtype="89" Variant="300" />
+		<entity ID="5" Image="Entities/5.300.90 - Soul of Eden.png" Name="Soul of Eden" Subtype="90" Variant="300" />
+		<entity ID="5" Image="Entities/5.300.91 - Soul of the Lost.png" Name="Soul of the Lost" Subtype="91" Variant="300" />
+		<entity ID="5" Image="Entities/5.300.92 - Soul of Lilith.png" Name="Soul of Lilith" Subtype="92" Variant="300" />
+		<entity ID="5" Image="Entities/5.300.93 - Soul of the Keeper.png" Name="Soul of the Keeper" Subtype="93" Variant="300" />
+		<entity ID="5" Image="Entities/5.300.94 - Soul of Apollyon.png" Name="Soul of Apollyon" Subtype="94" Variant="300" />
+		<entity ID="5" Image="Entities/5.300.95 - Soul of the Forgotten.png" Name="Soul of the Forgotten" Subtype="95" Variant="300" />
+		<entity ID="5" Image="Entities/5.300.96 - Soul of Bethany.png" Name="Soul of Bethany" Subtype="96" Variant="300" />
+		<entity ID="5" Image="Entities/5.300.97 - Soul of Jacob and Esau.png" Name="Soul of Jacob and Esau" Subtype="97" Variant="300" />
+	</group>
 
-	<!-- Blobs -->
-	<entity BaseHP="15" Champion="1" Group="Blobs" ID="15" Image="resources/Entities/15.1.0 - Clot.png" Kind="Enemies" Name="Clot" Subtype="0" Variant="1" />
-	<entity BaseHP="15" Champion="1" Group="Blobs" ID="15" Image="resources/Entities/15.2.0 - I.Blob.png" Kind="Enemies" Name="I.Blob" Subtype="0" Variant="2" />
-	<entity Group="Blobs" Kind="Enemies" Image="resources/Entities/305.0.0 - Ministro.png" BaseHP="9" Champion="1" ID="305" Name="Ministro" Variant="0" Subtype="0" />
-	<entity BaseHP="15" Champion="1" Group="Blobs" ID="15" Image="resources/Entities/15.0.0 - Clotty.png" Kind="Enemies" Name="Clotty" Subtype="0" Variant="0" />
-	<entity BaseHP="20" Champion="1" Group="Blobs" ID="15" Image="resources/Entities/15.3.0 - Grilled Clotty.png" Kind="Enemies" Name="Grilled Clotty" Variant="3" Subtype="0" />
-	<entity BaseHP="15" Champion="1" Group="Blobs" ID="872" Image="resources/Entities/872.0.0 - Cloggy.png" Kind="Enemies" Name="Cloggy" Variant="0" Subtype="0" />
-	<entity BaseHP="20" Champion="1" Group="Blobs" ID="282" Image="resources/Entities/282.0.0 - Mega Clotty.png" Kind="Enemies" Name="Mega Clotty" Subtype="0" Variant="0" />
-	<entity BaseHP="15" Champion="1" Group="Blobs" ID="290" Image="resources/Entities/290.0.0 - Meatball.png" Kind="Enemies" Name="Meatball" Subtype="0" Variant="0" />
-	<entity BaseHP="20" Group="Blobs" ID="892" Image="resources/Entities/892.0.0 - Poofer.png" Kind="Enemies" Name="Poofer" Variant="0" Subtype="0" />
+	<!--——— Global ———-->
+	<group Name="Basic Rock">
+		<entity ID="1000" Image="Entities/1000.0.1 - Rock (non-replaceable).png" Name="Rock (non-replaceable)" Subtype="1" Variant="0" EditorImage="Backgrounds/rocks_generic.png" UseRockTiling="1" OverlayImage="Overlays/NonRandom.png" />
+	</group>
 
-	<!-- Boils -->
-	<entity BaseHP="20" Champion="1" Group="Boils" ID="30" Image="resources/Entities/30.0.0 - Boil.png" Kind="Enemies" Name="Boil" Subtype="0" Variant="0" />
-	<entity BaseHP="20" Champion="1" Group="Boils" ID="30" Image="resources/Entities/30.1.0 - Gut.png" Kind="Enemies" Name="Gut" Subtype="0" Variant="1" />
-	<entity BaseHP="20" Champion="1" Group="Boils" ID="30" Image="resources/Entities/30.2.0 - Sack.png" Kind="Enemies" Name="Sack" Subtype="0" Variant="2" />
-	<entity Group="Boils" Kind="Enemies" Image="resources/Entities/309.0.0 - Gush.png" BaseHP="20" Champion="1" ID="309" Name="Gush" Variant="0" Subtype="0" />
-	<entity BaseHP="30" Champion="1" Group="Boils" ID="298" Image="resources/Entities/298.0.0 - Blue Boil.png" Kind="Enemies" Name="Blue Boil" Subtype="0" Variant="0" />
-	<entity BaseHP="19" Champion="1" Group="Boils" ID="861" Image="resources/Entities/861.0.0 - Pustule.png" Kind="Enemies" Name="Pustule" Variant="0" Subtype="0" />
-	<entity BaseHP="20" Champion="1" Group="Boils" ID="88" Image="resources/Entities/88.0.0 - Walking Boil.png" Kind="Enemies" Name="Walking Boil" Subtype="0" Variant="0" />
-	<entity BaseHP="20" Champion="1" Group="Boils" ID="88" Image="resources/Entities/88.1.0 - Walking Gut.png" Kind="Enemies" Name="Walking Gut" Subtype="0" Variant="1" />
-	<entity BaseHP="20" Champion="1" Group="Boils" ID="88" Image="resources/Entities/88.2.0 - Walking Sack.png" Kind="Enemies" Name="Walking Sack" Subtype="0" Variant="2" />
+	<group Name="Rocks">
+		<entity ID="1010" Image="Entities/1010.0.0 - Spike Rock.png" Name="Spike Rock" Subtype="0" Variant="0" />
+		<entity ID="1011" Image="Entities/1011.0.0 - Fool's Gold Rock.png" Name="Fool's Gold Rock" Subtype="0" Variant="0" />
+	</group>
 
-	<!-- Fatties -->
-	<entity BaseHP="20" Group="Fatties" ID="208" Image="resources/Entities/208.0.0 - Fatty.png" Kind="Enemies" Name="Fatty" Subtype="0" Variant="0" />
-	<entity BaseHP="20" Group="Fatties" ID="257" Image="resources/Entities/257.0.0 - Conjoined Fatty.png" Kind="Enemies" Name="Conjoined Fatty" Subtype="0" Variant="0" />
-	<entity BaseHP="18" Group="Fatties" ID="208" Image="resources/Entities/208.2.0 - Flaming Fatty.png" Kind="Enemies" Name="Flaming Fatty" Subtype="0" Variant="2" />
-	<entity BaseHP="20" Group="Fatties" ID="208" Image="resources/Entities/208.1.0 - Pale Fatty.png" Kind="Enemies" Name="Pale Fatty" Subtype="0" Variant="1" />
-	<entity BaseHP="16" Champion="1" Group="Fatties" ID="209" Image="resources/Entities/209.0.0 - Fat Sack.png" Kind="Enemies" Name="Fat Sack" Subtype="0" Variant="0" />
-	<entity BaseHP="16" Champion="1" Group="Fatties" ID="210" Image="resources/Entities/210.0.0 - Blubber.png" Kind="Enemies" Name="Blubber" Subtype="0" Variant="0" />
-	<entity BaseHP="10" Champion="1" Group="Fatties" ID="211" Image="resources/Entities/211.0.0 - Half Sack.png" Kind="Enemies" Name="Half Sack" Subtype="0" Variant="0" />
-	<entity Group="Fatties" Kind="Enemies" Image="resources/Entities/302.0.0 - Stoney.png" BaseHP="50" ID="302" Name="Stoney" Variant="0" Subtype="0" />
-	<entity Group="Fatties" Kind="Enemies" Image="resources/Entities/302.10.0 - Cross Stoney.png" BaseHP="50" ID="302" Name="Cross Stoney" Variant="10" Subtype="0" />
-	<entity BaseHP="60" Group="Fatties" ID="257" Image="resources/Entities/257.1.0 - Blue Conjoined Fatty.png" Kind="Enemies" Name="Blue Conjoined Fatty" Subtype="0" Variant="1" />
-	<entity BaseHP="20" Champion="1" Group="Fatties" ID="806" Image="resources/Entities/806.0.0 - Bubbles.png" Kind="Enemies" Name="Bubbles" Variant="0" Subtype="0" />
-	<entity BaseHP="26" Champion="1" Group="Fatties" ID="879" Image="resources/Entities/879.0.0 - Bloaty.png" Kind="Enemies" Name="Bloaty" Variant="0" Subtype="0" />
-	<entity BaseHP="45" Champion="1" Group="Fatties" ID="823" Image="resources/Entities/823.0.0 - Quakey.png" Kind="Enemies" Name="Quakey" Variant="0" Subtype="0" />
-	<entity BaseHP="50" Champion="1" Group="Fatties" ID="830" Image="resources/Entities/830.0.0 - Big Bony.png" Kind="Enemies" Name="Big Bony" Variant="0" Subtype="0" />
-	<entity BaseHP="40" Champion="1" Group="Fatties" ID="886" Image="resources/Entities/886.0.0 - Vis Fatty.png" Kind="Enemies" Name="Vis Fatty" Variant="0" Subtype="0" />
-	<entity BaseHP="40" Champion="1" Group="Fatties" ID="886" Image="resources/Entities/886.1.0 - Fetal Demon.png" Kind="Enemies" Name="Fetal Demon" Variant="1" Subtype="0" />
-	<entity BaseHP="60" Champion="1" Group="Fatties" ID="835" Image="resources/Entities/835.0.0 - Peeping Fatty.png" Kind="Enemies" Name="Peeping Fatty" Variant="0" Subtype="0" />
-	<entity BaseHP="60" Group="Fatties" ID="835" Image="resources/Entities/835.10.0 - Peeping Fatty Eye.png" Kind="Enemies" Name="Peeping Fatty Eye" Variant="10" Subtype="0" />
-	<entity BaseHP="80" Champion="1" Group="Fatties" ID="831" Image="resources/Entities/831.0.0 - Gutted Fatty.png" Kind="Enemies" Name="Gutted Fatty" Variant="0" Subtype="0" />
-	<entity BaseHP="80" Group="Fatties" ID="831" Image="resources/Entities/831.10.0 - Gutted Fatty Eye.png" Kind="Enemies" Name="Gutted Fatty Eye" Variant="10" Subtype="0" />
-	<entity BaseHP="22" Champion="1" Group="Fatties" ID="831" Image="resources/Entities/831.20.0 - Festering Guts.png" Kind="Enemies" Name="Festering Guts" Variant="20" Subtype="0" />
-	<entity BaseHP="60" Champion="1" Group="Fatties" ID="858" Image="resources/Entities/858.0.0 - Vessel.png" Kind="Enemies" Name="Vessel" Variant="0" Subtype="0" />
-	<entity BaseHP="80" Group="Fatties" ID="888" Image="resources/Entities/888.0.0 - Shady.png" Kind="Enemies" Name="Shady" Variant="0" Subtype="0" />
+	<group Name="Alt Rocks">
+		<entity ID="1008" Image="Entities/1008.0.0 - Marked Skull.png" Name="Marked Skull" Subtype="0" Variant="0" />
+	</group>
 
-	<!-- Flies -->
-	<entity BaseHP="3" Group="Flies" ID="13" Image="resources/Entities/13.0.0 - Fly.png" Kind="Enemies" Name="Fly" Subtype="0" Variant="0" />
-	<entity BaseHP="5" Group="Flies" ID="18" Image="resources/Entities/18.0.0 - Attack Fly.png" Kind="Enemies" Name="Attack Fly" Subtype="0" Variant="0" />
-	<entity BaseHP="5" Group="Flies" ID="222" Image="resources/Entities/222.0.0 - Ring Fly.png" Kind="Enemies" Name="Ring Fly" Subtype="0" Variant="0" />
-	<entity BaseHP="5" Group="Flies" ID="256" Image="resources/Entities/256.0.0 - Dart Fly.png" Kind="Enemies" Name="Dart Fly" Subtype="0" Variant="0" />
-	<entity BaseHP="5" Group="Flies" ID="281" Image="resources/Entities/281.0.0 - Swarm.png" Kind="Enemies" Name="Swarm" Subtype="0" Variant="0" />
-	<entity BaseHP="30" Champion="1" Group="Flies" ID="296" Image="resources/Entities/296.0.0 - Hush Fly.png" Kind="Enemies" Name="Hush Fly" Subtype="0" Variant="0" />
-	<entity BaseHP="5" Group="Flies" ID="868" Image="resources/Entities/868.0.0 - Army Fly.png" Kind="Enemies" Name="Army Fly" Variant="0" Subtype="0" />
-	<entity BaseHP="6" Group="Flies" ID="808" Image="resources/Entities/808.0.0 - Willo.png" Kind="Enemies" Name="Willo" Variant="0" Subtype="0" />
-	<entity BaseHP="20" Group="Flies" ID="838" Image="resources/Entities/838.0.0 - Level 2 Willo.png" Kind="Enemies" Name="Level 2 Willo" Variant="0" Subtype="0" />
-	<entity BaseHP="10" Group="Flies" ID="80" Image="resources/Entities/80.0.0 - Moter.png" Kind="Enemies" Name="Moter" Subtype="0" Variant="0" />
-	<entity BaseHP="8" Champion="1" Group="Flies" ID="14" Image="resources/Entities/14.0.0 - Pooter.png" Kind="Enemies" Name="Pooter" Subtype="0" Variant="0" />
-	<entity BaseHP="8" Champion="1" Group="Flies" ID="14" Image="resources/Entities/14.1.0 - Super Pooter.png" Kind="Enemies" Name="Super Pooter" Subtype="0" Variant="1" />
-	<entity BaseHP="20" Champion="1" Group="Flies" ID="25" Image="resources/Entities/25.0.0 - Boom Fly.png" Kind="Enemies" Name="Boom Fly" Subtype="0" Variant="0" />
-	<entity BaseHP="20" Champion="1" Group="Flies" ID="25" Image="resources/Entities/25.1.0 - Red Boom Fly.png" Kind="Enemies" Name="Red Boom Fly" Subtype="0" Variant="1" />
-	<entity BaseHP="20" Champion="1" Group="Flies" ID="25" Image="resources/Entities/25.2.0 - Drowned Boom Fly.png" Kind="Enemies" Name="Drowned Boom Fly" Subtype="0" Variant="2" />
-	<entity BaseHP="20" Champion="1" Group="Flies" ID="25" Image="resources/Entities/25.3.0 - Dragon Fly.png" Kind="Enemies" Name="Dragon Fly" Variant="3" Subtype="0" />
-	<entity BaseHP="20" Champion="1" Group="Flies" ID="25" Image="resources/Entities/25.3.1 - Dragon Fly X.png" Kind="Enemies" Name="Dragon Fly X" Variant="3" Subtype="1" />
-	<entity BaseHP="20" Champion="1" Group="Flies" ID="25" Image="resources/Entities/25.3.100 - Dragon Fly (random).png" Kind="Enemies" Name="Dragon Fly (random)" Variant="3" Subtype="100" />
-	<entity BaseHP="20" Champion="1" Group="Flies" ID="25" Image="resources/Entities/25.4.0 - Bone Fly.png" Kind="Enemies" Name="Bone Fly" Variant="4" Subtype="0" />
-	<entity BaseHP="20" Champion="1" Group="Flies" ID="25" Image="resources/Entities/25.5.0 - Sick Boom Fly.png" Kind="Enemies" Name="Sick Boom Fly" Variant="5" Subtype="0" />
-	<entity BaseHP="10" Champion="1" Group="Flies" ID="61" Image="resources/Entities/61.0.0 - Sucker.png" Kind="Enemies" Name="Sucker" Subtype="0" Variant="0" />
-	<entity BaseHP="10" Champion="1" Group="Flies" ID="61" Image="resources/Entities/61.1.0 - Spit.png" Kind="Enemies" Name="Spit" Subtype="0" Variant="1" />
-	<entity Group="Flies" Kind="Enemies" Image="resources/Entities/61.2.0 - Soul Sucker.png" BaseHP="18" Champion="1" ID="61" Name="Soul Sucker" Variant="2" Subtype="0" />
-	<entity BaseHP="10" Champion="1" Group="Flies" ID="61" Image="resources/Entities/61.3.0 - Ink.png" Kind="Enemies" Name="Ink" Variant="3" Subtype="0" />
-	<entity BaseHP="44" Champion="1" Group="Flies" ID="61" Image="resources/Entities/61.4.0 - Mama Fly.png" Kind="Enemies" Name="Mama Fly" Variant="4" Subtype="0" />
-	<entity BaseHP="10" Group="Flies" ID="61" Image="resources/Entities/61.5.0 - Bulb.png" Kind="Enemies" Name="Bulb" Variant="5" Subtype="0" />
-	<entity BaseHP="6" Group="Flies" ID="61" Image="resources/Entities/61.6.0 - Bloodfly.png" Kind="Enemies" Name="Bloodfly" Variant="6" Subtype="0" />
-	<entity BaseHP="10" Group="Flies" ID="214" Image="resources/Entities/214.0.0 - lvl2 Fly.png" Kind="Enemies" Name="lvl2 Fly" Subtype="0" Variant="0" />
-	<entity BaseHP="10" Group="Flies" ID="249" Image="resources/Entities/249.0.0 - Full Fly.png" Kind="Enemies" Name="Full Fly" Subtype="0" Variant="0" />
-	<entity BaseHP="7" Champion="1" Group="Flies" ID="819" Image="resources/Entities/819.0.0 - Fly Bomb.png" Kind="Enemies" Name="Fly Bomb" Variant="0" Subtype="0" />
-	<entity BaseHP="7" Champion="1" Group="Flies" ID="819" Image="resources/Entities/819.1.0 - Eternal Fly Bomb.png" Kind="Enemies" Name="Eternal Fly Bomb" Variant="1" Subtype="0" />
-	<entity BaseHP="40" Champion="1" Group="Flies" ID="91" Image="resources/Entities/91.0.0 - Swarmer.png" Kind="Enemies" Name="Swarmer" Subtype="0" Variant="0" />
-	<entity BaseHP="25" Group="Flies" ID="288" Image="resources/Entities/288.0.0 - Dukie.png" Kind="Enemies" Name="Dukie" Subtype="0" Variant="0" />
-	<entity BaseHP="10" Group="Flies" ID="289" Image="resources/Entities/289.0.0 - Ulcer.png" Kind="Enemies" Name="Ulcer" Subtype="0" Variant="0" />
+	<group Name="Metal Blocks">
+		<entity ID="1901" Image="Entities/1901.0.0 - Tall Block.png" Name="Tall Block" Variant="0" Subtype="0" />
+		<entity ID="1999" Image="Entities/1999.0.0 - Invisible Block.png" Name="Invisible Block" Subtype="0" Variant="0" />
+	</group>
 
+	<group Name="Pressure Plates">
+		<entity ID="4500" Image="Entities/4500.0.9 - Kill Plate.png" Name="Kill Plate" Subtype="0" Variant="9" />
+	</group>
 
-	<!-- Gapers -->
-	<entity BaseHP="10" Champion="1" Group="Gapers" ID="10" Image="resources/Entities/10.1.0 - Gaper.png" Kind="Enemies" Name="Gaper" Subtype="0" Variant="1" />
-	<entity BaseHP="10" Champion="1" Group="Gapers" ID="10" Image="resources/Entities/10.0.0 - Frowning Gaper.png" Kind="Enemies" Name="Frowning Gaper" Subtype="0" Variant="0" />
-	<entity BaseHP="10" Champion="1" Group="Gapers" ID="10" Image="resources/Entities/10.2.0 - Flaming Gaper.png" Kind="Enemies" Name="Flaming Gaper" Subtype="0" Variant="2" />
-	<entity BaseHP="10" Champion="1" Group="Gapers" ID="284" Image="resources/Entities/284.0.0 - Cyclopia.png" Kind="Enemies" Name="Cyclopia" Subtype="0" Variant="0" />
-	<entity BaseHP="40" Champion="1" Group="Gapers" ID="87" Image="resources/Entities/87.0.0 - Gurgle.png" Kind="Enemies" Name="Gurgle" Subtype="0" Variant="0" />
-	<entity BaseHP="40" Champion="1" Group="Gapers" ID="87" Image="resources/Entities/87.1.0 - Crackle.png" Kind="Enemies" Name="Crackle" Variant="1" Subtype="0" />
-	<entity BaseHP="30" Champion="1" Group="Gapers" ID="252" Image="resources/Entities/252.0.0 - Null.png" Kind="Enemies" Name="Null" Subtype="0" Variant="0" />
-	<entity BaseHP="30" Champion="1" Group="Gapers" ID="297" Image="resources/Entities/297.0.0 - Blue Gaper.png" Kind="Enemies" Name="Blue Gaper" Subtype="0" Variant="0" />
-	<entity BaseHP="30" Champion="1" Group="Gapers" ID="299" Image="resources/Entities/299.0.0 - Greed Gaper.png" Kind="Enemies" Name="Greed Gaper" Subtype="0" Variant="0" />
-	<entity BaseHP="10" Champion="1" Group="Gapers" ID="811" Image="resources/Entities/811.0.0 - Deep Gaper (random).png" Kind="Enemies" Name="Deep Gaper (random)" Variant="0" Subtype="0" />
-	<entity BaseHP="10" Champion="1" Group="Gapers" ID="811" Image="resources/Entities/811.0.1 - Deep Gaper (subtype 1).png" Kind="Enemies" Name="Deep Gaper (subtype 1)" Variant="0" Subtype="1" />
-	<entity BaseHP="10" Champion="1" Group="Gapers" ID="811" Image="resources/Entities/811.0.2 - Deep Gaper (subtype 2).png" Kind="Enemies" Name="Deep Gaper (subtype 2)" Variant="0" Subtype="2" />
-	<entity BaseHP="10" Champion="1" Group="Gapers" ID="811" Image="resources/Entities/811.0.3 - Deep Gaper (subtype 3).png" Kind="Enemies" Name="Deep Gaper (subtype 3)" Variant="0" Subtype="3" />
-	<entity BaseHP="10" Champion="1" Group="Gapers" ID="811" Image="resources/Entities/811.0.4 - Deep Gaper (subtype 4).png" Kind="Enemies" Name="Deep Gaper (subtype 4)" Variant="0" Subtype="4" />
-	<entity BaseHP="10" Champion="1" Group="Gapers" ID="811" Image="resources/Entities/811.0.5 - Deep Gaper (subtype 5).png" Kind="Enemies" Name="Deep Gaper (subtype 4)" Variant="0" Subtype="5" />
-	<entity BaseHP="10" Champion="1" Group="Gapers" ID="811" Image="resources/Entities/811.0.6 - Deep Gaper (subtype 6).png" Kind="Enemies" Name="Deep Gaper (subtype 5)" Variant="0" Subtype="6" />
-	<entity BaseHP="24" Champion="1" Group="Gapers" ID="10" Image="resources/Entities/10.3.0 - Rotten Gaper (random).png" Kind="Enemies" Name="Rotten Gaper (random)" Variant="3" Subtype="0" />
-	<entity BaseHP="24" Champion="1" Group="Gapers" ID="10" Image="resources/Entities/10.3.1 - Rotten Gaper (subtype 1).png" Kind="Enemies" Name="Rotten Gaper (subtype 1)" Variant="3" Subtype="1" />
-	<entity BaseHP="24" Champion="1" Group="Gapers" ID="10" Image="resources/Entities/10.3.2 - Rotten Gaper (subtype 2).png" Kind="Enemies" Name="Rotten Gaper (subtype 2)" Variant="3" Subtype="2" />
-	<entity BaseHP="24" Champion="1" Group="Gapers" ID="10" Image="resources/Entities/10.3.3 - Rotten Gaper (subtype 3).png" Kind="Enemies" Name="Rotten Gaper (subtype 3)" Variant="3" Subtype="3" />
-	<entity BaseHP="24" Champion="1" Group="Gapers" ID="10" Image="resources/Entities/10.3.4 - Rotten Gaper (subtype 4).png" Kind="Enemies" Name="Rotten Gaper (subtype 4)" Variant="3" Subtype="4" />
-	<entity BaseHP="24" Champion="1" Group="Gapers" ID="10" Image="resources/Entities/10.3.5 - Rotten Gaper (subtype 5).png" Kind="Enemies" Name="Rotten Gaper (subtype 5)" Variant="3" Subtype="5" />
-	<entity BaseHP="40" Champion="1" Group="Gapers" ID="850" Image="resources/Entities/850.0.0 - Level 2 Gaper.png" Kind="Enemies" Name="Level 2 Gaper" Variant="0" Subtype="0" />
-	<entity BaseHP="40" Champion="1" Group="Gapers" ID="851" Image="resources/Entities/851.0.0 - Twitchy.png" Kind="Enemies" Name="Twitchy" Variant="0" Subtype="0" />
-	<entity BaseHP="10" Champion="1" Group="Gapers" ID="807" Image="resources/Entities/807.0.0 - Wraith.png" Kind="Enemies" Name="Wraith" Variant="0" Subtype="0" />
-	<entity BaseHP="16" Champion="1" Group="Gapers" ID="813" Image="resources/Entities/813.0.0 - Blurb.png" Kind="Enemies" Name="Blurb" Variant="0" Subtype="0" />
-	<entity BaseHP="10" Champion="1" Group="Gapers" ID="876" Image="resources/Entities/876.0.0 - Dump.png" Kind="Enemies" Name="Dump" Variant="0" Subtype="0" />
-	<entity BaseHP="10" Champion="1" Group="Gapers" ID="876" Image="resources/Entities/876.1.0 - Dump Head.png" Kind="Enemies" Name="Dump Head" Variant="1" Subtype="0" />
-	<entity BaseHP="40" Champion="1" Group="Gapers" ID="820" Image="resources/Entities/820.0.0 - Danny.png" Kind="Enemies" Name="Danny" Variant="0" Subtype="0" />
-	<entity BaseHP="40" Champion="1" Group="Gapers" ID="820" Image="resources/Entities/820.1.0 - Coal Boy.png" Kind="Enemies" Name="Coal Boy" Variant="1" Subtype="0" />
-	<entity BaseHP="20" Champion="1" Group="Gapers" ID="821" Image="resources/Entities/821.0.0 - Blaster.png" Kind="Enemies" Name="Blaster" Variant="0" Subtype="0" />
-	<entity BaseHP="20" Champion="1" Group="Gapers" ID="827" Image="resources/Entities/827.0.0 - Faceless.png" Kind="Enemies" Name="Faceless" Variant="0" Subtype="0" />
-	<entity BaseHP="25" Champion="1" Group="Gapers" ID="832" Image="resources/Entities/832.0.0 - Exorcist.png" Kind="Enemies" Name="Exorcist" Variant="0" Subtype="0" />
-	<entity BaseHP="35" Champion="1" Group="Gapers" ID="832" Image="resources/Entities/832.1.0 - Fanatic.png" Kind="Enemies" Name="Fanatic" Variant="1" Subtype="0" />
-	<entity BaseHP="25" Champion="1" Group="Gapers" ID="839" Image="resources/Entities/839.0.0 - Strifer.png" Kind="Enemies" Name="Strifer" Variant="0" Subtype="0" />
-	<entity BaseHP="16" Champion="1" Group="Gapers" ID="843" Image="resources/Entities/843.0.0 - Canary.png" Kind="Enemies" Name="Canary" Variant="0" Subtype="0" />
-	<entity BaseHP="18" Champion="1" Group="Gapers" ID="843" Image="resources/Entities/843.1.0 - Foreigner.png" Kind="Enemies" Name="Foreigner" Variant="1" Subtype="0" />
-	<entity BaseHP="26" Champion="1" Group="Gapers" ID="844" Image="resources/Entities/844.0.0 - Bombgagger.png" Kind="Enemies" Name="Bombgagger" Variant="1" Subtype="0" />
-	<entity BaseHP="20" Champion="1" Group="Gapers" ID="889" Image="resources/Entities/889.0.0 - Clickety Clack.png" Kind="Enemies" Name="Clickety Clack" Variant="0" Subtype="0" />
-	<entity BaseHP="12" Champion="1" Group="Gapers" ID="890" Image="resources/Entities/890.0.0 - Maze Roamer (white).png" Kind="Enemies" Name="Maze Roamer (white)" Variant="0" Subtype="0" />
-	<entity BaseHP="12" Champion="1" Group="Gapers" ID="890" Image="resources/Entities/890.0.1 - Maze Roamer (red).png" Kind="Enemies" Name="Maze Roamer (red)" Variant="0" Subtype="1" />
-	<entity BaseHP="18" Champion="1" Group="Gapers" ID="891" Image="resources/Entities/891.0.0 - Goat.png" Kind="Enemies" Name="Goat" Variant="0" Subtype="0" />
-	<entity BaseHP="24" Champion="1" Group="Gapers" ID="891" Image="resources/Entities/891.1.0 - Black Goat.png" Kind="Enemies" Name="Black Goat" Variant="1" Subtype="0" />
-	<entity BaseHP="10" Champion="1" Group="Gapers" ID="11" Image="resources/Entities/11.1.0 - Pacer.png" Kind="Enemies" Name="Pacer" Subtype="0" Variant="1" />
-	<entity BaseHP="10" Champion="1" Group="Gapers" ID="11" Image="resources/Entities/11.0.0 - Gusher.png" Kind="Enemies" Name="Gusher" Subtype="0" Variant="0" />
-	<entity BaseHP="10" Group="Gapers" ID="238" Image="resources/Entities/238.0.0 - Splasher.png" Kind="Enemies" Name="Splasher" Subtype="0" Variant="0" />
-	<entity BaseHP="20" Champion="1" Group="Gapers" ID="850" Image="resources/Entities/850.2.0 - Level 2 Gusher.png" Kind="Enemies" Name="Level 2 Gusher" Variant="2" Subtype="0" />
-	<entity BaseHP="10" Champion="1" Group="Gapers" ID="280" Image="resources/Entities/280.0.0 - Black Globin's Body.png" Kind="Enemies" Name="Black Globin's Body" Subtype="0" Variant="0" />
-	<entity BaseHP="10" Champion="1" Group="Gapers" ID="29" Image="resources/Entities/29.0.0 - Hopper.png" Kind="Enemies" Name="Hopper" Subtype="0" Variant="0" />
-	<entity BaseHP="20" Champion="1" Group="Gapers" ID="54" Image="resources/Entities/54.0.0 - Flaming Hopper.png" Kind="Enemies" Name="Flaming Hopper" Subtype="0" Variant="0" />
-	<entity BaseHP="20" Champion="1" Group="Gapers" ID="29" Image="resources/Entities/29.2.0 - Eggy.png" Kind="Enemies" Name="Eggy" Variant="2" Subtype="0" />
-	<entity BaseHP="25" Champion="1" Group="Gapers" ID="34" Image="resources/Entities/34.0.0 - Leaper.png" Kind="Enemies" Name="Leaper" Subtype="0" Variant="0" />
-	<entity BaseHP="28" Champion="1" Group="Gapers" ID="34" Image="resources/Entities/34.1.0 - Sticky Leaper.png" Kind="Enemies" Name="Sticky Leaper" Variant="1" Subtype="0" />
-	<entity BaseHP="10" Group="Gapers" ID="226" Image="resources/Entities/226.0.0 - Skinny.png" Kind="Enemies" Name="Skinny" Subtype="0" Variant="0" />
-	<entity BaseHP="16" Group="Gapers" ID="226" Image="resources/Entities/226.1.0 - Rotty.png" Kind="Enemies" Name="Rotty" Subtype="0" Variant="1" />
-	<entity BaseHP="12" Group="Gapers" ID="226" Image="resources/Entities/226.2.0 - Crispy.png" Kind="Enemies" Name="Crispy" Subtype="0" Variant="2" />
-	<entity BaseHP="8" Group="Gapers" ID="227" Image="resources/Entities/227.0.0 - Boney Head.png" Kind="Enemies" Name="Boney" Subtype="0" Variant="0" />
-	<entity BaseHP="8" Group="Gapers" ID="277" Image="resources/Entities/277.0.0 - Black Bony.png" Kind="Enemies" Name="Black Bony" Subtype="0" Variant="0" />
-	<entity BaseHP="60" Champion="1" Group="Gapers" ID="227" Image="resources/Entities/227.1.0 - Holy Bony.png" Kind="Enemies" Name="Holy Bony" Variant="1" Subtype="0" />
-	<entity BaseHP="20" Champion="1" Group="Gapers" ID="841" Image="resources/Entities/841.0.0 - Revenant.png" Kind="Enemies" Name="Revenant" Variant="0" Subtype="0" />
-	<entity BaseHP="35" Champion="1" Group="Gapers" ID="841" Image="resources/Entities/841.1.0 - Quad Revenant.png" Kind="Enemies" Name="Quad Revenant" Variant="1" Subtype="0" />
-	<entity BaseHP="33" Champion="1" Group="Gapers" ID="24" Image="resources/Entities/24.0.0 - Globin.png" Kind="Enemies" Name="Globin" Subtype="0" Variant="0" />
-	<entity BaseHP="33" Champion="1" Group="Gapers" ID="24" Image="resources/Entities/24.1.0 - Gazing Globin.png" Kind="Enemies" Name="Gazing Globin" Subtype="0" Variant="1" />
-	<entity BaseHP="125" Champion="1" Group="Gapers" ID="857" Image="resources/Entities/857.0.0 - Cohort.png" Kind="Enemies" Name="Cohort" Variant="0" Subtype="0" />
-	<entity BaseHP="33" Champion="1" Group="Gapers" ID="24" Image="resources/Entities/24.2.0 - Dank Globin.png" Kind="Enemies" Name="Dank Globin" Subtype="0" Variant="2" />
-	<entity BaseHP="33" Champion="1" Group="Gapers" ID="278" Image="resources/Entities/278.0.0 - Black Globin.png" Kind="Enemies" Name="Black Globin" Subtype="0" Variant="0" />
-	<entity BaseHP="20" Champion="1" Group="Gapers" ID="279" Image="resources/Entities/279.0.0 - Black Globin's Head.png" Kind="Enemies" Name="Black Globin's Head" Subtype="0" Variant="0" />
-	<entity BaseHP="33" Champion="1" Group="Gapers" ID="24" Image="resources/Entities/24.3.0 - Cursed Globin.png" Kind="Enemies" Name="Cursed Globin" Variant="3" Subtype="0" />
-	
+	<group Name="Top Grids">
+		<group Label="Events">
+			<defaults>
+				<entity>
+					<tag>Grid</tag>
+					<tag>InEmptyRooms</tag>
+					<tag>InNonCombatRooms</tag>
+				</entity>
+			</defaults>
+			<entity ID="1009" Image="Entities/1009.0.0 - Rock (event).png" Name="Rock (event)" Subtype="0" Variant="0" EditorImage="Backgrounds/rocks_generic.png" UseRockTiling="1" OverlayImage="Overlays/Event.png"/>
+			<entity ID="3009" Image="Entities/3009.0.0 - Pit (event).png" Name="Pit (event)" Subtype="0" Variant="0" EditorImage="Backgrounds/pit_generic.png" UsePitTiling="1" OverlayImage="Overlays/Event.png"/>
+			<group Name="Numbered Events">
+				<defaults>
+					<entity>
+						<tag>NumberedEvents</tag>
+					</entity>
+				</defaults>
+				<entity ID="969" Image="Entities/969.0.0 - Event (group 0).png" Name="Event (group 0)" Subtype="0" Variant="0" />
+				<entity ID="969" Image="Entities/969.1.0 - Event (group 1).png" Name="Event (group 1)" Subtype="0" Variant="1" />
+				<entity ID="969" Image="Entities/969.2.0 - Event (group 2).png" Name="Event (group 2)" Subtype="0" Variant="2" />
+				<entity ID="969" Image="Entities/969.3.0 - Event (group 3).png" Name="Event (group 3)" Subtype="0" Variant="3" />
+			</group>
+			<entity ID="969" Image="Entities/969.9.0 - Event (After Cleaning).png" Name="Event (Room Clear)" Subtype="0" Variant="9" />
+			<group Name="Event Plates">
+				<defaults>
+					<entity>
+						<tag>EventPlates</tag>
+					</entity>
+				</defaults>
+				<entity ID="4500" Image="Entities/4500.10.0 - Event Plate (group 0).png" Name="Event Plate (group 0)" Subtype="0" Variant="10" />
+				<entity ID="4500" Image="Entities/4500.11.0 - Event Plate (group 1).png" Name="Event Plate (group 1)" Subtype="0" Variant="11" />
+				<entity ID="4500" Image="Entities/4500.12.0 - Event Plate (group 2).png" Name="Event Plate (group 2)" Subtype="0" Variant="12" />
+				<entity ID="4500" Image="Entities/4500.13.0 - Event Plate (group 3).png" Name="Event Plate (group 3)" Subtype="0" Variant="13" />
+			</group>
+			<entity ID="970" Image="Entities/970.1.11 - Force Water.png" Name="Force Water" Subtype="11" Variant="1" />
+		</group>
+	</group>
 
-	<!-- Hosts -->
-	<entity BaseHP="15" Champion="1" Group="Hosts" ID="27" Image="resources/Entities/27.0.0 - Host.png" Kind="Enemies" Name="Host" Subtype="0" Variant="0" />
-	<entity BaseHP="20" Champion="1" Group="Hosts" ID="204" Image="resources/Entities/204.0.0 - Mobile Host.png" Kind="Enemies" Name="Mobile Host" Subtype="0" Variant="0" />
-	<entity BaseHP="15" Champion="1" Group="Hosts" ID="27" Image="resources/Entities/27.1.0 - Red Host.png" Kind="Enemies" Name="Red Host" Subtype="0" Variant="1" />
-	<entity BaseHP="27" Champion="1" Group="Hosts" ID="247" Image="resources/Entities/247.0.0 - Flesh Mobile Host.png" Kind="Enemies" Name="Flesh Mobile Host" Subtype="0" Variant="0" />
-	<entity BaseHP="6.5" Group="Hosts" ID="815" Image="resources/Entities/815.0.0 - Fissure.png" Kind="Enemies" Name="Fissure" Variant="0" Subtype="0" />
-	<entity BaseHP="15" Champion="1" Group="Hosts" ID="27" Image="resources/Entities/27.3.0 - Hard Host.png" Kind="Enemies" Name="Hard Host" Variant="3" Subtype="0" />
-	<entity BaseHP="20" Champion="1" Group="Hosts" ID="859" Image="resources/Entities/859.0.0 - Floating Host.png" Kind="Enemies" Name="Floating Host" Variant="0" Subtype="0" />
-	<entity Group="Hosts" Kind="Enemies" Image="resources/Entities/300.0.0 - MushroomMan.png" BaseHP="23" Champion="1" ID="300" Name="Mushroom" Variant="0" Subtype="0" />
+	<group Name="Normal Poops">
+		<entity ID="1500" Image="Entities/1500.0.1 - Poop (non-replaceable).png" Name="Poop (non-replaceable)" Subtype="1" Variant="0" OverlayImage="Overlays/NonRandom.png" EditorImage="Entities/1500.0.0 - Poop.png" />
+	</group>
 
-	<!-- Knights -->
-	<entity BaseHP="20" Champion="1" Group="Knights" ID="41" Image="resources/Entities/41.0.0 - Knight.png" Kind="Enemies" Name="Knight" Subtype="0" Variant="0" />
-	<entity BaseHP="20" Champion="1" Group="Knights" ID="254" Image="resources/Entities/254.0.0 - Floating Knight.png" Kind="Enemies" Name="Floating Knight" Subtype="0" Variant="0" />
-	<entity BaseHP="20" Champion="1" Group="Knights" ID="41" Image="resources/Entities/41.1.0 - Selfless Knight.png" Kind="Enemies" Name="Selfless Knight" Subtype="0" Variant="1" />
-	<entity BaseHP="20" Champion="1" Group="Knights" ID="283" Image="resources/Entities/283.0.0 - Bone Knight.png" Kind="Enemies" Name="Bone Knight" Subtype="0" Variant="0" />
-	<entity BaseHP="20" Champion="1" Group="Knights" ID="41" Image="resources/Entities/41.2.0 - Loose Knight.png" Kind="Enemies" Name="Loose Knight" Variant="2" Subtype="0" />
-	<entity BaseHP="20" Group="Knights" ID="41" Image="resources/Entities/41.3.0 - Brainless Knight.png" Kind="Enemies" Name="Brainless Knight" Variant="3" Subtype="0" />
-	<entity BaseHP="30" Champion="1" Group="Knights" ID="41" Image="resources/Entities/41.4.0 - Black Knight.png" Kind="Enemies" Name="Black Knight" Variant="4" Subtype="0" />
-	<entity BaseHP="35" Champion="1" Group="Knights" ID="834" Image="resources/Entities/834.0.0 - Whipper.png" Kind="Enemies" Name="Whipper" Variant="0" Subtype="0" />
-	<entity BaseHP="35" Champion="1" Group="Knights" ID="834" Image="resources/Entities/834.1.0 - Snapper.png" Kind="Enemies" Name="Snapper" Variant="1" Subtype="0" />
-	<entity BaseHP="42" Champion="1" Group="Knights" ID="834" Image="resources/Entities/834.2.0 - Flagellant.png" Kind="Enemies" Name="Flagellant" Variant="2" Subtype="0" />
+	<group Name="Chunky Poops">
+		<entity ID="1495" Image="Entities/1495.0.1 - Chunky Poop (non-replaceable).png" Name="Chunky Poop (non-replaceable)" Subtype="1" Variant="0" OverlayImage="Overlays/NonRandom.png" EditorImage="Entities/1495.0.0 - Chunky Poop.png" />
+	</group>
 
-	<!-- Lumps -->
-	<entity BaseHP="30" Champion="1" Group="Lumps" ID="56" Image="resources/Entities/56.0.0 - Lump.png" Kind="Enemies" Name="Lump" Subtype="0" Variant="0" />
-	<entity BaseHP="35" Champion="1" Group="Lumps" ID="58" Image="resources/Entities/58.0.0 - Para-Bite.png" Kind="Enemies" Name="Para-Bite" Subtype="0" Variant="0" />
-	<entity BaseHP="35" Champion="1" Group="Lumps" ID="58" Image="resources/Entities/58.1.0 - Scarred Para-Bite.png" Kind="Enemies" Name="Scarred Para-Bite" Subtype="0" Variant="1" />
-	<entity BaseHP="20" Champion="1" Group="Lumps" ID="59" Image="resources/Entities/59.0.0 - Fred.png" Kind="Enemies" Name="Fred" Subtype="0" Variant="0" />
-	<entity Group="Lumps" Kind="Enemies" Image="resources/Entities/307.0.0 - Tar Boy.png" BaseHP="55" Champion="1" ID="307" Name="Tar Boy" Variant="0" Subtype="0" />
+	<group Name="Poops">
+		<entity ID="1501" Image="Entities/1501.0.0 - Charming Poop.png" Name="Charming Poop" Subtype="0" Variant="0" />
+	</group>
 
-	<!-- Maws -->
-	<entity BaseHP="10" Champion="1" Group="Maws" ID="12" Image="resources/Entities/12.0.0 - Horf.png" Kind="Enemies" Name="Horf" Subtype="0" Variant="0" />
-	<entity BaseHP="10" Champion="1" Group="Maws" ID="248" Image="resources/Entities/248.0.0 - Psychic Horf.png" Kind="Enemies" Name="Psychic Horf" Subtype="0" Variant="0" />
-	<entity BaseHP="14" Champion="1" Group="Maws" ID="812" Image="resources/Entities/812.0.0 - Sub Horf.png" Kind="Enemies" Name="Sub Horf" Variant="0" Subtype="0" />
-	<entity BaseHP="20" Champion="1" Group="Maws" ID="850" Image="resources/Entities/850.1.0 - Level 2 Horf.png" Kind="Enemies" Name="Level 2 Horf" Variant="1" Subtype="0" />
-	<entity BaseHP="20" Champion="1" Group="Maws" ID="26" Image="resources/Entities/26.0.0 - Maw.png" Kind="Enemies" Name="Maw" Subtype="0" Variant="0" />
-	<entity BaseHP="20" Champion="1" Group="Maws" ID="26" Image="resources/Entities/26.1.0 - Red Maw.png" Kind="Enemies" Name="Red Maw" Subtype="0" Variant="1" />
-	<entity BaseHP="20" Champion="1" Group="Maws" ID="26" Image="resources/Entities/26.2.0 - Psychic Maw.png" Kind="Enemies" Name="Psychic Maw" Subtype="0" Variant="2" />
-	<entity BaseHP="25" Group="Maws" ID="35" Image="resources/Entities/35.0.0 - Mr. Maw.png" Kind="Enemies" Name="Mr. Maw" Subtype="0" Variant="0" />
-	<entity BaseHP="25" Group="Maws" ID="35" Image="resources/Entities/35.2.0 - Mr. Red Maw.png" Kind="Enemies" Name="Mr. Red Maw" Subtype="0" Variant="2" />
-	<entity BaseHP="20" Champion="0" Group="Maws" ID="311" Image="resources/Entities/311.0.0 - Mr. Mine.png" Kind="Enemies" Name="Mr. Mine" Subtype="0" Variant="0" />
-	<entity BaseHP="38" Group="Maws" ID="216" Image="resources/Entities/216.0.0 - Swinger.png" Kind="Enemies" Name="Swinger" Subtype="0" Variant="0" />
-	<entity BaseHP="36" Champion="1" Group="Maws" ID="86" Image="resources/Entities/86.0.0 - Keeper.png" Kind="Enemies" Name="Keeper" Subtype="0" Variant="0" />
-	<entity BaseHP="20" Group="Maws" ID="212" Image="resources/Entities/212.0.0 - Death's Head.png" Kind="Enemies" Name="Death's Head" Subtype="0" Variant="0" />
-	<entity BaseHP="20" Group="Maws" ID="212" Image="resources/Entities/212.1.0 - Dank Death's Head.png" Kind="Enemies" Name="Dank Death's Head" Subtype="0" Variant="1" />
-	<entity BaseHP="50" Group="Maws" ID="286" Image="resources/Entities/286.0.0 - Flesh Death's Head.png" Kind="Enemies" Name="Flesh Death's Head" Subtype="0" Variant="0" />
-	<entity BaseHP="20" Group="Maws" ID="212" Image="resources/Entities/212.2.0 - Cursed Death's Head.png" Kind="Enemies" Name="Cursed Death's Head" Variant="2" Subtype="0" />
-	<entity BaseHP="20" Group="Maws" ID="212" Image="resources/Entities/212.3.0 - Brimstone Death's Head.png" Kind="Enemies" Name="Brimstone Death's Head" Variant="3" Subtype="0" />
-	<entity BaseHP="80" Group="Maws" ID="212" Image="resources/Entities/212.4.0 - Redskull.png" Kind="Enemies" Name="Redskull" Variant="4" Subtype="0" />
-	<entity BaseHP="20" Group="Maws" ID="887" Image="resources/Entities/887.0.0 - Dusty Death's Head (left).png" Kind="Enemies" Name="Dusty Death's Head (left)" Variant="0" Subtype="0" />
-	<entity BaseHP="20" Group="Maws" ID="887" Image="resources/Entities/887.0.1 - Dusty Death's Head (right).png" Kind="Enemies" Name="Dusty Death's Head (right)" Variant="0" Subtype="1" />
-	<entity BaseHP="22" Champion="1" Group="Maws" ID="828" Image="resources/Entities/828.0.0 - Necro.png" Kind="Enemies" Name="Necro" Variant="0" Subtype="0" />
+	<group Name="Retracting Spikes">
+		<entity ID="1931" Image="Entities/1931.1.0 - Retracting Spikes (Down 1).png" Name="Retracting Spikes (Down 1/5)" Subtype="0" Variant="1" />
+		<entity ID="1931" Image="Entities/1931.2.0 - Retracting Spikes (Down 2).png" Name="Retracting Spikes (Down 2/5)" Subtype="0" Variant="2" />
+		<entity ID="1931" Image="Entities/1931.3.0 - Retracting Spikes (Down 3).png" Name="Retracting Spikes (Down 3/5)" Subtype="0" Variant="3" />
+		<entity ID="1931" Image="Entities/1931.4.0 - Retracting Spikes (Down 4).png" Name="Retracting Spikes (Down 4/5)" Subtype="0" Variant="4" />
+		<entity ID="1931" Image="Entities/1931.5.0 - Retracting Spikes (Down 5).png" Name="Retracting Spikes (Down 5/5)" Subtype="0" Variant="5" />
+		<entity ID="1931" Image="Entities/1931.6.0 - Retracting Spikes (Up 1).png" Name="Retracting Spikes (Up 1/5)" Subtype="0" Variant="6" />
+		<entity ID="1931" Image="Entities/1931.7.0 - Retracting Spikes (Up 2).png" Name="Retracting Spikes (Up 2/5)" Subtype="0" Variant="7" />
+		<entity ID="1931" Image="Entities/1931.8.0 - Retracting Spikes (Up 3).png" Name="Retracting Spikes (Up 3/5)" Subtype="0" Variant="8" />
+		<entity ID="1931" Image="Entities/1931.9.0 - Retracting Spikes (Up 4).png" Name="Retracting Spikes (Up 4/5)" Subtype="0" Variant="9" />
+		<entity ID="1931" Image="Entities/1931.10.0 - Retracting Spikes (Up 5).png" Name="Retracting Spikes (Up 5/5)" Subtype="0" Variant="10" />
+	</group>
 
-	<!-- Mulligans -->
-	<entity BaseHP="13" Champion="1" Group="Mulligans" ID="16" Image="resources/Entities/16.0.0 - Mulligan.png" Kind="Enemies" Name="Mulligan" Subtype="0" Variant="0" />
-	<entity BaseHP="13" Champion="1" Group="Mulligans" ID="16" Image="resources/Entities/16.1.0 - Mulligoon.png" Kind="Enemies" Name="Mulligoon" Subtype="0" Variant="1" />
-	<entity BaseHP="13" Champion="1" Group="Mulligans" ID="16" Image="resources/Entities/16.2.0 - Mulliboom.png" Kind="Enemies" Name="Mulliboom" Subtype="0" Variant="2" />
-	<entity BaseHP="20" Champion="1" Group="Mulligans" ID="22" Image="resources/Entities/22.0.0 - Hive.png" Kind="Enemies" Name="Hive" Subtype="0" Variant="0" />
-	<entity BaseHP="20" Champion="1" Group="Mulligans" ID="205" Image="resources/Entities/205.0.0 - Nest.png" Kind="Enemies" Name="Nest" Subtype="0" Variant="0" />
-	<entity BaseHP="18" Champion="1" Group="Mulligans" ID="22" Image="resources/Entities/22.1.0 - Drowned Hive.png" Kind="Enemies" Name="Drowned Hive" Subtype="0" Variant="1" />
-	<entity BaseHP="14" Champion="1" Group="Mulligans" ID="817" Image="resources/Entities/817.0.0 - Prey.png" Kind="Enemies" Name="Prey" Variant="0" Subtype="0" />
-	<entity BaseHP="14" Champion="1" Group="Mulligans" ID="817" Image="resources/Entities/817.1.0 - Mullighoul.png" Kind="Enemies" Name="Mullighoul" Variant="1" Subtype="0" />
-	<entity BaseHP="13" Champion="1" Group="Mulligans" ID="874" Image="resources/Entities/874.0.0 - Fartigan.png" Kind="Enemies" Name="Fartigan" Variant="0" Subtype="0" />
-	<entity BaseHP="60" Champion="1" Group="Mulligans" ID="310" Image="resources/Entities/310.0.0 - Leper.png" Kind="Enemies" Name="Leper" Subtype="0" Variant="0" />
-	<entity BaseHP="45" Champion="1" Group="Mulligans" ID="310" Image="resources/Entities/310.0.1 - Leper (stage 2).png" Kind="Enemies" Name="Leper (stage 2)" Subtype="1" Variant="0" />
-	<entity BaseHP="30" Champion="1" Group="Mulligans" ID="310" Image="resources/Entities/310.0.2 - Leper (stage 3).png" Kind="Enemies" Name="Leper (stage 3)" Subtype="2" Variant="0" />
-	<entity BaseHP="15" Champion="1" Group="Mulligans" ID="310" Image="resources/Entities/310.0.3 - Leper (stage 4).png" Kind="Enemies" Name="Leper (stage 4)" Subtype="3" Variant="0" />
-	<entity BaseHP="40" Champion="1" Group="Mulligans" ID="22" Image="resources/Entities/22.2.0 - Holy Mulligan.png" Kind="Enemies" Name="Holy Mulligan" Variant="2" Subtype="0" />
-	<entity BaseHP="30" Champion="1" Group="Mulligans" ID="822" Image="resources/Entities/822.0.0 - Bouncer.png" Kind="Enemies" Name="Bouncer" Variant="0" Subtype="0" />
+	<group Name="Troll Bombs">
+		<entity ID="5" Image="Entities/5.40.6 - Golden Troll Bomb.png" Name="Golden Troll Bomb" Variant="40" Subtype="6" />
+	</group>
 
-	<!-- Organs -->
-	<entity BaseHP="20" Champion="1" Group="Organs" ID="32" Image="resources/Entities/32.0.0 - Brain.png" Kind="Enemies" Name="Brain" Subtype="0" Variant="0" />
-	<entity Group="Organs" Kind="Enemies" Image="resources/Entities/301.0.0 - PoisonMind.png" BaseHP="20" Champion="1" ID="301" Name="Poison Mind" Variant="0" Subtype="0" />
-	<entity BaseHP="62" Champion="1" Group="Organs" ID="57" Image="resources/Entities/57.0.0 - MemBrain.png" Kind="Enemies" Name="MemBrain" Subtype="0" Variant="0" />
-	<entity BaseHP="20" Champion="1" Group="Organs" ID="840" Image="resources/Entities/840.0.0 - Pon.png" Kind="Enemies" Name="Pon" Variant="0" Subtype="0" />
-	<entity BaseHP="25" Champion="1" Group="Organs" ID="40" Image="resources/Entities/40.0.0 - Guts.png" Kind="Enemies" Name="Guts (Random)" Subtype="0" Variant="0" />
-	<entity BaseHP="25" Champion="1" Group="Organs" ID="40" Image="resources/Entities/40.0.1 - Guts (Left).png" Kind="Enemies" Name="Guts (Left)" Subtype="1" Variant="0" MirrorX="40.0.3" />
-	<entity BaseHP="25" Champion="1" Group="Organs" ID="40" Image="resources/Entities/40.0.2 - Guts (Up).png" Kind="Enemies" Name="Guts (Up)" Subtype="2" Variant="0" MirrorY="40.0.4" />
-	<entity BaseHP="25" Champion="1" Group="Organs" ID="40" Image="resources/Entities/40.0.3 - Guts (Right).png" Kind="Enemies" Name="Guts (Right)" Subtype="3" Variant="0" MirrorX="40.0.1" />
-	<entity BaseHP="25" Champion="1" Group="Organs" ID="40" Image="resources/Entities/40.0.4 - Guts (Down).png" Kind="Enemies" Name="Guts (Down)" Subtype="4" Variant="0" MirrorY="40.0.2" />
-	<entity BaseHP="25" Champion="1" Group="Organs" ID="40" Image="resources/Entities/40.1.0 - Scarred Guts.png" Kind="Enemies" Name="Scarred Guts (Random)" Subtype="0" Variant="1" />
-	<entity BaseHP="28" Champion="1" Group="Organs" ID="40" Image="resources/Entities/40.1.1 - Scarred Guts (Left).png" Kind="Enemies" Name="Scarred Guts (Left)" Subtype="1" Variant="1" MirrorX="40.1.3" />
-	<entity BaseHP="28" Champion="1" Group="Organs" ID="40" Image="resources/Entities/40.1.2 - Scarred Guts (Up).png" Kind="Enemies" Name="Scarred Guts (Up)" Subtype="2" Variant="1" MirrorY="40.1.4" />
-	<entity BaseHP="28" Champion="1" Group="Organs" ID="40" Image="resources/Entities/40.1.3 - Scarred Guts (Right).png" Kind="Enemies" Name="Scarred Guts (Right)" Subtype="3" Variant="1" MirrorX="40.1.1" />
-	<entity BaseHP="28" Champion="1" Group="Organs" ID="40" Image="resources/Entities/40.1.4 - Scarred Guts (Down).png" Kind="Enemies" Name="Scarred Guts (Down)" Subtype="4" Variant="1" MirrorY="40.1.2" />
-	<entity BaseHP="28" Champion="1" Group="Organs" ID="40" Image="resources/Entities/40.2.0 - Slog (random).png" Kind="Enemies" Name="Slog (random)" Variant="2" Subtype="0"/>
-	<entity BaseHP="28" Champion="1" Group="Organs" ID="40" Image="resources/Entities/40.2.1 - Slog (left).png" Kind="Enemies" Name="Slog (left)" Variant="2" Subtype="1" MirrorX="40.2.3" />
-	<entity BaseHP="28" Champion="1" Group="Organs" ID="40" Image="resources/Entities/40.2.2 - Slog (up).png" Kind="Enemies" Name="Slog (up)" Variant="2" Subtype="2" MirrorY="40.2.4" />
-	<entity BaseHP="28" Champion="1" Group="Organs" ID="40" Image="resources/Entities/40.2.3 - Slog (right).png" Kind="Enemies" Name="Slog (right)" Variant="2" Subtype="3" MirrorX="40.2.1" />
-	<entity BaseHP="28" Champion="1" Group="Organs" ID="40" Image="resources/Entities/40.2.4 - Slog (down).png" Kind="Enemies" Name="Slog (down)" Variant="2" Subtype="4" MirrorY="40.2.2" />
-	<entity BaseHP="25" Champion="1" Group="Organs" ID="862" Image="resources/Entities/862.0.0 - Cyst (random).png" Kind="Enemies" Name="Cyst (random)" Variant="0" Subtype="0" />
-	<entity BaseHP="25" Champion="1" Group="Organs" ID="862" Image="resources/Entities/862.0.1 - Cyst (left).png" Kind="Enemies" Name="Cyst (left)" Variant="0" Subtype="1" MirrorX="862.0.3" />
-	<entity BaseHP="25" Champion="1" Group="Organs" ID="862" Image="resources/Entities/862.0.2 - Cyst (up).png" Kind="Enemies" Name="Cyst (up)" Variant="0" Subtype="2" MirrorY="862.0.4" />
-	<entity BaseHP="25" Champion="1" Group="Organs" ID="862" Image="resources/Entities/862.0.3 - Cyst (right).png" Kind="Enemies" Name="Cyst (right)" Variant="0" Subtype="3" MirrorX="862.0.1" />
-	<entity BaseHP="25" Champion="1" Group="Organs" ID="862" Image="resources/Entities/862.0.4 - Cyst (down).png" Kind="Enemies" Name="Cyst (down)" Variant="0" Subtype="4" MirrorY="862.0.2" />
-	<entity BaseHP="62" Champion="1" Group="Organs" ID="57" Image="resources/Entities/57.1.0 - Mama Guts.png" Kind="Enemies" Name="Mama Guts" Subtype="0" Variant="1" />
-	<entity BaseHP="62" Champion="1" Group="Organs" ID="57" Image="resources/Entities/57.2.0 - Dead Meat.png" Kind="Enemies" Name="Dead Meat" Variant="2" Subtype="0" />
-	<entity BaseHP="20" Champion="1" Group="Organs" ID="60" Image="resources/Entities/60.0.0 - Eye.png" Kind="Enemies" Name="Eye" Subtype="0" Variant="0" />
-	<entity BaseHP="20" Champion="1" Group="Organs" ID="60" Image="resources/Entities/60.1.0 - Bloodshot Eye.png" Kind="Enemies" Name="Bloodshot Eye" Subtype="0" Variant="1" />
-	<entity BaseHP="20" Champion="1" Group="Organs" ID="60" Image="resources/Entities/60.2.0 - Holy Eye.png" Kind="Enemies" Name="Holy Eye" Variant="2" Subtype="0" />
-	<entity BaseHP="40" Group="Organs" ID="92" Image="resources/Entities/92.0.0 - Heart.png" Kind="Enemies" Name="Heart" Subtype="0" Variant="0" />
-	<entity BaseHP="40" Group="Organs" ID="93" Image="resources/Entities/93.0.0 - Mask.png" Kind="Enemies" Name="Mask" Subtype="0" Variant="0" />
-	<entity BaseHP="40" Group="Organs" ID="92" Image="resources/Entities/92.1.0 - 1_2 Heart.png" Kind="Enemies" Name="1/2 Heart" Variant="1" Subtype="0" />
-	<entity BaseHP="40" Group="Organs" ID="92" Image="resources/Entities/92.1.1 - 1_2 Heart.png" Kind="Enemies" Name="1/2 Heart" Variant="1" Subtype="1" />
-	<entity BaseHP="40" Group="Organs" ID="93" Image="resources/Entities/93.1.0 - Mask II.png" Kind="Enemies" Name="Mask II" Variant="1" Subtype="0" />
-	<entity BaseHP="20" Group="Organs" ID="213" Image="resources/Entities/213.0.0 - Mom's Hand.png" Kind="Enemies" Name="Mom's Hand" Subtype="0" Variant="0" />
-	<entity BaseHP="20" Group="Organs" ID="287" Image="resources/Entities/287.0.0 - Mom's Dead Hand.png" Kind="Enemies" Name="Mom's Dead Hand" Subtype="0" Variant="0" />
-	<entity BaseHP="20" Group="Organs" ID="229" Image="resources/Entities/229.0.0 - Tumor.png" Kind="Enemies" Name="Tumor" Subtype="0" Variant="0" />
-	<entity BaseHP="28" Champion="1" Group="Organs" ID="229" Image="resources/Entities/229.1.0 - Planetoid.png" Kind="Enemies" Name="Planetoid" Variant="1" Subtype="0" />
-	<entity BaseHP="40" Group="Organs" ID="253" Image="resources/Entities/253.0.0 - Psy Tumor.png" Kind="Enemies" Name="Psy Tumor" Subtype="0" Variant="0" />
-	<entity BaseHP="32" Group="Organs" ID="230" Image="resources/Entities/230.0.0 - Camillo Jr.png" Kind="Enemies" Name="Camillo Jr." Subtype="0" Variant="0" />
-	<entity BaseHP="20" Group="Organs" ID="231" Image="resources/Entities/231.0.0 - Nerve Ending.png" Kind="Enemies" Name="Nerve Ending" Subtype="0" Variant="0" />
-	<entity BaseHP="20" Group="Organs" ID="231" Image="resources/Entities/231.1.0 - Nerve Ending 2.png" Kind="Enemies" Name="Nerve Ending 2" Subtype="0" Variant="1" />
-	<entity BaseHP="80" Champion="1" Group="Organs" ID="856" Image="resources/Entities/856.0.0 - Gasbag.png" Kind="Enemies" Name="Gasbag" Variant="0" Subtype="0" />
-	<entity BaseHP="40" Group="Organs" ID="864" Image="resources/Entities/864.0.0 - Mockulus.png" Kind="Enemies" Name="Mockulus" Variant="0" Subtype="0" />
+	<group Name="Beggars">
+		<entity ID="6" Image="Entities/6.13.0 - Battery Bum.png" Name="Battery Bum" Variant="13" Subtype="0" />
+		<entity ID="6" Image="Entities/6.18.0 - Rotten Beggar.png" Name="Rotten Beggar" Variant="18" Subtype="0" />
+	</group>
 
-	<!-- Other -->
-	<entity BaseHP="40" Group="Other" ID="90" Image="resources/Entities/90.0.0 - Hanger.png" Kind="Enemies" Name="Hanger" Subtype="0" Variant="0" />
-	<entity BaseHP="25" Group="Other" ID="219" Image="resources/Entities/219.0.0 - Wizoob.png" Kind="Enemies" Name="Wizoob" Subtype="0" Variant="0" />
-	<entity BaseHP="25" Group="Other" ID="285" Image="resources/Entities/285.0.0 - Red Ghost.png" Kind="Enemies" Name="Red Ghost" Subtype="0" Variant="0" />
-	<entity BaseHP="100" Group="Other" ID="224" Image="resources/Entities/224.0.0 - Oob.png" Kind="Enemies" Name="Oob" Subtype="0" Variant="0" />
-	<entity BaseHP="20" Group="Other" ID="225" Image="resources/Entities/225.0.0 - Black Maw.png" Kind="Enemies" Name="Black Maw" Subtype="0" Variant="0" />
-	<entity BaseHP="36" Group="Other" ID="228" Image="resources/Entities/228.0.0 - Homunculus.png" Kind="Enemies" Name="Homunculus" Subtype="0" Variant="0" />
-	<entity BaseHP="60" Group="Other" ID="251" Image="resources/Entities/251.0.0 - Begotten.png" Kind="Enemies" Name="Begotten" Subtype="0" Variant="0" />
-	<entity BaseHP="20" Group="Other" ID="234" Image="resources/Entities/234.0.0 - One Tooth.png" Kind="Enemies" Name="One Tooth" Subtype="0" Variant="0" />
-	<entity BaseHP="18" Champion="1" Group="Other" ID="803" Image="resources/Entities/803.0.0 - Blind Bat.png" Kind="Enemies" Name="Blind Bat" Variant="0" Subtype="0" />
-	<entity BaseHP="50" Group="Other" ID="258" Image="resources/Entities/258.0.0 - Fat Bat.png" Kind="Enemies" Name="Fat Bat" Subtype="0" Variant="0" />
-	<entity BaseHP="24" Champion="1" Group="Other" ID="237" Image="resources/Entities/237.0.0 - Gurgling.png" Kind="Enemies" Name="Gurgling" Subtype="0" Variant="0" />
-	<entity BaseHP="25" Group="Other" ID="260" Image="resources/Entities/260.10.0 - Lil' Haunt.png" Kind="Enemies" Name="Lil' Haunt" Subtype="0" Variant="10" />
-	<entity BaseHP="14" Champion="1" Group="Other" ID="816" Image="resources/Entities/816.0.0 - Polty.png" Kind="Enemies" Name="Polty" Variant="0" Subtype="0" />
-	<entity BaseHP="45" Champion="1" Group="Other" ID="816" Image="resources/Entities/816.1.0 - Kineti.png" Kind="Enemies" Name="Kineti" Variant="1" Subtype="0" />
-	<entity BaseHP="25" Champion="1" Group="Other" ID="833" Image="resources/Entities/833.0.0 - Candler.png" Kind="Enemies" Name="Candler" Variant="0" Subtype="0" />
-	<entity Group="Other" Kind="Enemies" Image="resources/Entities/306.0.0 - Portal.png" BaseHP="10" ID="306" Name="Portal" Variant="0" Subtype="0" />
-	<entity BaseHP="15" Group="Other" ID="306" Image="resources/Entities/306.1.0 - Lil Portal.png" Kind="Enemies" Name="Lil Portal" Variant="1" Subtype="0" />
-	<entity Group="Other" Kind="Enemies" Image="resources/Entities/308.0.0 - Fistuloid.png" BaseHP="30" Champion="1" ID="308" Name="Fistuloid" Variant="0" Subtype="0" />
-	<entity BaseHP="5" Champion="0" Group="Other" ID="310" Image="resources/Entities/311.1.0 - Leper Flesh.png" Kind="Enemies" Name="Leper Flesh" Subtype="0" Variant="1" />
-	<entity BaseHP="18" Champion="1" Group="Other" ID="824" Image="resources/Entities/824.0.0 - Gyro.png" Kind="Enemies" Name="Gyro" Variant="0" Subtype="0" />
-	<entity BaseHP="20" Champion="1" Group="Other" ID="824" Image="resources/Entities/824.1.0 - Grilled Gyro.png" Kind="Enemies" Name="Grilled Gyro" Variant="1" Subtype="0" />
-	<entity BaseHP="12" Champion="1" Group="Other" ID="829" Image="resources/Entities/829.0.0 - Mole.png" Kind="Enemies" Name="Mole" Variant="0" Subtype="0" />
-	<entity BaseHP="80" Group="Other" ID="837" Image="resources/Entities/837.0.0 - Henry.png" Kind="Enemies" Name="Henry" Variant="0" Subtype="0" />
-	<entity BaseHP="60" Champion="1" Group="Other" ID="863" Image="resources/Entities/863.0.0 - Morningstar.png" Kind="Enemies" Name="Morningstar" Variant="0" Subtype="0" />
-	<entity BaseHP="16" Champion="1" Group="Other" ID="873" Image="resources/Entities/873.0.0 - Fly Trap.png" Kind="Enemies" Name="Fly Trap" Variant="0" Subtype="0" />
-	<entity BaseHP="12" Champion="1" Group="Other" ID="875" Image="resources/Entities/875.0.0 - Poot Mine.png" Kind="Enemies" Name="Poot Mine" Variant="0" Subtype="0" />
-	<entity BaseHP="24" Champion="1" Group="Other" ID="880" Image="resources/Entities/880.0.0 - Flesh Maiden.png" Kind="Enemies" Name="Flesh Maiden" Variant="0" Subtype="0" />
-	<entity BaseHP="22" Champion="1" Group="Other" ID="882" Image="resources/Entities/882.0.0 - Dust.png" Kind="Enemies" Name="Dust" Variant="0" Subtype="0" />
-	<entity BaseHP="24" Champion="1" Group="Other" ID="885" Image="resources/Entities/885.0.0 - Cultist.png" Kind="Enemies" Name="Cultist" Variant="0" Subtype="0" />
-	<entity BaseHP="24" Champion="1" Group="Other" ID="885" Image="resources/Entities/885.1.0 - Blood Cultist.png" Kind="Enemies" Name="Blood Cultist" Variant="1" Subtype="0" />
-	<entity BaseHP="10" Group="Other" ID="404" Image="resources/Entities/404.1.0 - Dark Ball.png" Kind="Enemies" Name="Dark Ball" Subtype="0" Variant="1" />
-	<entity BaseHP="250" Boss="1" Group="Other" ID="866" Image="resources/Entities/866.0.0 - Dark Esau.png" Kind="Enemies" Name="Dark Esau" Variant="0" Subtype="0" />
+	<group Name="Shell Game">
+		<entity ID="6" Image="Entities/6.15.0 - Hell Game.png" Name="Hell Game" Variant="15" Subtype="0" />
+	</group>
 
-	<!-- Poop -->
-	<entity BaseHP="3" Group="Poop" ID="217" Image="resources/Entities/217.0.0 - Dip.png" Kind="Enemies" Name="Dip" Subtype="0" Variant="0" />
-	<entity BaseHP="3" Group="Poop" ID="870" Image="resources/Entities/870.0.0 - Drip.png" Kind="Enemies" Name="Drip" Variant="0" Subtype="0" />
-	<entity BaseHP="3" Group="Poop" ID="217" Image="resources/Entities/217.1.0 - Corn.png" Kind="Enemies" Name="Corn" Subtype="0" Variant="1" />
-	<entity BaseHP="3" Group="Poop" ID="217" Image="resources/Entities/217.2.0 - Brownie Corn.png" Kind="Enemies" Name="Brownie Corn" Subtype="0" Variant="2" />
-	<entity BaseHP="6" Group="Poop" ID="217" Image="resources/Entities/217.3.0 - Big Corn.png" Kind="Enemies" Name="Big Corn" Variant="3" Subtype="0" />
-	<entity BaseHP="15" Group="Poop" ID="220" Image="resources/Entities/220.0.0 - Squirt.png" Kind="Enemies" Name="Squirt" Subtype="0" Variant="0" />
-	<entity BaseHP="15" Group="Poop" ID="220" Image="resources/Entities/220.1.0 - Dank Squirt.png" Kind="Enemies" Name="Dank Squirt" Subtype="0" Variant="1" />
-	<entity BaseHP="15" Group="Poop" ID="871" Image="resources/Entities/871.0.0 - Splurt.png" Kind="Enemies" Name="Splurt" Variant="0" Subtype="0" />
-	<entity BaseHP="42" Champion="1" Group="Poop" ID="826" Image="resources/Entities/826.0.0 - Hardy.png" Kind="Enemies" Name="Hardy" Variant="0" Subtype="0" />
-	<entity BaseHP="62" Group="Poop" ID="223" Image="resources/Entities/223.0.0 - Dinga.png" Kind="Enemies" Name="Dinga" Subtype="0" Variant="0" />
-	<entity BaseHP="30" Group="Poop" ID="295" Image="resources/Entities/295.0.0 - Corn Mine.png" Kind="Enemies" Name="Corn Mine" Subtype="0" Variant="0" />
+	<group Name="Machines">
+		<entity ID="6" Image="Entities/6.16.0 - Crane Game.png" Name="Crane Game" Variant="16" Subtype="0" />
+		<entity ID="6" Image="Entities/6.17.0 - Confessional.png" Name="Confessional" Variant="17" Subtype="0" />
+	</group>
 
-	<!-- Spiders -->
-	<entity BaseHP="6.5" Group="Spiders" ID="85" Image="resources/Entities/85.0.0 - Spider.png" Kind="Enemies" Name="Spider" Subtype="0" Variant="0" />
-	<entity BaseHP="20" Group="Spiders" ID="94" Image="resources/Entities/94.0.0 - Big Spider.png" Kind="Enemies" Name="Big Spider" Subtype="0" Variant="0" />
-	<entity BaseHP="6.5" Group="Spiders" ID="814" Image="resources/Entities/814.0.0 - Strider.png" Kind="Enemies" Name="Strider" Variant="0" Subtype="0" />
-	<entity BaseHP="4.5" Group="Spiders" ID="884" Image="resources/Entities/884.0.0 - Swarm Spider.png" Kind="Enemies" Name="Swarm Spider" Variant="0" Subtype="0" />
-	<entity BaseHP="4.5" Group="Spiders" ID="884" Image="resources/Entities/884.0.2 - Swarm Spider (two).png" Kind="Enemies" Name="Swarm Spider (two)" Variant="0" Subtype="2" />
-	<entity BaseHP="4.5" Group="Spiders" ID="884" Image="resources/Entities/884.0.4 - Swarm Spider (four).png" Kind="Enemies" Name="Swarm Spider (four)" Variant="0" Subtype="4" />
-	<entity BaseHP="12" Group="Spiders" ID="818" Image="resources/Entities/818.0.0 - Rock Spider.png" Kind="Enemies" Name="Rock Spider (random)" Variant="0" Subtype="0" />
-	<entity BaseHP="12" Group="Spiders" ID="818" Image="resources/Entities/818.0.1 - Rock Spider.png" Kind="Enemies" Name="Rock Spider (subtype 1)" Variant="0" Subtype="1" />
-	<entity BaseHP="12" Group="Spiders" ID="818" Image="resources/Entities/818.0.2 - Rock Spider.png" Kind="Enemies" Name="Rock Spider (subtype 2)" Variant="0" Subtype="2" />
-	<entity BaseHP="12" Group="Spiders" ID="818" Image="resources/Entities/818.0.3 - Rock Spider.png" Kind="Enemies" Name="Rock Spider (subtype 3)" Variant="0" Subtype="3" />
-	<entity BaseHP="22" Group="Spiders" ID="818" Image="resources/Entities/818.1.0 - Tinted Rock Spider.png" Kind="Enemies" Name="Tinted Rock Spider (random)" Variant="1" Subtype="0" />
-	<entity BaseHP="22" Group="Spiders" ID="818" Image="resources/Entities/818.1.1 - Tinted Rock Spider.png" Kind="Enemies" Name="Tinted Rock Spider (subtype 1)" Variant="1" Subtype="1" />
-	<entity BaseHP="22" Group="Spiders" ID="818" Image="resources/Entities/818.1.2 - Tinted Rock Spider.png" Kind="Enemies" Name="Tinted Rock Spider (subtype 2)" Variant="1" Subtype="2" />
-	<entity BaseHP="22" Group="Spiders" ID="818" Image="resources/Entities/818.1.3 - Tinted Rock Spider.png" Kind="Enemies" Name="Tinted Rock Spider (subtype 3)" Variant="1" Subtype="3" />
-	<entity BaseHP="15" Group="Spiders" ID="818" Image="resources/Entities/818.2.0 - Coal Spider.png" Kind="Enemies" Name="Coal Spider (random)" Variant="2" Subtype="0" />
-	<entity BaseHP="15" Group="Spiders" ID="818" Image="resources/Entities/818.2.1 - Coal Spider.png" Kind="Enemies" Name="Coal Spider (subtype 1)" Variant="2" Subtype="1" />
-	<entity BaseHP="15" Group="Spiders" ID="818" Image="resources/Entities/818.2.2 - Coal Spider.png" Kind="Enemies" Name="Coal Spider (subtype 2)" Variant="2" Subtype="2" />
-	<entity BaseHP="15" Group="Spiders" ID="818" Image="resources/Entities/818.2.3 - Coal Spider.png" Kind="Enemies" Name="Coal Spider (subtype 3)" Variant="2" Subtype="3" />
-	<entity BaseHP="13" Group="Spiders" ID="215" Image="resources/Entities/215.0.0 - lvl2 Spider.png" Kind="Enemies" Name="lvl2 Spider" Subtype="0" Variant="0" />
-	<entity BaseHP="13" Group="Spiders" ID="250" Image="resources/Entities/250.0.0 - Ticking Spider.png" Kind="Enemies" Name="Ticking Spider" Subtype="0" Variant="0" />
-	<entity BaseHP="16" Champion="1" Group="Spiders" ID="869" Image="resources/Entities/869.0.0 - Migraine.png" Kind="Enemies" Name="Migraine" Variant="0" Subtype="0" />
-	<entity BaseHP="10" Champion="1" Group="Spiders" ID="29" Image="resources/Entities/29.1.0 - Trite.png" Kind="Enemies" Name="Trite" Subtype="0" Variant="1" />
-	<entity BaseHP="13" Champion="1" Group="Spiders" ID="246" Image="resources/Entities/246.0.0 - Ragling.png" Kind="Enemies" Name="Ragling" Subtype="0" Variant="0" />
-	<entity BaseHP="30" Group="Spiders" ID="246" Image="resources/Entities/246.1.0 - Rag Man's Ragling.png" Kind="Enemies" Name="Rag Man's Ragling" Subtype="0" Variant="1" />
-	<entity Group="Spiders" Kind="Enemies" Image="resources/Entities/303.0.0 - Blister.png" BaseHP="54" Champion="1" ID="303" Name="Blister" Variant="0" Subtype="0" />
-	<entity BaseHP="12" Champion="1" Group="Spiders" ID="206" Image="resources/Entities/206.1.0 - Small Baby Long Legs.png" Kind="Enemies" Name="Small Baby Long Legs" Subtype="0" Variant="1" />
-	<entity BaseHP="16" Champion="1" Group="Spiders" ID="206" Image="resources/Entities/206.0.0 - Baby Long Legs.png" Kind="Enemies" Name="Baby Long Legs" Subtype="0" Variant="0" />
-	<entity BaseHP="12" Champion="1" Group="Spiders" ID="207" Image="resources/Entities/207.1.0 - Small Crazy Long Legs.png" Kind="Enemies" Name="Small Crazy Long Legs" Subtype="0" Variant="1" />
-	<entity BaseHP="16" Champion="1" Group="Spiders" ID="207" Image="resources/Entities/207.0.0 - Crazy Long Legs.png" Kind="Enemies" Name="Crazy Long Legs" Subtype="0" Variant="0" />
-	<entity BaseHP="10" Group="Spiders" ID="240" Image="resources/Entities/240.0.0 - Wall Creep.png" PlaceVisual="WallSnap" Kind="Enemies" Name="Wall Creep" Subtype="0" Variant="0" />
-	<entity BaseHP="13.5" Group="Spiders" ID="240" Image="resources/Entities/240.1.0 - Soy Creep.png" PlaceVisual="WallSnap" Kind="Enemies" Name="Soy Creep" Variant="1" Subtype="0" />
-	<entity BaseHP="17" Group="Spiders" ID="240" Image="resources/Entities/240.2.0 - Rag Creep.png" PlaceVisual="WallSnap" Kind="Enemies" Name="Rag Creep" Variant="2" Subtype="0" />
-	<entity BaseHP="10" Group="Spiders" ID="242" Image="resources/Entities/242.0.0 - Blind Creep.png" PlaceVisual="WallSnap" Kind="Enemies" Name="Blind Creep" Subtype="0" Variant="0" />
-	<entity BaseHP="15" Group="Spiders" ID="304" Image="resources/Entities/304.0.0 - TheThing.png" PlaceVisual="WallSnap" Kind="Enemies" Name="The Thing" Variant="0" Subtype="0" Champion="1" />
-	<entity BaseHP="10" Group="Spiders" ID="241" Image="resources/Entities/241.0.0 - Rage Creep.png" PlaceVisual="WallSnap" Kind="Enemies" Name="Rage Creep" Subtype="0" Variant="0" />
-	<entity BaseHP="16" Champion="1" Group="Spiders" ID="241" Image="resources/Entities/241.1.0 - Split Rage Creep.png" PlaceVisual="WallSnap" Kind="Enemies" Name="Split Rage Creep" Variant="1" Subtype="0" />
-	
+	<group Name="Special Enemies">
+		<entity BaseHP="25" Tags="Champion" ID="832" Image="Entities/832.0.0 - Exorcist.png" Name="Exorcist" Variant="0" Subtype="0"/>
+		<entity BaseHP="35" Tags="Champion" ID="832" Image="Entities/832.1.0 - Fanatic.png" Name="Fanatic" Variant="1" Subtype="0"/>
+		<entity BaseHP="6" ID="61" Image="Entities/61.6.0 - Bloodfly.png" Name="Bloodfly" Variant="6" Subtype="0"/>
+		<entity BaseHP="20" ID="802" Image="Entities/802.0.0 - Blood Puppy.png" Name="Blood Puppy (lvl 2)" Variant="0" Subtype="0" />
+		<entity BaseHP="50" ID="802" Image="Entities/802.1.0 - Blood Puppy.png" Name="Blood Puppy (lvl 3)" Variant="1" Subtype="0" />
+	</group>
 
-	<!-- Spikes -->
-	<entity BaseHP="100" Group="Spikes" ID="44" Image="resources/Entities/44.0.0 - Poky.png" PlaceVisual="0,0.5" Kind="Enemies" Name="Poky" Subtype="0" Variant="0" />
-	<entity BaseHP="100" Group="Spikes" ID="44" Image="resources/Entities/44.1.0 - Slide.png" PlaceVisual="0,0.5" Kind="Enemies" Name="Slide" Subtype="0" Variant="1" />
-	<entity BaseHP="100" Group="Spikes" ID="218" Image="resources/Entities/218.0.0 - Wall Hugger.png" PlaceVisual="0,0.5" Kind="Enemies" Name="Wall Hugger (Random)" Subtype="0" Variant="0" />
-	<entity BaseHP="100" Group="Spikes" ID="218" Image="resources/Entities/218.0.1 - Wall Hugger (Left).png" PlaceVisual="0,0.3" Kind="Enemies" Name="Wall Hugger (Left)" Subtype="1" Variant="0" MirrorX="218.0.3" />
-	<entity BaseHP="100" Group="Spikes" ID="218" Image="resources/Entities/218.0.2 - Wall Hugger (Up).png" PlaceVisual="0,0.5" Kind="Enemies" Name="Wall Hugger (Up)" Subtype="2" Variant="0" MirrorY="218.0.4" />
-	<entity BaseHP="100" Group="Spikes" ID="218" Image="resources/Entities/218.0.3 - Wall Hugger (Right).png" PlaceVisual="0,0.3" Kind="Enemies" Name="Wall Hugger (Right)" Subtype="3" Variant="0" MirrorX="218.0.1" />
-	<entity BaseHP="100" Group="Spikes" ID="218" Image="resources/Entities/218.0.4 - Wall Hugger (Down).png" PlaceVisual="0,0.25" Kind="Enemies" Name="Wall Hugger (Down)" Subtype="4" Variant="0" MirrorY="218.0.2" />
-	<entity BaseHP="100" Group="Spikes" ID="877" Image="resources/Entities/877.0.0 - Grudge.png" Kind="Enemies" Name="Grudge" Variant="0" Subtype="0" />
-	<entity BaseHP="100" Group="Spikes" ID="852" Image="resources/Entities/852.0.0 - Spikeball (left).png" Kind="Enemies" Name="Spikeball (left)" Subtype="0" Variant="0" MirrorX="852.0.2"/>
-	<entity BaseHP="100" Group="Spikes" ID="852" Image="resources/Entities/852.0.1 - Spikeball (up).png" Kind="Enemies" Name="Spikeball (up)" Subtype="1" Variant="0" MirrorY="852.0.3"/>
-	<entity BaseHP="100" Group="Spikes" ID="852" Image="resources/Entities/852.0.2 - Spikeball (right).png" Kind="Enemies" Name="Spikeball (right)" Subtype="2" Variant="0" MirrorX="852.0.0"/>
-	<entity BaseHP="100" Group="Spikes" ID="852" Image="resources/Entities/852.0.3 - Spikeball (down).png" Kind="Enemies" Name="Spikeball (down)" Subtype="3" Variant="0" MirrorY="852.0.1" />
-	<entity BaseHP="100" Group="Spikes" ID="893" Image="resources/Entities/893.0.0 - Ball and Chain.png" Kind="Enemies" Name="Ball and Chain" Variant="0" Subtype="0" />
+	<group Name="Global Enemies">
+		<entity BaseHP="10" ID="61" Image="Entities/61.5.0 - Bulb.png" Name="Bulb" Variant="5" Subtype="0"/>
+	</group>
 
-	<!-- Stones -->
-	<entity BaseHP="20" Group="Stones" ID="42" Image="resources/Entities/42.0.0 - Stone Grimace.png" Kind="Enemies" Name="Stone Grimace" Subtype="0" Variant="0" />
-	<entity BaseHP="20" Group="Stones" ID="42" Image="resources/Entities/42.1.0 - Vomit Grimace.png" Kind="Enemies" Name="Vomit Grimace" Subtype="0" Variant="1" />
-	<entity BaseHP="20" Group="Stones" ID="42" Image="resources/Entities/42.2.0 - Triple Grimace.png" Kind="Enemies" Name="Triple Grimace" Variant="2" Subtype="0" />
-	<entity BaseHP="1" Group="Stones" ID="202" Image="resources/Entities/202.0.3 - Constant Stone Shooter.png" Kind="Enemies" Name="Constant Stone Shooter (Left)" Subtype="0" Variant="0" MirrorX="202.0.2" />
-	<entity BaseHP="1" Group="Stones" ID="202" Image="resources/Entities/202.0.1 - Constant Stone Shooter.png" Kind="Enemies" Name="Constant Stone Shooter (Up)" Subtype="1" Variant="0" MirrorY="202.0.3" />
-	<entity BaseHP="1" Group="Stones" ID="202" Image="resources/Entities/202.0.2 - Constant Stone Shooter.png" Kind="Enemies" Name="Constant Stone Shooter (Right)" Subtype="2" Variant="0" MirrorX="202.0.0" />
-	<entity BaseHP="1" Group="Stones" ID="202" Image="resources/Entities/202.0.0 - Constant Stone Shooter.png" Kind="Enemies" Name="Constant Stone Shooter (Down)" Subtype="3" Variant="0" MirrorY="202.0.1" />
-	<entity Group="Stones" Kind="Enemies" Image="resources/Entities/202.10.0 - Cross Stone Shooter.png" Champion="0" ID="202" Name="Cross Stone Shooter" Variant="10" Subtype="0" />
-	<entity Group="Stones" Kind="Enemies" Image="resources/Entities/202.10.1 - Cross Stone Shooter.png" Champion="0" ID="202" Name="Cross Stone Shooter (×)" Variant="10" Subtype="1" />
-	<entity Group="Stones" Kind="Enemies" Image="resources/Entities/202.11.0 - Cross Stone Shooter.png" Champion="0" ID="202" Name="Cross Stone Shooter (Always On)" Variant="11" Subtype="0" />
-	<entity Group="Stones" Kind="Enemies" Image="resources/Entities/202.11.1 - Cross Stone Shooter.png" Champion="0" ID="202" Name="Cross Stone Shooter (×) (Always On)" Variant="11" Subtype="1" />
-	<entity BaseHP="1" Group="Stones" ID="203" Image="resources/Entities/203.0.0 - Brimstone Head.png" Kind="Enemies" Name="Brimstone Head (Left)" Subtype="0" Variant="0" MirrorX="203.0.2" />
-	<entity BaseHP="1" Group="Stones" ID="203" Image="resources/Entities/203.0.1 - Brimstone Head.png" Kind="Enemies" Name="Brimstone Head (Up)" Subtype="1" Variant="0" MirrorY="203.0.3" />
-	<entity BaseHP="1" Group="Stones" ID="203" Image="resources/Entities/203.0.2 - Brimstone Head.png" Kind="Enemies" Name="Brimstone Head (Right)" Subtype="2" Variant="0" MirrorX="203.0.0" />
-	<entity BaseHP="1" Group="Stones" ID="203" Image="resources/Entities/203.0.3 - Brimstone Head.png" Kind="Enemies" Name="Brimstone Head (Down)" Subtype="3" Variant="0" MirrorY="203.0.1" />
-	<entity BaseHP="100" Group="Stones" ID="235" Image="resources/Entities/235.0.0 - Gaping Maw.png" Kind="Enemies" Name="Gaping Maw" Subtype="0" Variant="0" />
-	<entity BaseHP="100" Group="Stones" ID="236" Image="resources/Entities/236.0.0 - Broken Gaping Maw.png" Kind="Enemies" Name="Broken Gaping Maw" Subtype="0" Variant="0" />
-	<entity BaseHP="20" Group="Stones" ID="804" Image="resources/Entities/804.0.0 - Quake Grimace (left).png" Kind="Enemies" Name="Quake Grimace (left)" Variant="0" Subtype="0" />
-	<entity BaseHP="20" Group="Stones" ID="804" Image="resources/Entities/804.0.1 - Quake Grimace (up).png" Kind="Enemies" Name="Quake Grimace (up)" Variant="0" Subtype="1" />
-	<entity BaseHP="20" Group="Stones" ID="804" Image="resources/Entities/804.0.2 - Quake Grimace (right).png" Kind="Enemies" Name="Quake Grimace (right)" Variant="0" Subtype="2" />
-	<entity BaseHP="20" Group="Stones" ID="804" Image="resources/Entities/804.0.3 - Quake Grimace (down).png" Kind="Enemies" Name="Quake Grimace (down)" Variant="0" Subtype="3" />
-	<entity BaseHP="20" Group="Stones" ID="809" Image="resources/Entities/809.0.0 - Bomb Grimace.png" Kind="Enemies" Name="Bomb Grimace" Variant="0" Subtype="0" />
-	<entity BaseHP="1" Group="Stones" ID="201" Image="resources/Entities/201.0.0 - Stone Eye.png" Kind="Enemies" Name="Stone Eye" Subtype="0" Variant="0" />
-	<entity BaseHP="14" Group="Stones" ID="805" Image="resources/Entities/805.0.0 - Bishop.png" Kind="Enemies" Name="Bishop" Variant="0" Subtype="0" />
+	<!--——— Floors ———-->
+	<group Name="Chapter 1">
+		<group Label="Chapter 1 (Alt Path)">
+			<group Name="Chapter 1 (Alt Path) Shared" Label="- Shared -">
+				<group Name="Chapter 1 (Alt Path) Events" Label="Events"/>
+				<group Name="Chapter 1 (Alt Path) Obstacles" Label="Obstacles"/>
+				<group Name="Chapter 1 (Alt Path) Enemies" Label="Enemies"/>
+			</group>
+			<group Name="Downpour" Label="- Downpour -">
+				<group Name="Downpour Events" Label="Events"/>
+				<group Name="Downpour Obstacles" Label="Obstacles"/>
+				<group Name="Downpour Enemies" Label="Enemies"/>
+			</group>
+			<group Name="Dross" Label="- Dross -">
+				<group Name="Dross Events" Label="Events"/>
+				<group Name="Dross Obstacles" Label="Obstacles"/>
+				<group Name="Dross Enemies" Label="Enemies"/>
+			</group>
+		</group>
+	</group>
 
-	<!-- Twins -->
-	<entity BaseHP="20" Champion="1" Group="Twins" ID="53" Image="resources/Entities/53.0.0 - Dople.png" Kind="Enemies" Name="Dople" Subtype="0" Variant="0" />
-	<entity BaseHP="20" Champion="1" Group="Twins" ID="53" Image="resources/Entities/53.1.0 - Evil Twin.png" Kind="Enemies" Name="Evil Twin" Subtype="0" Variant="1" />
+	<group Name="Chapter 2">
+		<group Label="Chapter 2 (Alt Path)">
+			<group Name="Chapter 2 (Alt Path) Shared" Label="- Shared -">
+				<group Name="Chapter 2 (Alt Path) Events" Label="Events"/>
+				<group Name="Chapter 2 (Alt Path) Obstacles" Label="Obstacles"/>
+				<group Name="Chapter 2 (Alt Path) Enemies" Label="Enemies"/>
+			</group>
+			<group Name="Mines" Label="- Mines -">
+				<group Name="Mines Events" Label="Events"/>
+				<group Name="Mines Obstacles" Label="Obstacles"/>
+				<group Name="Mines Enemies" Label="Enemies"/>
+			</group>
+			<group Name="Ashpit" Label="- Ashpit -">
+				<group Name="Ashpit Events" Label="Events"/>
+				<group Name="Ashpit Obstacles" Label="Obstacles"/>
+				<group Name="Ashpit Enemies" Label="Enemies"/>
+			</group>
+		</group>
+	</group>
 
-	<!-- Vises -->
-	<entity BaseHP="25" Champion="1" Group="Vises" ID="39" Image="resources/Entities/39.0.0 - Vis.png" Kind="Enemies" Name="Vis" Subtype="0" Variant="0" />
-	<entity BaseHP="25" Champion="1" Group="Vises" ID="39" Image="resources/Entities/39.1.0 - Double Vis.png" Kind="Enemies" Name="Double Vis" Subtype="0" Variant="1" />
-	<entity BaseHP="22" Champion="1" Group="Vises" ID="39" Image="resources/Entities/39.3.0 - Scarred Double Vis.png" Kind="Enemies" Name="Scarred Double Vis" Subtype="0" Variant="3" />
-	<entity BaseHP="25" Champion="1" Group="Vises" ID="836" Image="resources/Entities/836.0.0 - Vis Versa.png" Kind="Enemies" Name="Vis Versa" Variant="0" Subtype="0" />
-	<entity BaseHP="40" Champion="1" Group="Vises" ID="865" Image="resources/Entities/865.0.0 - Evis.png" Kind="Enemies" Name="Evis" Variant="0" Subtype="0" />
-	<entity BaseHP="25" Champion="1" Group="Vises" ID="39" Image="resources/Entities/39.2.0 - Chubber.png" Kind="Enemies" Name="Chubber" Subtype="0" Variant="2" />
+	<group Name="Chapter 3">
+		<group Label="Chapter 3 (Alt Path)">
+			<group Name="Chapter 3 (Alt Path) Shared" Label="- Shared -">
+				<group Name="Chapter 3 (Alt Path) Events" Label="Events"/>
+				<group Name="Chapter 3 (Alt Path) Obstacles" Label="Obstacles"/>
+				<group Name="Chapter 3 (Alt Path) Enemies" Label="Enemies"/>
+			</group>
+			<group Name="Mausoleum" Label="- Mausoleum -">
+				<group Name="Mausoleum Events" Label="Events"/>
+				<group Name="Mausoleum Obstacles" Label="Obstacles"/>
+				<group Name="Mausoleum Enemies" Label="Enemies"/>
+			</group>
+			<group Name="Gehenna" Label="- Gehenna -">
+				<group Name="Gehenna Events" Label="Events"/>
+				<group Name="Gehenna Obstacles" Label="Obstacles"/>
+				<group Name="Gehenna Enemies" Label="Enemies"/>
+			</group>
+		</group>
+	</group>
 
-	<!-- Worms -->
-	<entity BaseHP="15" Champion="1" Group="Worms" ID="21" Image="resources/Entities/21.0.0 - Maggot.png" Kind="Enemies" Name="Maggot" Subtype="0" Variant="0" />
-	<entity BaseHP="10" Group="Worms" ID="853" Image="resources/Entities/853.0.0 - Small Maggot.png" Kind="Enemies" Name="Small Maggot" Variant="0" Subtype="0" />
-	<entity BaseHP="10" Group="Worms" ID="853" Image="resources/Entities/853.10.3 - Small Maggot (three).png" Kind="Enemies" Name="Small Maggot (three)" Variant="10" Subtype="3"/>
-	<entity BaseHP="10" Group="Worms" ID="853" Image="resources/Entities/853.10.5 - Small Maggot (five).png" Kind="Enemies" Name="Small Maggot (five)" Variant="10" Subtype="5"/>
-	<entity BaseHP="20" Champion="1" Group="Worms" ID="23" Image="resources/Entities/23.0.0 - Charger.png" Kind="Enemies" Name="Charger" Subtype="0" Variant="0" />
-	<entity BaseHP="40" Champion="1" Group="Worms" ID="855" Image="resources/Entities/855.0.0 - Level 2 Charger.png" Kind="Enemies" Name="Level 2 Charger" Variant="0" Subtype="0" />
-	<entity BaseHP="22" Champion="1" Group="Worms" ID="23" Image="resources/Entities/23.1.0 - Drowned Charger.png" Kind="Enemies" Name="Drowned Charger" Subtype="0" Variant="1" />
-	<entity BaseHP="26" Champion="1" Group="Worms" ID="23" Image="resources/Entities/23.2.0 - Dank Charger.png" Kind="Enemies" Name="Dank Charger" Subtype="0" Variant="2" />
-	<entity BaseHP="26" Champion="1" Group="Worms" ID="23" Image="resources/Entities/23.3.0 - Carrion Princess.png" Kind="Enemies" Name="Carrion Princess" Variant="3" Subtype="0" />
-	<entity BaseHP="10" Champion="1" Group="Worms" ID="31" Image="resources/Entities/31.0.0 - Spitty.png" Kind="Enemies" Name="Spitty" Subtype="0" Variant="0" />
-	<entity BaseHP="18" Group="Worms" ID="243" Image="resources/Entities/243.0.0 - Conjoined Spitty.png" Kind="Enemies" Name="Conjoined Spitty" Subtype="0" Variant="0" />
-	<entity BaseHP="25" Champion="1" Group="Worms" ID="55" Image="resources/Entities/55.0.0 - Leech.png" Kind="Enemies" Name="Leech" Subtype="0" Variant="0" />
-	<entity BaseHP="25" Champion="1" Group="Worms" ID="55" Image="resources/Entities/55.1.0 - Kamikaze Leech.png" Kind="Enemies" Name="Kamikaze Leech" Subtype="0" Variant="1" />
-	<entity BaseHP="25" Champion="1" Group="Worms" ID="55" Image="resources/Entities/55.2.0 - Holy Leech.png" Kind="Enemies" Name="Holy Leech" Subtype="0" Variant="2" />
-	<entity BaseHP="90" Champion="1" Group="Worms" ID="854" Image="resources/Entities/854.0.0 - Adult Leech.png" Kind="Enemies" Name="Adult Leech" Variant="0" Subtype="0" />
-	<entity BaseHP="12" Group="Worms" ID="77" Image="resources/Entities/77.0.0 - Embryo.png" Kind="Enemies" Name="Embryo" Subtype="0" Variant="0" />
-	<entity BaseHP="20" Group="Worms" ID="89" Image="resources/Entities/89.0.0 - Buttlicker.png" Kind="Enemies" Name="Buttlicker" Subtype="0" Variant="0" />
-	<entity BaseHP="16" Champion="1" Group="Worms" ID="878" Image="resources/Entities/878.0.0 - Butt Slicker.png" Kind="Enemies" Name="Butt Slicker" Variant="0" Subtype="0" />
-	<entity BaseHP="10" Group="Worms" ID="239" Image="resources/Entities/239.0.0 - Grub.png" Kind="Enemies" Name="Grub" Subtype="0" Variant="0" />
-	<entity BaseHP="48" Group="Worms" ID="239" Image="resources/Entities/239.100.0 - Corpse Eater.png" Kind="Enemies" Name="Corpse Eater" Variant="100" Subtype="0" />
-	<entity BaseHP="48" Group="Worms" ID="239" Image="resources/Entities/239.101.0 - Carrion Rider.png" Kind="Enemies" Name="Carrion Rider" Variant="101" Subtype="0" />
-	<entity BaseHP="10" Group="Worms" ID="244" Image="resources/Entities/244.0.0 - Round Worm.png" Kind="Enemies" Name="Round Worm" Subtype="0" Variant="0" />
-	<entity BaseHP="35" Group="Worms" ID="255" Image="resources/Entities/255.0.0 - Night Crawler.png" Kind="Enemies" Name="Night Crawler" Subtype="0" Variant="0" />
-	<entity Group="Worms" Kind="Enemies" Image="resources/Entities/244.1.0 - Tube Worm.png" BaseHP="20" Champion="0" ID="244" Name="Tube Worm" Variant="1" Subtype="0" />
-	<entity BaseHP="10" Group="Worms" ID="276" Image="resources/Entities/276.0.0 - Roundy.png" Kind="Enemies" Name="Roundy" Subtype="0" Variant="0" />
-	<entity BaseHP="10" Champion="1" Group="Worms" ID="825" Image="resources/Entities/825.0.0 - Fire Worm.png" Kind="Enemies" Name="Fire Worm" Variant="0" Subtype="0" />
-	<entity BaseHP="20" Champion="1" Group="Worms" ID="221" Image="resources/Entities/221.0.0 - Cod Worm.png" Kind="Enemies" Name="Cod Worm" Subtype="0" Variant="0" />
-	<entity BaseHP="20" Group="Worms" ID="802" Image="resources/Entities/802.0.0 - Blood Puppy.png" Kind="Enemies" Name="Blood Puppy (lvl 2)" Variant="0" Subtype="0" />
-	<entity BaseHP="50" Group="Worms" ID="802" Image="resources/Entities/802.1.0 - Blood Puppy.png" Kind="Enemies" Name="Blood Puppy (lvl 3)" Variant="1" Subtype="0" />
-	<entity BaseHP="5" Group="Worms" ID="810" Image="resources/Entities/810.0.0 - Small Leech.png" Kind="Enemies" Name="Small Leech" Variant="0" Subtype="0" />
-	<entity BaseHP="10" Champion="1" Group="Worms" ID="881" Image="resources/Entities/881.0.0 - Needle.png" Kind="Enemies" Name="Needle" Variant="0" Subtype="0" />
-	<entity BaseHP="10" Champion="1" Group="Worms" ID="881" Image="resources/Entities/881.1.0 - Pasty.png" Kind="Enemies" Name="Pasty" Variant="1" Subtype="0" />
-	
+	<group Name="Chapter 4">
+		<group Label="Chapter 4 (Alt Path)">
+			<group Name="Chapter 4 (Alt Path) Shared" Label="- Shared -">
+				<group Name="Chapter 4 (Alt Path) Events" Label="Events"/>
+				<group Name="Chapter 4 (Alt Path) Obstacles" Label="Obstacles"/>
+				<group Name="Chapter 4 (Alt Path) Enemies" Label="Enemies"/>
+			</group>
+			<group Name="Corpse" Label="- Corpse -">
+				<group Name="Corpse Events" Label="Events"/>
+				<group Name="Corpse Obstacles" Label="Obstacles"/>
+				<group Name="Corpse Enemies" Label="Enemies"/>
+			</group>
+		</group>
+	</group>
+
+	<group Name="Floors">
+		<group Name="Ascent" Label="- Ascent -">
+			<group Name="Ascent Events" Label="Events"/>
+			<group Name="Ascent Obstacles" Label="Obstacles"/>
+			<group Name="Ascent Enemies" Label="Enemies"/>
+		</group>
+		<group Name="Home" Label="- Home -">
+			<group Name="Home Events" Label="Events"/>
+			<group Name="Home Obstacles" Label="Obstacles"/>
+			<group Name="Home Enemies" Label="Enemies"/>
+		</group>
+	</group>
+
+	<group Name="Basement Enemies">
+		<entity BaseHP="5" ID="868" Image="Entities/868.0.0 - Army Fly.png" Name="Army Fly" Variant="0" Subtype="0"/>
+	</group>
+
+	<group Name="Cellar Enemies">
+		<entity BaseHP="16" Tags="Champion" ID="869" Image="Entities/869.0.0 - Migraine.png" Name="Migraine" Variant="0" Subtype="0"/>
+		<entity BaseHP="4.5" ID="884" Image="Entities/884.0.0 - Swarm Spider.png" Name="Swarm Spider" Variant="0" Subtype="0">
+			<bitfield Key="Subtype">
+				<spinner Length="16" ValueOffset="1" Name="Count">
+					<tooltip>Number of swarm spiders spawned.
+1, 3, and 5 are used in the base game.</tooltip>
+				</spinner>
+			</bitfield>
+		</entity>
+	</group>
+
+	<group Name="Burning Basement Enemies">
+		<entity Name="Army Fly"/>
+		<entity Name="Swarm Spider"/>
+		<entity BaseHP="20" Tags="Champion" ID="15" Image="Entities/15.3.0 - Grilled Clotty.png" Name="Grilled Clotty" Variant="3" Subtype="0" />
+	</group>
+
+	<group Name="Chapter 1 (Alt Path) Events">
+		<defaults>
+			<entity>
+				<tag>Grid</tag>
+				<tag>InEmptyRooms</tag>
+				<tag>InNonCombatRooms</tag>
+			</entity>
+		</defaults>
+		<entity ID="970" Image="Entities/970.2.0 - Quest Door.png" Name="Quest Door" PlaceVisual="WallSnap" Subtype="0" Variant="2"/>
+		<entity BaseHP="5" ID="33" Image="Entities/33.4.0 - White Fire Place.png" Name="White Fire Place" Variant="4" Subtype="0"/>
+	</group>
+
+	<group Name="Chapter 1 (Alt Path) Enemies">
+		<group Name="Default Gapers"/>
+		<group Name="Default Gushers"/>
+		<group Name="Deep Gapers">
+			<defaults>
+				<entity>
+					<tag>Champion</tag>
+					<tag>DeepGapers</tag>
+				</entity>
+			</defaults>
+			<entity BaseHP="10" ID="811" Image="Entities/811.0.0 - Deep Gaper (random).png" Name="Deep Gaper (random)" Variant="0" Subtype="0"/>
+			<entity BaseHP="10" ID="811" Image="Entities/811.0.1 - Deep Gaper (subtype 1).png" Name="Deep Gaper (subtype 1)" Variant="0" Subtype="1"/>
+			<entity BaseHP="10" ID="811" Image="Entities/811.0.2 - Deep Gaper (subtype 2).png" Name="Deep Gaper (subtype 2)" Variant="0" Subtype="2"/>
+			<entity BaseHP="10" ID="811" Image="Entities/811.0.3 - Deep Gaper (subtype 3).png" Name="Deep Gaper (subtype 3)" Variant="0" Subtype="3"/>
+			<entity BaseHP="10" ID="811" Image="Entities/811.0.4 - Deep Gaper (subtype 4).png" Name="Deep Gaper (subtype 4)" Variant="0" Subtype="4"/>
+			<entity BaseHP="10" ID="811" Image="Entities/811.0.5 - Deep Gaper (subtype 5).png" Name="Deep Gaper (subtype 5)" Variant="0" Subtype="5"/>
+			<entity BaseHP="10" ID="811" Image="Entities/811.0.6 - Deep Gaper (subtype 6).png" Name="Deep Gaper (subtype 6)" Variant="0" Subtype="6"/>
+		</group>
+		<entity BaseHP="10" Tags="Champion" ID="807" Image="Entities/807.0.0 - Wraith.png" Name="Wraith" Variant="0" Subtype="0"/>
+		<entity BaseHP="16" Tags="Champion" ID="813" Image="Entities/813.0.0 - Blurb.png" Name="Blurb" Variant="0" Subtype="0"/>
+		<entity BaseHP="20" Tags="Champion" ID="806" Image="Entities/806.0.0 - Bubbles.png" Name="Bubbles" Variant="0" Subtype="0"/>
+		<entity BaseHP="14" Tags="Champion" ID="817" Image="Entities/817.0.0 - Prey.png" Name="Prey" Variant="0" Subtype="0" />
+		<entity Name="Fly"/>
+		<entity BaseHP="5" ID="810" Image="Entities/810.0.0 - Small Leech.png" Name="Small Leech" Variant="0" Subtype="0" />
+		<entity Name="Tube Worm"/>
+		<entity BaseHP="14" Tags="Champion" ID="812" Image="Entities/812.0.0 - Sub Horf.png" Name="Sub Horf" Variant="0" Subtype="0" />
+	</group>
+
+	<group Name="Downpour Enemies">
+		<entity BaseHP="26" Tags="Champion" ID="879" Image="Entities/879.0.0 - Bloaty.png" Name="Bloaty" Variant="0" Subtype="0"/>
+		<entity BaseHP="14" Tags="Champion" ID="817" Image="Entities/817.1.0 - Mullighoul.png" Name="Mullighoul" Variant="1" Subtype="0" />
+		<entity BaseHP="6" ID="808" Image="Entities/808.0.0 - Willo.png" Name="Willo" Variant="0" Subtype="0"/>
+		<entity BaseHP="20" ID="838" Image="Entities/838.0.0 - Level 2 Willo.png" Name="Level 2 Willo" Variant="0" Subtype="0"/>
+		<entity BaseHP="6.5" ID="814" Image="Entities/814.0.0 - Strider.png" Name="Strider" Variant="0" Subtype="0"/>
+		<entity BaseHP="14" Tags="Champion" ID="816" Image="Entities/816.0.0 - Polty.png" Name="Polty" Variant="0" Subtype="0" />
+		<entity BaseHP="100" ID="3001" Image="Entities/3001.0.0 - Fissure Spawner.png" Name="Fissure Spawner" Variant="0" Subtype="0" Tags="Grid">
+			<bitfield Key="Subtype">
+				<slider Length="4" Offset="8" Name="Frequency" Unit="Seconds" ValueOffset="1" ScalarRange="5">
+					<tooltip>Seconds between each spawned Fissure</tooltip>
+				</slider>
+				<spinner Length="4" Offset="4" Name="Jump Distance" Unit="Grids" ValueOffset=".5">
+					<tooltip>Distance the Fissure will jump based on the center of the Spawner. It will die on the 7th bounce.</tooltip>
+				</spinner>
+				<dial Length="4" Offset="0" Name="Angle" Unit="Degrees" ValueOffset="12">
+					<tooltip>Spawn angle of the Fissures</tooltip>
+				</dial>
+			</bitfield>
+		</entity>
+		<entity Name="Clotty"/>
+	</group>
+
+	<group Name="Dross Events" Label="Events">
+		<defaults>
+			<entity>
+				<tag>Grid</tag>
+				<tag>InEmptyRooms</tag>
+				<tag>InNonCombatRooms</tag>
+			</entity>
+		</defaults>
+		<group Name="Water Flows">
+			<defaults>
+				<entity>
+					<tag>WaterFlows</tag>
+				</entity>
+			</defaults>
+			<entity ID="970" Image="Entities/970.1.0 - Water Flow (left).png" Name="Water Flow (left)" Subtype="0" Variant="1" MirrorX="970.1.2"/>
+			<entity ID="970" Image="Entities/970.1.1 - Water Flow (up).png" Name="Water Flow (up)" Subtype="1" Variant="1" MirrorY="970.1.3"/>
+			<entity ID="970" Image="Entities/970.1.2 - Water Flow (right).png" Name="Water Flow (right)" Subtype="2" Variant="1" MirrorX="970.1.0"/>
+			<entity ID="970" Image="Entities/970.1.3 - Water Flow (down).png" Name="Water Flow (down)" Subtype="3" Variant="1" MirrorY="970.1.1"/>
+		</group>
+		<entity ID="970" Image="Entities/970.1.10 - Water Disabler.png" Name="Water Disabler" Subtype="10" Variant="1"/>
+		<entity ID="999" Image="Entities/1000.141.1 - Smoke Cloud.png" Name="Smoke Cloud" Variant="141" Subtype="1" />
+		<entity ID="1499" Image="Entities/1499.0.0 - Giant Poop.png" Name="Giant Poop" Subtype="0" Variant="0">
+			<tag>Grid</tag>
+		</entity>
+	</group>
+
+	<group Name="Dross Enemies" Label="Enemies">
+		<entity BaseHP="3" ID="870" Image="Entities/870.0.0 - Drip.png" Name="Drip" Variant="0" Subtype="0" />
+		<entity BaseHP="6" ID="217" Image="Entities/217.3.0 - Big Corn.png" Name="Big Corn" Variant="3" Subtype="0" />
+		<entity BaseHP="15" ID="871" Image="Entities/871.0.0 - Splurt.png" Name="Splurt" Variant="0" Subtype="0" />
+		<entity BaseHP="15" Tags="Champion" ID="872" Image="Entities/872.0.0 - Cloggy.png" Name="Cloggy" Variant="0" Subtype="0" />
+		<entity BaseHP="10" Tags="Champion" ID="876" Image="Entities/876.0.0 - Dump.png" Name="Dump" Variant="0" Subtype="0"/>
+		<entity BaseHP="10" Tags="Champion" ID="876" Image="Entities/876.1.0 - Dump Head.png" Name="Dump Head" Variant="1" Subtype="0"/>
+		<entity BaseHP="13" Tags="Champion" ID="874" Image="Entities/874.0.0 - Gas Dwarf.png" Name="Gas Dwarf" Variant="0" Subtype="0" />
+		<entity BaseHP="12" Tags="Champion" ID="875" Image="Entities/875.0.0 - Poot Mine.png" Name="Poot Mine" Variant="0" Subtype="0" />
+		<entity BaseHP="16" Tags="Champion" ID="873" Image="Entities/873.0.0 - Fly Trap.png" Name="Fly Trap" Variant="0" Subtype="0" />
+		<entity Name="Attack Fly"/>
+		<entity Name="Ring Fly"/>
+		<entity Name="Dart Fly"/>
+		<entity Name="Swarm"/>
+		<entity Name="Army Fly"/>
+		<entity Name="Boom Fly"/>
+		<entity BaseHP="80" ID="837" Image="Entities/837.0.0 - Henry.png" Name="Henry" Variant="0" Subtype="0" />
+	</group>
+
+	<group Name="Caves Enemies">
+		<entity BaseHP="10" Tags="Champion" ID="881" Image="Entities/881.0.0 - Needle.png" Name="Needle" Variant="0" Subtype="0" />
+		<entity Name="Army Fly"/>
+	</group>
+
+	<group Name="Catacombs Enemies">
+		<entity Name="Migraine"/>
+		<entity Name="Swarm Spider"/>
+	</group>
+
+	<group Name="Flooded Caves Enemies">
+		<entity Name="Bloaty"/>
+		<entity Name="Needle"/>
+	</group>
+
+	<group Name="Chapter 2 (Alt Path) Events">
+		<defaults>
+			<entity>
+				<tag>Grid</tag>
+				<tag>InEmptyRooms</tag>
+				<tag>InNonCombatRooms</tag>
+			</entity>
+		</defaults>
+		<entity ID="970" Image="Entities/970.0.0 - Room Darkness.png" Name="Room Darkness" Subtype="0" Variant="0"/>
+		<entity ID="970" Image="Entities/970.1.20 - Lava Disabler.png" Name="Lava Disabler" Subtype="20" Variant="1"/>
+		<entity Name="Quest Door"/>
+		<entity ID="4500" Image="Entities/4500.3.0 - Rail Plate.png" Name="Rail Plate" Subtype="0" Variant="3"/>
+		<entity ID="3002" Image="Entities/3002.0.0 - Button Rail.png" Name="Button Rail" Subtype="0" Variant="0"/>
+		<entity BaseHP="0" ID="965" Image="Entities/965.10.0 - Quest Minecart.png" Name="Quest Minecart" Variant="10" Subtype="0" />
+	</group>
+
+	<group Name="Chapter 2 (Alt Path) Obstacles">
+		<entity Name="Stone Grimace"/>
+		<group Name="Constant Stone Shooter"/>
+		<group Name="Quake Grimace">
+			<defaults>
+				<entity>
+					<tag>QuakeGrimaces</tag>
+				</entity>
+			</defaults>
+			<entity BaseHP="20" ID="804" Image="Entities/804.0.0 - Quake Grimace (left).png" Name="Quake Grimace (left)" Variant="0" Subtype="0" MirrorX="804.0.2" />
+			<entity BaseHP="20" ID="804" Image="Entities/804.0.1 - Quake Grimace (up).png" Name="Quake Grimace (up)" Variant="0" Subtype="1" MirrorY="804.0.3" />
+			<entity BaseHP="20" ID="804" Image="Entities/804.0.2 - Quake Grimace (right).png" Name="Quake Grimace (right)" Variant="0" Subtype="2" MirrorX="804.0.0" />
+			<entity BaseHP="20" ID="804" Image="Entities/804.0.3 - Quake Grimace (down).png" Name="Quake Grimace (down)" Variant="0" Subtype="3" MirrorY="804.0.1" />
+		</group>
+		<entity BaseHP="20" ID="809" Image="Entities/809.0.0 - Bomb Grimace.png" Name="Bomb Grimace" Variant="0" Subtype="0" />
+		<group Label="Rails">
+			<defaults>
+				<entity>
+					<tag>Grid</tag>
+					<tag>InEmptyRooms</tag>
+					<tag>InNonCombatRooms</tag>
+					<tag>Rails</tag>
+				</entity>
+			</defaults>
+			<entity ID="6000" Image="Entities/6000.0.0 - Rail (left-to-right).png" Name="Rail (left-to-right)" Subtype="0" Variant="0" />
+			<entity ID="6000" Image="Entities/6000.1.0 - Rail (up-to-down).png" Name="Rail (up-to-down)" Subtype="0" Variant="1" />
+			<entity ID="6000" Image="Entities/6000.2.0 - Rail (up-to-right).png" Name="Rail (up-to-right)" Subtype="0" Variant="2" MirrorX="6000.3.0" MirrorY="6000.4.0" />
+			<entity ID="6000" Image="Entities/6000.3.0 - Rail (up-to-left).png" Name="Rail (up-to-left)" Subtype="0" Variant="3" MirrorX="6000.2.0" MirrorY="6000.5.0" />
+			<entity ID="6000" Image="Entities/6000.4.0 - Rail (left-to-up).png" Name="Rail (left-to-up)" Subtype="0" Variant="4" MirrorX="6000.5.0" MirrorY="6000.2.0" />
+			<entity ID="6000" Image="Entities/6000.5.0 - Rail (right-to-up).png" Name="Rail (right-to-up)" Subtype="0" Variant="5" MirrorX="6000.4.0" MirrorY="6000.3.0" />
+			<entity ID="6000" Image="Entities/6000.6.0 - Rail (crossroad).png" Name="Rail (crossroad)" Subtype="0" Variant="6" />
+			<entity ID="6000" Image="Entities/6000.7.0 - Rail (stop-to-right).png" Name="Rail (stop-to-right)" Subtype="0" Variant="7" MirrorX="6000.8.0" />
+			<entity ID="6000" Image="Entities/6000.8.0 - Rail (left-to-stop).png" Name="Rail (left-to-stop)" Subtype="0" Variant="8" MirrorX="6000.7.0" />
+			<entity ID="6000" Image="Entities/6000.9.0 - Rail (up-to-stop).png" Name="Rail (up-to-stop)" Subtype="0" Variant="9" MirrorY="6000.10.0" />
+			<entity ID="6000" Image="Entities/6000.10.0 - Rail (stop-to-down).png" Name="Rail (left-to-stop)" Subtype="0" Variant="10" MirrorY="6000.9.0" />
+			<entity ID="6000" Image="Entities/6000.16.0 - Rail (cart-left).png" Name="Rail (cart-left)" Subtype="0" Variant="16" MirrorX="6000.32.0" />
+			<entity ID="6000" Image="Entities/6000.32.0 - Rail (cart-right).png" Name="Rail (cart-right)" Subtype="0" Variant="32" MirrorX="6000.16.0" />
+			<entity ID="6000" Image="Entities/6000.17.0 - Rail (cart-up).png" Name="Rail (cart-up)" Subtype="0" Variant="17" MirrorY="6000.33.0" />
+			<entity ID="6000" Image="Entities/6000.33.0 - Rail (cart-down).png" Name="Rail (cart-down)" Subtype="0" Variant="33" MirrorY="6000.17.0" />
+			<entity ID="6000" Image="Entities/6000.80.0 - Rail (Mineshaft).png" Name="Rail (Mineshaft)" Subtype="0" Variant="80" />
+			<entity ID="6000" Image="Entities/6000.81.0 - Rail (Mineshaft).png" Name="Rail (Mineshaft)" Subtype="0" Variant="81" />
+			<entity ID="6000" Image="Entities/6000.82.0 - Rail (Mineshaft).png" Name="Rail (Mineshaft)" Subtype="0" Variant="82" />
+			<entity ID="6000" Image="Entities/6000.83.0 - Rail (Mineshaft).png" Name="Rail (Mineshaft)" Subtype="0" Variant="83" />
+			<entity ID="6000" Image="Entities/6000.84.0 - Rail (Mineshaft).png" Name="Rail (Mineshaft)" Subtype="0" Variant="84" />
+			<entity ID="6000" Image="Entities/6000.85.0 - Rail (Mineshaft).png" Name="Rail (Mineshaft)" Subtype="0" Variant="85" />
+			<entity ID="6000" Image="Entities/6000.96.0 - Rail (Mineshaft).png" Name="Rail (Mineshaft)" Subtype="0" Variant="96" />
+			<entity ID="6000" Image="Entities/6000.97.0 - Rail (Mineshaft).png" Name="Rail (Mineshaft)" Subtype="0" Variant="97" />
+			<entity ID="6000" Image="Entities/6000.98.0 - Rail (Mineshaft).png" Name="Rail (Mineshaft)" Subtype="0" Variant="98" />
+			<entity ID="6000" Image="Entities/6000.99.0 - Rail (Mineshaft).png" Name="Rail (Mineshaft)" Subtype="0" Variant="99" />
+			<entity ID="6000" Image="Entities/6000.100.0 - Rail (Mineshaft).png" Name="Rail (Mineshaft)" Subtype="0" Variant="100" />
+			<entity ID="6000" Image="Entities/6000.101.0 - Rail (Mineshaft).png" Name="Rail (Mineshaft)" Subtype="0" Variant="101" />
+			<entity ID="6000" Image="Entities/6000.112.0 - Rail (Mineshaft).png" Name="Rail (Mineshaft)" Subtype="0" Variant="112" />
+			<entity ID="6000" Image="Entities/6000.113.0 - Rail (Mineshaft).png" Name="Rail (Mineshaft)" Subtype="0" Variant="113" />
+
+			<entity ID="6001" Image="Entities/6001.0.0 - Rail (Pit) (left-to-right).png" Name="Rail (Pit) (left-to-right)" Subtype="0" Variant="0" />
+			<entity ID="6001" Image="Entities/6001.1.0 - Rail (Pit) (up-to-down).png" Name="Rail (Pit) (up-to-down)" Subtype="0" Variant="1" />
+			<entity ID="6001" Image="Entities/6001.2.0 - Rail (Pit) (up-to-right).png" Name="Rail (Pit) (up-to-right)" Subtype="0" Variant="2" MirrorX="6001.3.0" MirrorY="6001.4.0" />
+			<entity ID="6001" Image="Entities/6001.3.0 - Rail (Pit) (up-to-left).png" Name="Rail (Pit) (up-to-left)" Subtype="0" Variant="3" MirrorX="6001.2.0" MirrorY="6001.5.0" />
+			<entity ID="6001" Image="Entities/6001.4.0 - Rail (Pit) (left-to-up).png" Name="Rail (Pit) (left-to-up)" Subtype="0" Variant="4" MirrorX="6001.5.0" MirrorY="6001.2.0" />
+			<entity ID="6001" Image="Entities/6001.5.0 - Rail (Pit) (right-to-up).png" Name="Rail (Pit) (right-to-up)" Subtype="0" Variant="5" MirrorX="6001.4.0" MirrorY="6001.3.0" />
+			<entity ID="6001" Image="Entities/6001.6.0 - Rail (Pit) (crossroad).png" Name="Rail (Pit) (crossroad)" Subtype="0" Variant="6"/>
+			<entity ID="6001" Image="Entities/6001.16.0 - Rail (Pit) (cart-left).png" Name="Rail (Pit) (cart-left)" Subtype="0" Variant="16" MirrorX="6001.32.0" />
+			<entity ID="6001" Image="Entities/6001.32.0 - Rail (Pit) (cart-right).png" Name="Rail (Pit) (cart-right)" Subtype="0" Variant="32" MirrorX="6000.16.0" />
+			<entity ID="6001" Image="Entities/6001.17.0 - Rail (Pit) (cart-up).png" Name="Rail (Pit) (cart-up)" Subtype="0" Variant="17" MirrorY="6001.33.0" />
+			<entity ID="6001" Image="Entities/6001.33.0 - Rail (Pit) (cart-down).png" Name="Rail (Pit) (cart-down)" Subtype="0" Variant="33" MirrorY="6001.17.0" />
+		</group>
+	</group>
+
+	<group Name="Chapter 2 (Alt Path) Enemies">
+		<entity Name="Bony"/>
+		<entity Name="Gurgle"/>
+		<entity Name="Splasher"/>
+		<entity BaseHP="20" Tags="Champion" ID="821" Image="Entities/821.0.0 - Blaster.png" Name="Blaster" Variant="0" Subtype="0"/>
+		<entity BaseHP="40" Tags="Champion" ID="820" Image="Entities/820.1.0 - Coal Boy.png" Name="Coal Boy" Variant="1" Subtype="0"/>
+		<entity BaseHP="10" Tags="Champion" ID="61" Image="Entities/61.3.0 - Ink.png" Name="Ink" Variant="3" Subtype="0"/>
+		<entity BaseHP="7" Tags="Champion" ID="819" Image="Entities/819.0.0 - Fly Bomb.png" Name="Fly Bomb" Variant="0" Subtype="0"/>
+		<group Name="Dragon Flies">
+			<defaults>
+				<entity>
+					<tag>Champion</tag>
+					<tag>DragonFlies</tag>
+				</entity>
+			</defaults>
+			<entity BaseHP="20" ID="25" Image="Entities/25.3.0 - Dragon Fly.png" Name="Dragon Fly" Variant="3" Subtype="0"/>
+			<entity BaseHP="20" ID="25" Image="Entities/25.3.1 - Dragon Fly X.png" Name="Dragon Fly X" Variant="3" Subtype="1"/>
+			<entity BaseHP="20" ID="25" Image="Entities/25.3.100 - Dragon Fly (random).png" Name="Dragon Fly (random)" Variant="3" Subtype="100"/>
+		</group>
+		<group Name="Rock Spiders">
+			<defaults>
+				<entity>
+					<tag>RockSpiders</tag>
+				</entity>
+			</defaults>
+			<entity BaseHP="12" ID="818" Image="Entities/818.0.0 - Rock Spider.png" Name="Rock Spider (random)" Variant="0" Subtype="0"/>
+			<entity BaseHP="12" ID="818" Image="Entities/818.0.1 - Rock Spider.png" Name="Rock Spider (subtype 1)" Variant="0" Subtype="1"/>
+			<entity BaseHP="12" ID="818" Image="Entities/818.0.2 - Rock Spider.png" Name="Rock Spider (subtype 2)" Variant="0" Subtype="2"/>
+			<entity BaseHP="12" ID="818" Image="Entities/818.0.3 - Rock Spider.png" Name="Rock Spider (subtype 3)" Variant="0" Subtype="3"/>
+		</group>
+		<group Name="Tinted Rock Spiders">
+			<defaults>
+				<entity>
+					<tag>TintedRockSpiders</tag>
+				</entity>
+			</defaults>
+			<entity BaseHP="22" ID="818" Image="Entities/818.1.0 - Tinted Rock Spider.png" Name="Tinted Rock Spider (random)" Variant="1" Subtype="0"/>
+			<entity BaseHP="22" ID="818" Image="Entities/818.1.1 - Tinted Rock Spider.png" Name="Tinted Rock Spider (subtype 1)" Variant="1" Subtype="1"/>
+			<entity BaseHP="22" ID="818" Image="Entities/818.1.2 - Tinted Rock Spider.png" Name="Tinted Rock Spider (subtype 2)" Variant="1" Subtype="2"/>
+			<entity BaseHP="22" ID="818" Image="Entities/818.1.3 - Tinted Rock Spider.png" Name="Tinted Rock Spider (subtype 3)" Variant="1" Subtype="3"/>
+		</group>
+		<group Name="Coal Spiders">
+			<defaults>
+				<entity>
+					<tag>CoalSpiders</tag>
+				</entity>
+			</defaults>
+			<entity BaseHP="15" ID="818" Image="Entities/818.2.0 - Coal Spider.png" Name="Coal Spider (random)" Variant="2" Subtype="0"/>
+			<entity BaseHP="15" ID="818" Image="Entities/818.2.1 - Coal Spider.png" Name="Coal Spider (subtype 1)" Variant="2" Subtype="1"/>
+			<entity BaseHP="15" ID="818" Image="Entities/818.2.2 - Coal Spider.png" Name="Coal Spider (subtype 2)" Variant="2" Subtype="2"/>
+			<entity BaseHP="15" ID="818" Image="Entities/818.2.3 - Coal Spider.png" Name="Coal Spider (subtype 3)" Variant="2" Subtype="3"/>
+		</group>
+		<group Name="Coals">
+			<defaults>
+				<entity>
+					<tag>Coals</tag>
+				</entity>
+			</defaults>
+			<entity BaseHP="15" ID="33" Image="Entities/33.11.0 - Coal.png" Name="Coal (random)" Variant="11" Subtype="0" />
+			<entity BaseHP="15" ID="33" Image="Entities/33.11.1 - Coal.png" Name="Coal (subtype 1)" Variant="11" Subtype="1" />
+			<entity BaseHP="15" ID="33" Image="Entities/33.11.2 - Coal.png" Name="Coal (subtype 2)" Variant="11" Subtype="2" />
+			<entity BaseHP="15" ID="33" Image="Entities/33.11.3 - Coal.png" Name="Coal (subtype 3)" Variant="11" Subtype="3" />
+		</group>
+		<entity BaseHP="42" Tags="Champion" ID="826" Image="Entities/826.0.0 - Hardy.png" Name="Hardy" Variant="0" Subtype="0" />
+		<entity BaseHP="15" Tags="Champion" ID="27" Image="Entities/27.3.0 - Hard Host.png" Name="Hard Host" Variant="3" Subtype="0" />
+	</group>
+
+	<group Name="Mines Enemies">
+		<entity Name="Crispy"/>
+		<entity BaseHP="20" Tags="Champion" ID="827" Image="Entities/827.0.0 - Faceless.png" Name="Faceless" Variant="0" Subtype="0"/>
+		<entity BaseHP="40" Tags="Champion" ID="820" Image="Entities/820.0.0 - Danny.png" Name="Danny" Variant="0" Subtype="0"/>
+		<entity BaseHP="30" Tags="Champion" ID="822" Image="Entities/822.0.0 - Bouncer.png" Name="Bouncer" Variant="0" Subtype="0" />
+		<entity BaseHP="45" Tags="Champion" ID="823" Image="Entities/823.0.0 - Quakey.png" Name="Quakey" Variant="0" Subtype="0"/>
+		<entity BaseHP="13.5" ID="240" Image="Entities/240.1.0 - Soy Creep.png" PlaceVisual="WallSnap" Name="Soy Creep" Variant="1" Subtype="0"/>
+		<entity BaseHP="10" Tags="Champion" ID="825" Image="Entities/825.0.0 - Fire Worm.png" Name="Fire Worm" Variant="0" Subtype="0" />
+		<entity BaseHP="18" Tags="Champion" ID="824" Image="Entities/824.0.0 - Gyro.png" Name="Gyro" Variant="0" Subtype="0" />
+		<entity BaseHP="20" Tags="Champion" ID="824" Image="Entities/824.1.0 - Grilled Gyro.png" Name="Grilled Gyro" Variant="1" Subtype="0" />
+		<entity BaseHP="12" Tags="Champion" ID="829" Image="Entities/829.0.0 - Mole.png" Name="Mole" Variant="0" Subtype="0" />
+		<entity BaseHP="20" Tags="Champion" ID="840" Image="Entities/840.0.0 - Pon.png" Name="Pon" Variant="0" Subtype="0" />
+	</group>
+
+	<group Name="Mines Obstacles">
+		<group Name="Cross Stone Shooter"/>
+	</group>
+
+	<group Name="Ashpit Enemies">
+		<entity BaseHP="20" Tags="Champion" ID="889" Image="Entities/889.0.0 - Clickety Clack.png" Name="Clickety Clack" Variant="0" Subtype="0"/>
+		<entity BaseHP="40" Tags="Champion" ID="87" Image="Entities/87.1.0 - Crackle.png" Name="Crackle" Variant="1" Subtype="0"/>
+		<entity BaseHP="26" Tags="Champion" ID="844" Image="Entities/844.0.0 - Bombgagger.png" Name="Bombgagger" Variant="1" Subtype="0"/>
+		<entity BaseHP="50" Tags="Champion" ID="830" Image="Entities/830.0.0 - Big Bony.png" Name="Big Bony" Variant="0" Subtype="0"/>
+		<entity BaseHP="20" Tags="Champion" ID="25" Image="Entities/25.4.0 - Bone Fly.png" Name="Bone Fly" Variant="4" Subtype="0"/>
+		<entity BaseHP="26" Tags="Champion" ID="23" Image="Entities/23.3.0 - Carrion Princess.png" Name="Carrion Princess" Variant="3" Subtype="0" />
+		<entity BaseHP="10" Tags="Champion" ID="881" Image="Entities/881.1.0 - Pasty.png" Name="Pasty" Variant="1" Subtype="0" />
+		<entity BaseHP="24" Tags="Champion" ID="880" Image="Entities/880.0.0 - Flesh Maiden.png" Name="Flesh Maiden" Variant="0" Subtype="0" />
+		<entity BaseHP="22" Tags="Champion" ID="882" Image="Entities/882.0.0 - Dust.png" Name="Dust" Variant="0" Subtype="0" />
+		<entity BaseHP="80" ID="212" Image="Entities/212.4.0 - Redskull.png" Name="Redskull" Variant="4" Subtype="0" />
+		<group Name="Dusty Death's Head">
+			<defaults>
+				<entity>
+					<tag>DustyDeathsHeads</tag>
+				</entity>
+			</defaults>
+			<entity BaseHP="20" ID="887" Image="Entities/887.0.0 - Dusty Death's Head (left).png" Name="Dusty Death's Head (left)" Variant="0" Subtype="0" MirrorX="887.0.1"/>
+			<entity BaseHP="20" ID="887" Image="Entities/887.0.1 - Dusty Death's Head (right).png" Name="Dusty Death's Head (right)" Variant="0" Subtype="1" MirrorX="887.0.0"/>
+		</group>
+		<entity BaseHP="22" Tags="Champion" ID="828" Image="Entities/828.0.0 - Necro.png" Name="Necro" Variant="0" Subtype="0" />
+	</group>
+
+	<group Name="Ashpit Obstacles">
+		<entity Name="Vomit Grimace"/>
+		<entity BaseHP="20" ID="42" Image="Entities/42.2.0 - Triple Grimace.png" Name="Triple Grimace" Variant="2" Subtype="0" />
+	</group>
+
+	<group Name="Depths Enemies">
+		<entity Name="Needle"/>
+		<entity Name="Army Fly"/>
+	</group>
+
+	<group Name="Necropolis Enemies">
+		<entity BaseHP="20" Tags="Champion" ID="29" Image="Entities/29.2.0 - Eggy.png" Name="Eggy" Variant="2" Subtype="0"/>
+		<entity Name="Migraine"/>
+		<entity Name="Swarm Spider"/>
+	</group>
+
+	<group Name="Necropolis Obstacles">
+		<entity Name="Triple Grimace"/>
+	</group>
+
+	<group Name="Dank Depths Enemies">
+		<entity Name="Ink"/>
+		<entity BaseHP="28" Tags="Champion" ID="34" Image="Entities/34.1.0 - Sticky Leaper.png" Name="Sticky Leaper" Variant="1" Subtype="0"/>
+		<group Name="Slog">
+			<defaults>
+				<entity>
+					<tag>Champion</tag>
+					<tag>Slogs</tag>
+				</entity>
+			</defaults>
+			<entity BaseHP="28" ID="40" Image="Entities/40.2.0 - Slog (random).png" Name="Slog (random)" Variant="2" Subtype="0"/>
+			<entity BaseHP="28" ID="40" Image="Entities/40.2.1 - Slog (left).png" Name="Slog (left)" Variant="2" Subtype="1" MirrorX="40.2.3" />
+			<entity BaseHP="28" ID="40" Image="Entities/40.2.2 - Slog (up).png" Name="Slog (up)" Variant="2" Subtype="2" MirrorY="40.2.4" />
+			<entity BaseHP="28" ID="40" Image="Entities/40.2.3 - Slog (right).png" Name="Slog (right)" Variant="2" Subtype="3" MirrorX="40.2.1" />
+			<entity BaseHP="28" ID="40" Image="Entities/40.2.4 - Slog (down).png" Name="Slog (down)" Variant="2" Subtype="4" MirrorY="40.2.2" />
+		</group>
+		<entity BaseHP="16" Tags="Champion" ID="878" Image="Entities/878.0.0 - Butt Slicker.png" Name="Butt Slicker" Variant="0" Subtype="0" />
+		<entity Name="Needle"/>
+	</group>
+
+	<group Name="Dank Depths Obstacles">
+		<entity Name="Triple Grimace"/>
+	</group>
+
+	<group Name="Chapter 3 (Alt Path) Obstacles">
+		<entity Name="Triple Grimace"/>
+		<entity BaseHP="100" ID="877" Image="Entities/877.0.0 - Grudge.png" Name="Grudge" Variant="0" Subtype="0" />
+		<group Label="Teleporters">
+			<defaults>
+				<entity>
+					<tag>Grid</tag>
+					<tag>InEmptyRooms</tag>
+					<tag>InNonCombatRooms</tag>
+					<tag>Teleporters</tag>
+				</entity>
+			</defaults>
+			<entity ID="6100" Image="Entities/6100.0.0 - Teleporter(Square).png" Name="Teleporter(Square)" Subtype="0" Variant="0" />
+			<entity ID="6100" Image="Entities/6100.1.0 - Teleporter(Moon).png" Name="Teleporter(Moon)" Subtype="0" Variant="1" />
+			<entity ID="6100" Image="Entities/6100.2.0 - Teleporter(Rhombus).png" Name="Teleporter(Rhombus)" Subtype="0" Variant="2" />
+			<entity ID="6100" Image="Entities/6100.3.0 - Teleporter(M).png" Name="Teleporter(M)" Subtype="0" Variant="3" />
+			<entity ID="6100" Image="Entities/6100.4.0 - Teleporter(Pentagram).png" Name="Teleporter(Pentagram)" Subtype="0" Variant="4" />
+			<entity ID="6100" Image="Entities/6100.5.0 - Teleporter(Cross).png" Name="Teleporter(Cross)" Subtype="0" Variant="5" />
+			<entity ID="6100" Image="Entities/6100.6.0 - Teleporter(Triangle).png" Name="Teleporter(Triangle)" Subtype="0" Variant="6" />
+
+			<entity ID="6100" Image="Entities/6100.0.1 - Teleporter(Square-off).png" Name="Teleporter(Square-off)" Subtype="1" Variant="0" />
+			<entity ID="6100" Image="Entities/6100.1.1 - Teleporter(Moon-off).png" Name="Teleporter(Moon-off)" Subtype="1" Variant="1" />
+			<entity ID="6100" Image="Entities/6100.2.1 - Teleporter(Rhombus-off).png" Name="Teleporter(Rhombus-off)" Subtype="1" Variant="2" />
+			<entity ID="6100" Image="Entities/6100.3.1 - Teleporter(M-off).png" Name="Teleporter(M-off)" Subtype="1" Variant="3" />
+			<entity ID="6100" Image="Entities/6100.4.1 - Teleporter(Pentagram-off).png" Name="Teleporter(Pentagram-off)" Subtype="1" Variant="4" />
+			<entity ID="6100" Image="Entities/6100.5.1 - Teleporter(Cross-off).png" Name="Teleporter(Cross-off)" Subtype="1" Variant="5" />
+			<entity ID="6100" Image="Entities/6100.6.1 - Teleporter(Triangle-off).png" Name="Teleporter(Triangle-off)" Subtype="1" Variant="6" />
+		</group>
+	</group>
+
+	<group Name="Chapter 3 (Alt Path) Enemies">
+		<entity Name="Bony"/>
+		<entity BaseHP="33" Tags="Champion" ID="24" Image="Entities/24.3.0 - Cursed Globin.png" Name="Cursed Globin" Variant="3" Subtype="0"/>
+		<entity BaseHP="20" Tags="Champion" ID="841" Image="Entities/841.0.0 - Revenant.png" Name="Revenant" Variant="0" Subtype="0"/>
+		<entity BaseHP="35" Tags="Champion" ID="841" Image="Entities/841.1.0 - Quad Revenant.png" Name="Quad Revenant" Variant="1" Subtype="0"/>
+		<entity BaseHP="35" Tags="Champion" ID="834" Image="Entities/834.0.0 - Whipper.png" Name="Whipper" Variant="0" Subtype="0" />
+		<entity BaseHP="35" Tags="Champion" ID="834" Image="Entities/834.1.0 - Snapper.png" Name="Snapper" Variant="1" Subtype="0" />
+		<entity BaseHP="25" Tags="Champion" ID="836" Image="Entities/836.0.0 - Vis Versa.png" Name="Vis Versa" Variant="0" Subtype="0" />
+		<entity BaseHP="40" Tags="Champion" ID="886" Image="Entities/886.0.0 - Vis Fatty.png" Name="Vis Fatty" Variant="0" Subtype="0"/>
+		<entity BaseHP="40" Tags="Champion" ID="886" Image="Entities/886.1.0 - Fetal Demon.png" Name="Fetal Demon" Variant="1" Subtype="0"/>
+		<entity Name="Soul Sucker"/>
+		<entity BaseHP="18" Tags="Champion" ID="883" Image="Entities/883.0.0 - Baby Begotten.png" Name="Baby Begotten" Variant="0" Subtype="0" />
+		<entity BaseHP="15" ID="306" Image="Entities/306.1.0 - Lil Portal.png" Name="Lil Portal" Variant="1" Subtype="0" />
+		<entity BaseHP="15" ID="306" Image="Entities/306.1.1 - Lil Portal (flies only).png" Name="Lil Portal (flies only)" Variant="1" Subtype="1" />
+		<entity Name="Death's Head"/>
+	</group>
+
+	<group Label="Mausoleum Enemies">
+		<entity BaseHP="20" Tags="Champion" ID="41" Image="Entities/41.2.0 - Loose Knight.png" Name="Loose Knight" Variant="2" Subtype="0" />
+		<entity BaseHP="20" ID="41" Image="Entities/41.3.0 - Brainless Knight.png" Name="Brainless Knight" Variant="3" Subtype="0" />
+		<entity Name="Pon"/>
+		<entity BaseHP="42" Tags="Champion" ID="834" Image="Entities/834.2.0 - Flagellant.png" Name="Flagellant" Variant="2" Subtype="0" />
+		<entity BaseHP="45" Tags="Champion" ID="816" Image="Entities/816.1.0 - Kineti.png" Name="Kineti" Variant="1" Subtype="0" />
+		<entity BaseHP="25" Tags="Champion" ID="833" Image="Entities/833.0.0 - Candler.png" Name="Candler" Variant="0" Subtype="0" />
+		<entity BaseHP="24" Tags="Champion" ID="885" Image="Entities/885.0.0 - Cultist.png" Name="Cultist" Variant="0" Subtype="0" />
+		<entity BaseHP="20" ID="212" Image="Entities/212.2.0 - Cursed Death's Head.png" Name="Cursed Death's Head" Variant="2" Subtype="0" />
+		<entity BaseHP="14" ID="805" Image="Entities/805.0.0 - Bishop.png" Name="Bishop" Variant="0" Subtype="0" />
+		<entity Name="Dark Ball"/>
+	</group>
+
+	<group Name="Gehenna Obstacles">
+		<entity BaseHP="100" ID="893" Image="Entities/893.0.0 - Ball and Chain.png" Name="Ball and Chain" Variant="0" Subtype="0" >
+			<bitfield Key="Subtype">
+				<spinner Length="4" Name="Distance" Unit="Grids">
+					<tooltip>Distance in grid tiles between the source grid and the Ball and Chain</tooltip>
+				</spinner>
+				<spinner Length="4" Name="Speed"/>
+				<dropdown Length="1">
+					<choice>Clockwise</choice>
+					<choice>Counter-Clockwise</choice>
+				</dropdown>
+			</bitfield>
+		</entity>
+	</group>
+
+	<group Name="Gehenna Enemies">
+		<entity BaseHP="18" Tags="Champion" ID="891" Image="Entities/891.0.0 - Goat.png" Name="Goat" Variant="0" Subtype="0"/>
+		<entity BaseHP="24" Tags="Champion" ID="891" Image="Entities/891.1.0 - Black Goat.png" Name="Black Goat" Variant="1" Subtype="0"/>
+		<entity BaseHP="12" Tags="Champion" ID="890" Image="Entities/890.0.0 - Maze Roamer (white).png" Name="Maze Roamer (white)" Variant="0" Subtype="0"/>
+		<entity BaseHP="12" Tags="Champion" ID="890" Image="Entities/890.0.1 - Maze Roamer (red).png" Name="Maze Roamer (red)" Variant="0" Subtype="1"/>
+		<entity BaseHP="30" Tags="Champion" ID="41" Image="Entities/41.4.0 - Black Knight.png" Name="Black Knight" Variant="4" Subtype="0" />
+		<entity BaseHP="20" ID="892" Image="Entities/892.0.0 - Poofer.png" Name="Poofer" Variant="0" Subtype="0" />
+		<entity BaseHP="60" Tags="Champion" ID="863" Image="Entities/863.0.0 - Morningstar.png" Name="Morningstar" Variant="0" Subtype="0" />
+		<entity BaseHP="40" ID="864" Image="Entities/864.0.0 - Mockulus.png" Name="Mockulus" Variant="0" Subtype="0" />
+		<entity BaseHP="24" Tags="Champion" ID="885" Image="Entities/885.1.0 - Blood Cultist.png" Name="Blood Cultist" Variant="1" Subtype="0" />
+		<entity BaseHP="20" ID="212" Image="Entities/212.3.0 - Brimstone Death's Head.png" Name="Brimstone Death's Head" Variant="3" Subtype="0" />
+		<group Name="Mask II">
+			<group Name="1/2 Hearts">
+				<defaults>
+					<entity>
+						<tag>HalfHeartEnemy</tag>
+					</entity>
+				</defaults>
+				<entity BaseHP="40" ID="92" Image="Entities/92.1.0 - 1_2 Heart.png" Name="1/2 Heart (Left)" Variant="1" Subtype="0" />
+				<entity BaseHP="40" ID="92" Image="Entities/92.1.1 - 1_2 Heart.png" Name="1/2 Heart (Right)" Variant="1" Subtype="1" />
+			</group>
+			<entity BaseHP="40" ID="93" Image="Entities/93.1.0 - Mask II.png" Name="Mask II" Variant="1" Subtype="0" />
+		</group>
+	</group>
+
+	<group Name="Chapter 4 (Main Path) Enemies">
+		<entity Name="Needle"/>
+	</group>
+
+	<group Name="Utero Enemies">
+		<entity Name="Eggy"/>
+		<entity BaseHP="125" Tags="Champion" ID="857" Image="Entities/857.0.0 - Cohort.png" Name="Cohort" Variant="0" Subtype="0"/>
+		<entity BaseHP="60" Tags="Champion" ID="835" Image="Entities/835.0.0 - Peeping Fatty.png" Name="Peeping Fatty" Variant="0" Subtype="0"/>
+		<entity BaseHP="60" ID="835" Image="Entities/835.10.0 - Peeping Fatty Eye.png" Name="Peeping Fatty Eye" Variant="10" Subtype="0"/>
+		<entity BaseHP="25" Tags="Champion" ID="38" Image="Entities/38.3.0 - Wrinkly Baby.png" Name="Wrinkly Baby" Variant="3" Subtype="0" />
+		<entity BaseHP="28" Tags="Champion" ID="229" Image="Entities/229.1.0 - Planetoid.png" Name="Planetoid" Variant="1" Subtype="0" />
+		<entity BaseHP="20" Tags="Champion" ID="859" Image="Entities/859.0.0 - Floast.png" Name="Floast" Variant="0" Subtype="0" />
+	</group>
+
+	<group Name="Utero Obstacles">
+		<entity Name="Triple Grimace"/>
+	</group>
+
+	<group Name="Scarred Womb Enemies">
+		<entity Name="Faceless"/>
+		<group Name="Mask II"/>
+	</group>
+
+	<group Name="Corpse Obstacles" Label="Obstacles">
+		<entity Name="Stone Grimace"/>
+		<entity Name="Triple Grimace"/>
+		<group Name="Spikeball">
+			<defaults>
+				<entity>
+					<tag>Spikeballs</tag>
+				</entity>
+			</defaults>
+			<entity BaseHP="100" ID="852" Image="Entities/852.0.0 - Spikeball (left).png" Name="Spikeball (left)" Subtype="0" Variant="0" MirrorX="852.0.2"/>
+			<entity BaseHP="100" ID="852" Image="Entities/852.0.1 - Spikeball (up).png" Name="Spikeball (up)" Subtype="1" Variant="0" MirrorY="852.0.3"/>
+			<entity BaseHP="100" ID="852" Image="Entities/852.0.2 - Spikeball (right).png" Name="Spikeball (right)" Subtype="2" Variant="0" MirrorX="852.0.0"/>
+			<entity BaseHP="100" ID="852" Image="Entities/852.0.3 - Spikeball (down).png" Name="Spikeball (down)" Subtype="3" Variant="0" MirrorY="852.0.1" />
+		</group>
+	</group>
+
+	<group Name="Corpse Enemies" Label="Enemies">
+		<entity Name="Cohort"/>
+		<entity BaseHP="80" Tags="Champion" ID="856" Image="Entities/856.0.0 - Gasbag.png" Name="Gasbag" Variant="0" Subtype="0" />
+		<entity BaseHP="40" Tags="Champion" ID="865" Image="Entities/865.0.0 - Evis.png" Name="Evis" Variant="0" Subtype="0" />
+		<group Name="Rotten Gapers">
+			<defaults>
+				<entity>
+					<tag>Champion</tag>
+					<tag>RottenGapers</tag>
+				</entity>
+			</defaults>
+			<entity BaseHP="24" ID="10" Image="Entities/10.3.0 - Rotten Gaper (random).png" Name="Rotten Gaper (random)" Variant="3" Subtype="0"/>
+			<entity BaseHP="24" ID="10" Image="Entities/10.3.1 - Rotten Gaper (subtype 1).png" Name="Rotten Gaper (subtype 1)" Variant="3" Subtype="1"/>
+			<entity BaseHP="24" ID="10" Image="Entities/10.3.2 - Rotten Gaper (subtype 2).png" Name="Rotten Gaper (subtype 2)" Variant="3" Subtype="2"/>
+			<entity BaseHP="24" ID="10" Image="Entities/10.3.3 - Rotten Gaper (subtype 3).png" Name="Rotten Gaper (subtype 3)" Variant="3" Subtype="3"/>
+			<entity BaseHP="24" ID="10" Image="Entities/10.3.4 - Rotten Gaper (subtype 4).png" Name="Rotten Gaper (subtype 4)" Variant="3" Subtype="4"/>
+			<entity BaseHP="24" ID="10" Image="Entities/10.3.5 - Rotten Gaper (subtype 5).png" Name="Rotten Gaper (subtype 5)" Variant="3" Subtype="5"/>
+		</group>
+		<entity BaseHP="40" Tags="Champion" ID="850" Image="Entities/850.0.0 - Level 2 Gaper.png" Name="Level 2 Gaper" Variant="0" Subtype="0"/>
+		<entity BaseHP="20" Tags="Champion" ID="850" Image="Entities/850.1.0 - Level 2 Horf.png" Name="Level 2 Horf" Variant="1" Subtype="0" />
+		<entity BaseHP="20" Tags="Champion" ID="850" Image="Entities/850.2.0 - Level 2 Gusher.png" Name="Level 2 Gusher" Variant="2" Subtype="0"/>
+		<entity BaseHP="40" Tags="Champion" ID="851" Image="Entities/851.0.0 - Twitchy.png" Name="Twitchy" Variant="0" Subtype="0"/>
+		<entity BaseHP="80" Tags="Champion" ID="831" Image="Entities/831.0.0 - Gutted Fatty.png" Name="Gutted Fatty" Variant="0" Subtype="0"/>
+		<entity BaseHP="80" ID="831" Image="Entities/831.10.0 - Gutted Fatty Eye.png" Name="Gutted Fatty Eye" Variant="10" Subtype="0"/>
+		<entity BaseHP="22" Tags="Champion" ID="831" Image="Entities/831.20.0 - Festering Guts.png" Name="Festering Guts" Variant="20" Subtype="0"/>
+		<entity BaseHP="62" Tags="Champion" ID="57" Image="Entities/57.2.0 - Dead Meat.png" Name="Dead Meat" Variant="2" Subtype="0" />
+		<group Name="Cysts">
+			<defaults>
+				<entity>
+					<tag>Champion</tag>
+					<tag>Cysts</tag>
+				</entity>
+			</defaults>
+			<entity BaseHP="25" ID="862" Image="Entities/862.0.0 - Cyst (random).png" Name="Cyst (random)" Variant="0" Subtype="0" />
+			<entity BaseHP="25" ID="862" Image="Entities/862.0.1 - Cyst (left).png" Name="Cyst (left)" Variant="0" Subtype="1" MirrorX="862.0.3" />
+			<entity BaseHP="25" ID="862" Image="Entities/862.0.2 - Cyst (up).png" Name="Cyst (up)" Variant="0" Subtype="2" MirrorY="862.0.4" />
+			<entity BaseHP="25" ID="862" Image="Entities/862.0.3 - Cyst (right).png" Name="Cyst (right)" Variant="0" Subtype="3" MirrorX="862.0.1" />
+			<entity BaseHP="25" ID="862" Image="Entities/862.0.4 - Cyst (down).png" Name="Cyst (down)" Variant="0" Subtype="4" MirrorY="862.0.2" />
+		</group>
+		<entity BaseHP="20" Tags="Champion" ID="25" Image="Entities/25.5.0 - Sick Boom Fly.png" Name="Sick Boom Fly" Variant="5" Subtype="0"/>
+		<entity BaseHP="44" Tags="Champion" ID="61" Image="Entities/61.4.0 - Mama Fly.png" Name="Mama Fly" Variant="4" Subtype="0"/>
+		<entity BaseHP="90" Tags="Champion" ID="854" Image="Entities/854.0.0 - Adult Leech.png" Name="Adult Leech" Variant="0" Subtype="0" />
+		<entity Name="Leech"/>
+		<entity BaseHP="40" Tags="Champion" ID="855" Image="Entities/855.0.0 - Level 2 Charger.png" Name="Level 2 Charger" Variant="0" Subtype="0" />
+		<entity Name="Maggot"/>
+		<entity Name="Charger"/>
+		<group Name="Small Maggots">
+			<defaults>
+				<entity>
+					<tag>SmallMaggots</tag>
+				</entity>
+			</defaults>
+			<entity BaseHP="10" ID="853" Image="Entities/853.0.0 - Small Maggot.png" Name="Small Maggot" Variant="0" Subtype="0" />
+			<entity BaseHP="10" ID="853" Image="Entities/853.10.3 - Small Maggot (three).png" Name="Small Maggot (three)" Variant="10" Subtype="3"/>
+			<entity BaseHP="10" ID="853" Image="Entities/853.10.5 - Small Maggot (five).png" Name="Small Maggot (five)" Variant="10" Subtype="5"/>
+		</group>
+		<entity Name="Wrinkly Baby"/>
+		<entity BaseHP="32" Tags="Champion" ID="860" Image="Entities/860.0.0 - Unborn.png" Name="Unborn" Variant="0" Subtype="0" />
+		<entity BaseHP="19" Tags="Champion" ID="861" Image="Entities/861.0.0 - Pustule.png" Name="Pustule" Variant="0" Subtype="0" />
+		<entity Name="Floast"/>
+	</group>
+
+	<group Name="Sheol Enemies">
+		<entity Name="Whipper"/>
+		<entity Name="Snapper"/>
+		<entity Name="Flagellant"/>
+		<entity BaseHP="80" ID="888" Image="Entities/888.0.0 - Shady.png" Name="Shady" Variant="0" Subtype="0"/>
+	</group>
+
+	<group Name="Cathedral Enemies">
+		<entity BaseHP="60" Tags="Champion" ID="227" Image="Entities/227.1.0 - Holy Bony.png" Name="Holy Bony" Variant="1" Subtype="0"/>
+		<entity BaseHP="40" Tags="Champion" ID="22" Image="Entities/22.2.0 - Holy Mulligan.png" Name="Holy Mulligan" Variant="2" Subtype="0" />
+		<entity BaseHP="16" Tags="Champion" ID="38" Image="Entities/38.1.1 - Angelic Baby (small).png" Name="Angelic Baby (small)" Variant="1" Subtype="1" />
+		<entity BaseHP="20" Tags="Champion" ID="60" Image="Entities/60.2.0 - Holy Eye.png" Name="Holy Eye" Variant="2" Subtype="0" />
+		<entity Name="Candler"/>
+		<entity Name="Bishop"/>
+	</group>
+
+	<group Name="Cathedral Obstacles">
+		<entity Name="Triple Grimace"/>
+	</group>
+
+	<group Name="Dark Room Enemies">
+		<entity Name="Shady"/>
+	</group>
+
+	<group Name="Ascent Enemies">
+		<entity Name="Cohort"/>
+		<entity Name="Peeping Fatty"/>
+		<entity Name="Peeping Fatty Eye"/>
+		<entity Name="Shady"/>
+		<entity BaseHP="75" ID="14" Image="Entities/14.2.0 - Tainted Pooter.png" Name="Tainted Pooter" Subtype="0" Variant="2" />
+		<entity BaseHP="120" ID="22" Image="Entities/22.3.0 - Tainted Mulligan.png" Name="Tainted Mulligan" Variant="3" Subtype="0" />
+		<entity BaseHP="20" ID="25" Image="Entities/25.6.0 - Tainted Boom Fly.png" Name="Tainted Boom Fly" Variant="6" Subtype="0" />
+		<entity BaseHP="80" ID="29" Image="Entities/29.3.0 - Tainted Hopper.png" Name="Tainted Hopper" Variant="3" Subtype="0" />
+		<entity BaseHP="60" ID="31" Image="Entities/31.1.0 - Tainted Spitty.png" Name="Tainted Spitty" Variant="1" Subtype="0" />
+		<entity BaseHP="14" ID="61" Image="Entities/61.7.0 - Tainted Sucker.png" Name="Tainted Sucker" Variant="7" Subtype="0" />
+		<entity BaseHP="50" ID="240" Image="Entities/240.3.0 - Tainted Soy Creep.png" PlaceVisual="WallSnap" Name="Tainted Soy Creep" Variant="3" Subtype="0" />
+		<entity BaseHP="100" ID="244" Image="Entities/244.2.0 - Tainted Round Worm.png" Name="Tainted Round Worm" Variant="2" Subtype="0" />
+		<entity BaseHP="100" ID="244" Image="Entities/244.2.1 - Tainted Round Worm Butt.png" Name="Tainted Round Worm Butt" Variant="2" Subtype="1" />
+		<entity BaseHP="100" ID="244" Image="Entities/244.3.0 - Tainted Tube Worm.png" Name="Tainted Tube Worm" Variant="3" Subtype="0" />
+		<entity BaseHP="50" ID="812" Image="Entities/812.1.0 - Tainted Sub Horf.png" Name="Tainted Sub Horf" Variant="1" Subtype="0" />
+		<entity BaseHP="100" ID="827" Image="Entities/827.1.0 - Tainted Faceless.png" Name="Tainted Faceless" Variant="1" Subtype="0" />
+		<entity BaseHP="80" Tags="Champion" ID="829" Image="Entities/829.1.0 - Tainted Mole.png" Name="Tainted Mole" Variant="1" Subtype="0" />
+		<entity BaseHP="60" ID="855" Image="Entities/855.1.0 - Elleech.png" Name="Elleech" Variant="1" Subtype="0" />
+	</group>
+
+	<group Name="Home Events">
+		<defaults>
+			<entity>
+				<tag>InNonCombatRooms</tag>
+			</entity>
+		</defaults>
+		<entity ID="6" Image="Entities/6.14.0 - Isaac (secret).png" Name="Isaac (secret)" Variant="14" Subtype="0" />
+		<entity ID="5" Image="Entities/5.380.10 - Mom's Bed.png" Name="Mom's Bed" Variant="380" Subtype="10" />
+		<entity ID="5" Image="Entities/5.390.0 - Mom's Chest.png" Name="Mom's Chest" Variant="390" Subtype="0" />
+		<entity BaseHP="1" ID="960" Image="Entities/960.1.0 - Mom's Dresser.png" Name="Mom's Dresser" Variant="1" Subtype="0" />
+		<entity BaseHP="1" ID="960" Image="Entities/960.2.0 - Mom's Vanity.png" Name="Mom's Vanity" Variant="2" Subtype="0" />
+		<entity BaseHP="1" ID="960" Image="Entities/960.3.0 - Couch.png" Name="Couch" Variant="3" Subtype="0" />
+		<entity BaseHP="1" ID="960" Image="Entities/960.4.0 - TV.png" Name="TV" Variant="4" Subtype="0" />
+		<entity ID="999" Image="Entities/1000.74.1 - Moms Room Carpet.png" Name="Moms Room Carpet" Variant="74" Subtype="1" PlaceVisual="0,1.5">
+			<tag>Grid</tag>
+			<tag>NoBlockDoors</tag>
+		</entity>
+		<entity ID="999" Image="Entities/1000.74.2 - Living Room Carpet.png" Name="Living Room Carpet" Variant="74" Subtype="2" PlaceVisual="0,1.5">
+			<tag>Grid</tag>
+			<tag>NoBlockDoors</tag>
+		</entity>
+	</group>
+
 	<!--——— Bosses ———-->
+	<group Name="Chapter 1 Bosses (Main Path) Shared">
+		<entity BaseHP="234" ID="908" Image="Entities/908.0.0 - Baby Plum.png" Name="Baby Plum" Variant="0" Subtype="0" />
+	</group>
 
-	<!-- Chapter 1 -->
-	<entity BaseHP="250" Boss="1" Group="Chapter 1" ID="20" Image="resources/Entities/20.0.0 - Monstro.png" Kind="Bosses" Name="Monstro" Subtype="0" Variant="0" />
-	<entity BaseHP="140" Boss="1" Group="Chapter 1" ID="79" Image="resources/Entities/79.0.0 - Gemini.png" Kind="Bosses" Name="Gemini" Subtype="0" Variant="0" />
-	<entity BaseHP="140" Boss="1" Group="Chapter 1" ID="79" Image="resources/Entities/79.10.0 - Gemini Baby.png" Kind="Bosses" Name="Suture (Gemini Baby)" Subtype="0" Variant="10" />
-	<entity BaseHP="140" Boss="1" Group="Chapter 1" ID="79" Image="resources/Entities/79.1.0 - Steven.png" Kind="Bosses" Name="Steven" Subtype="0" Variant="1" />
-	<entity BaseHP="140" Boss="1" Group="Chapter 1" ID="79" Image="resources/Entities/79.11.0 - Steven Baby.png" Kind="Bosses" Name="Steven Baby" Subtype="0" Variant="11" />
-	<entity BaseHP="140" Boss="1" Group="Chapter 1" ID="79" Image="resources/Entities/79.2.0 - The Blighted Ovum.png" Kind="Bosses" Name="The Blighted Ovum" Subtype="0" Variant="2" />
-	<entity BaseHP="22" Boss="1" Group="Chapter 1" ID="19" Image="resources/Entities/19.0.0 - Larry Jr.png" Kind="Bosses" Name="Larry Jr." Subtype="0" Variant="0" />
-	<entity BaseHP="300" Boss="1" Group="Chapter 1" ID="261" Image="resources/Entities/261.0.0 - Dingle.png" Kind="Bosses" Name="Dingle" Subtype="0" Variant="0" />
-	<entity BaseHP="375" Boss="1" Group="Chapter 1" ID="261" Image="resources/Entities/261.1.0 - Dangle.png" Kind="Bosses" Name="Dangle" Subtype="0" Variant="1" />
-	<entity BaseHP="110" Boss="1" Group="Chapter 1" ID="67" Image="resources/Entities/67.0.0 - The Duke of Flies.png" Kind="Bosses" Name="The Duke of Flies" Subtype="0" Variant="0" />
-	<entity BaseHP="130" Boss="1" Group="Chapter 1" ID="100" Image="resources/Entities/100.0.0 - Widow.png" Kind="Bosses" Name="Widow" Subtype="0" Variant="0" />
-	<entity BaseHP="90" Boss="1" Group="Chapter 1" ID="237" Image="resources/Entities/237.1.0 - Gurgling (boss).png" Kind="Bosses" Name="Gurgling (boss)" Subtype="0" Variant="1" />
-	<entity BaseHP="90" Boss="1" Group="Chapter 1" ID="237" Image="resources/Entities/237.2.0 - Turdling.png" Kind="Bosses" Name="Turdling" Subtype="0" Variant="2" />
-	<entity BaseHP="180" Boss="1" Group="Chapter 1" ID="62" Image="resources/Entities/62.0.0 - Pin.png" Kind="Bosses" Name="Pin" Subtype="0" Variant="0" />
-	<entity BaseHP="200" Boss="1" Group="Chapter 1" ID="260" Image="resources/Entities/260.0.0 - Haunt.png" Kind="Bosses" Name="Haunt" Subtype="0" Variant="0" />
-	<entity BaseHP="240" Boss="1" Group="Chapter 1" ID="63" Image="resources/Entities/63.0.0 - Famine.png" Kind="Bosses" Name="Famine" Subtype="0" Variant="0" />
-	<entity BaseHP="200" Boss="1" Group="Chapter 1" ID="404" Image="resources/Entities/404.0.0 - Little Horn.png" Kind="Bosses" Name="Little Horn" Subtype="0" Variant="0" />
-	<entity BaseHP="250" Boss="1" Group="Chapter 1" ID="405" Image="resources/Entities/405.0.0 - Rag Man.png" Kind="Bosses" Name="Rag Man" Subtype="0" Variant="0" />
-	<entity BaseHP="234" Boss="1" Group="Chapter 1" ID="908" Image="resources/Entities/908.0.0 - Baby Plum.png" Kind="Bosses" Name="Baby Plum" Variant="0" Subtype="0" />
-	
-	<!-- Chapter 1.5 -->
-	<entity BaseHP="200" Boss="1" Group="Chapter 1.5" ID="62" Image="resources/Entities/62.3.0 - Wormwood.png" Kind="Bosses" Name="Wormwood" Variant="3" Subtype="0" />
-	<entity BaseHP="200" Boss="1" Group="Chapter 1.5" ID="901" Image="resources/Entities/901.0.0 - Lil Blub.png" Kind="Bosses" Name="Lil Blub" Variant="0" Subtype="0" />
-	<entity BaseHP="240" Boss="1" Group="Chapter 1.5" ID="902" Image="resources/Entities/902.0.0 - Rainmaker.png" Kind="Bosses" Name="Rainmaker" Variant="0" Subtype="0" />
-	<entity BaseHP="280" Boss="1" Group="Chapter 1.5" ID="913" Image="resources/Entities/913.0.0 - Min Min.png" Kind="Bosses" Name="Min Min" Variant="0" Subtype="0" />
-	<entity BaseHP="420" Boss="1" Group="Chapter 1.5" ID="914" Image="resources/Entities/914.0.0 - Clog.png" Kind="Bosses" Name="Clog" Variant="0" Subtype="0" />
-	<entity BaseHP="380" Boss="1" Group="Chapter 1.5" ID="917" Image="resources/Entities/917.0.0 - Colostomia.png" Kind="Bosses" Name="Colostomia" Variant="0" Subtype="0" />
-	<entity BaseHP="190" Boss="1" Group="Chapter 1.5" ID="918" Image="resources/Entities/918.0.0 - Turdlet.png" Kind="Bosses" Name="Turdlet" Variant="0" Subtype="0" />
-	
-	<!-- Chapter 2 -->
-	<entity BaseHP="350" Boss="1" Group="Chapter 2" ID="28" Image="resources/Entities/28.0.0 - Chub.png" Kind="Bosses" Name="Chub" Subtype="0" Variant="0" />
-	<entity BaseHP="350" Boss="1" Group="Chapter 2" ID="28" Image="resources/Entities/28.1.0 - C.H.A.D..png" Kind="Bosses" Name="C.H.A.D." Subtype="0" Variant="1" />
-	<entity BaseHP="350" Boss="1" Group="Chapter 2" ID="28" Image="resources/Entities/28.2.0 - The Carrion Queen.png" Kind="Bosses" Name="The Carrion Queen" Subtype="0" Variant="2" />
-	<entity BaseHP="450" Boss="1" Group="Chapter 2" ID="68" Image="resources/Entities/68.0.0 - Peep.png" Kind="Bosses" Name="Peep" Subtype="0" Variant="0" />
-	<entity BaseHP="595" Boss="1" Group="Chapter 2" ID="36" Image="resources/Entities/36.0.0 - Gurdy.png" PlaceVisual="0,1" Kind="Bosses" Name="Gurdy" Subtype="0" Variant="0" />
-	<entity BaseHP="250" Boss="1" Group="Chapter 2" ID="99" Image="resources/Entities/99.0.0 - Gurdy Jr.png" Kind="Bosses" Name="Gurdy Jr." Subtype="0" Variant="0" />
-	<entity BaseHP="8" Boss="1" Group="Chapter 2" ID="73" Image="resources/Entities/73.0.0 - Fistula Small.png" Kind="Bosses" Name="Fistula Small" Subtype="0" Variant="0" />
-	<entity BaseHP="15" Boss="1" Group="Chapter 2" ID="72" Image="resources/Entities/72.0.0 - Fistula Medium.png" Kind="Bosses" Name="Fistula Medium" Subtype="0" Variant="0" />
-	<entity BaseHP="60" Boss="1" Group="Chapter 2" ID="71" Image="resources/Entities/71.0.0 - Fistula Big.png" Kind="Bosses" Name="Fistula Big" Subtype="0" Variant="0" />
-	<entity BaseHP="22" Boss="1" Group="Chapter 2" ID="19" Image="resources/Entities/19.1.0 - The Hollow.png" Kind="Bosses" Name="The Hollow" Subtype="0" Variant="1" />
-	<entity BaseHP="150" Boss="1" Group="Chapter 2" ID="67" Image="resources/Entities/67.1.0 - The Husk.png" Kind="Bosses" Name="The Husk" Subtype="0" Variant="1" />
-	<entity BaseHP="215" Boss="1" Group="Chapter 2" ID="100" Image="resources/Entities/100.1.0 - The Wretched.png" Kind="Bosses" Name="The Wretched" Subtype="0" Variant="1" />
-	<entity BaseHP="200" Boss="1" Group="Chapter 2" ID="269" Image="resources/Entities/269.0.0 - Polycephalus.png" Kind="Bosses" Name="Polycephalus" Subtype="0" Variant="0" />
-	<entity BaseHP="350" Boss="1" Group="Chapter 2" ID="262" Image="resources/Entities/262.0.0 - Mega Maw.png" PlaceVisual="0,-2" Kind="Bosses" Name="Mega Maw" Subtype="0" Variant="0" />
-	<entity BaseHP="600" Boss="1" Group="Chapter 2" ID="264" Image="resources/Entities/264.0.0 - Mega Fatty.png" Kind="Bosses" Name="Mega Fatty" Subtype="0" Variant="0" />
-	<entity BaseHP="400" Boss="1" Group="Chapter 2" ID="267" Image="resources/Entities/267.0.0 - Dark One.png" Kind="Bosses" Name="Dark One" Subtype="0" Variant="0" />
-	<entity BaseHP="280" Boss="1" Group="Chapter 2" ID="64" Image="resources/Entities/64.0.0 - Pestilence.png" Kind="Bosses" Name="Pestilence" Subtype="0" Variant="0" />
-	<entity BaseHP="400" Boss="1" Group="Chapter 2" ID="401" Image="resources/Entities/401.0.0 - The Stain.png" Kind="Bosses" Name="The Stain" Subtype="0" Variant="0" />
-	<entity BaseHP="200" Boss="1" Group="Chapter 2" ID="62" Image="resources/Entities/62.2.0 - The Frail.png" Kind="Bosses" Name="The Frail" Subtype="0" Variant="2" />
-	<entity BaseHP="220" Boss="1" Group="Chapter 2" ID="403" Image="resources/Entities/403.0.0 - The Forsaken.png" Kind="Bosses" Name="The Forsaken" Subtype="0" Variant="0" />
-	<entity BaseHP="110" Boss="1" Group="Chapter 2" Kind="Bosses" ID="409" Image="resources/Entities/409.0.0 - RagMega.png" Name="Rag Mega" Variant="0" Subtype="0" />
-	<entity BaseHP="600" Boss="1" Group="Chapter 2" Kind="Bosses" ID="411" Image="resources/Entities/411.0.0 - BigHorn.png" Name="Big Horn" Variant="0" Subtype="0" />
-	<entity BaseHP="385" Boss="1" Group="Chapter 2" ID="916" Image="resources/Entities/916.0.0 - Bumbino.png" Kind="Bosses" Name="Bumbino" Variant="0" Subtype="0" />
-	
-	<!-- Chapter 2.5 -->
-	<entity BaseHP="35" Boss="1" Group="Chapter 2.5" ID="19" Image="resources/Entities/19.2.0 - Tuff Twin.png" Kind="Bosses" Name="Tuff Twin" Variant="2" Subtype="0" />
-	<entity BaseHP="35" Boss="1" Group="Chapter 2.5" ID="19" Image="resources/Entities/19.3.0 - The Shell.png" Kind="Bosses" Name="The Shell" Variant="3" Subtype="0" />
-	<entity BaseHP="580" Boss="1" Group="Chapter 2.5" ID="269" Image="resources/Entities/269.1.0 - The Pile.png" Kind="Bosses" Name="The Pile" Variant="1" Subtype="0" />
-	<entity BaseHP="690" Boss="1" Group="Chapter 2.5" ID="900" Image="resources/Entities/900.0.0 - Reap Creep.png" Kind="Bosses" Name="Reap Creep" Variant="0" Subtype="0" />
-	<entity BaseHP="240" Boss="1" Group="Chapter 2.5" ID="906" Image="resources/Entities/906.0.0 - Hornfel.png" Kind="Bosses" Name="Hornfel" Variant="0" Subtype="0" />
-	<entity BaseHP="6" Boss="1" Group="Chapter 2.5" ID="907" Image="resources/Entities/907.0.0 - Great Gideon.png" Kind="Bosses" Name="Great Gideon" Variant="0" Subtype="0" />
-	<entity BaseHP="6" Boss="1" Group="Chapter 2.5" ID="907" Image="resources/Entities/907.0.1 - Great Gideon (defeated).png" Kind="Bosses" Name="Great Gideon (defeated)" Variant="0" Subtype="1" />
-	<entity BaseHP="444" Boss="1" Group="Chapter 2.5" ID="915" Image="resources/Entities/915.0.0 - Singe.png" Kind="Bosses" Name="Singe" Variant="0" Subtype="0" />
-	<entity BaseHP="100" Group="Chapter 2.5" ID="915" Image="resources/Entities/915.1.0 - Singe's Ball.png" Kind="Bosses" Name="Singe's Ball" Variant="1" Subtype="0" />
+	<group Name="Chapter 1 Bosses">
+		<group Name="Chapter 1 Bosses (Alt Path)" Label="Chapter 1 (Alt Path)">
+			<group Name="Chapter 1 Bosses (Alt Path) Shared"/>
+			<group Name="Downpour Bosses" Label="Downpour"/>
+			<group Name="Dross Bosses" Label="Dross"/>
+		</group>
+	</group>
 
-	<!-- Chapter 3 -->
-	<entity BaseHP="632.5" Boss="1" Group="Chapter 3" ID="43" Image="resources/Entities/43.0.0 - Monstro II.png" Kind="Bosses" Name="Monstro II" Subtype="0" Variant="0" />
-	<entity BaseHP="632.5" Boss="1" Group="Chapter 3" ID="43" Image="resources/Entities/43.1.0 - Gish.png" Kind="Bosses" Name="Gish" Subtype="0" Variant="1" />
-	<entity BaseHP="350" Boss="1" Group="Chapter 3" ID="69" Image="resources/Entities/69.0.0 - Loki.png" Kind="Bosses" Name="Loki" Subtype="0" Variant="0" />
-	<entity BaseHP="450" Boss="1" Group="Chapter 3" ID="68" Image="resources/Entities/68.1.0 - The Bloat.png" Kind="Bosses" Name="The Bloat" Subtype="0" Variant="1" />
-	<entity BaseHP="150" Boss="1" Group="Chapter 3" ID="97" Image="resources/Entities/97.0.0 - Mask of Infamy.png" Kind="Bosses" Name="Mask of Infamy" Subtype="0" Variant="0" />
-	<entity BaseHP="200" Boss="1" Group="Chapter 3" ID="98" Image="resources/Entities/98.0.0 - Heart of Infamy.png" Kind="Bosses" Name="Heart of Infamy" Subtype="0" Variant="0" />
-	<entity BaseHP="800" Boss="1" Group="Chapter 3" ID="265" Image="resources/Entities/265.0.0 - The Cage.png" Kind="Bosses" Name="The Cage" Subtype="0" Variant="0" />
-	<entity BaseHP="500" Boss="1" Group="Chapter 3" ID="263" Image="resources/Entities/263.0.0 - The Gate.png" PlaceVisual="0,-1" Kind="Bosses" Name="The Gate" Subtype="0" Variant="0" />
-	<entity BaseHP="520" Boss="1" Group="Chapter 3" ID="268" Image="resources/Entities/268.0.0 - The Adversary.png" Kind="Bosses" Name="The Adversary" Subtype="0" Variant="0" />
-	<entity BaseHP="500" Boss="1" Group="Chapter 3" ID="65" Image="resources/Entities/65.0.0 - War.png" Kind="Bosses" Name="War" Subtype="0" Variant="0" />
-	<entity BaseHP="500" Boss="1" Group="Chapter 3" ID="65" Image="resources/Entities/65.10.0 - War without Horse.png" Kind="Bosses" Name="War without Horse" Subtype="0" Variant="10" />
-	<entity BaseHP="400" Boss="1" Group="Chapter 3" ID="402" Image="resources/Entities/402.0.0 - Brownie.png" Kind="Bosses" Name="Brownie" Subtype="0" Variant="0" />
-	<entity BaseHP="800" Boss="1" Group="Chapter 3" ID="410" Image="resources/Entities/265.1.0 - SistersVis.png" Kind="Bosses" Name="Sisters Vis" Subtype="0" Variant="0" />
-	
-	<!-- Chapter 3.5 -->
-	<entity BaseHP="666" Boss="1" Group="Chapter 3.5" ID="904" Image="resources/Entities/904.0.0 - Siren.png" Kind="Bosses" Name="Siren" Variant="0" Subtype="0" />
-	<entity BaseHP="20" Group="Chapter 3.5" ID="904" Image="resources/Entities/904.1.0 - Siren's Skull.png" Kind="Bosses" Name="Siren's Skull" Variant="1" Subtype="0" />
-	<entity BaseHP="789" Boss="1" Group="Chapter 3.5" ID="905" Image="resources/Entities/905.0.0 - The Heretic.png" Kind="Bosses" Name="The Heretic" Variant="0" Subtype="0" />
-	<entity BaseHP="620" Boss="1" Group="Chapter 3.5" ID="903" Image="resources/Entities/903.0.0 - Visage Heart.png" Kind="Bosses" Name="Visage Heart" Variant="0" Subtype="0" />
-	<entity BaseHP="100" Boss="1" Group="Chapter 3.5" ID="903" Image="resources/Entities/903.1.0 - Visage Mask.png" Kind="Bosses" Name="Visage Mask" Variant="1" Subtype="0" />
-	<entity BaseHP="707" Boss="1" Group="Chapter 3.5" ID="920" Image="resources/Entities/920.0.0 - Horny Boys.png" Kind="Bosses" Name="Horny Boys" Variant="0" Subtype="0" />
-	
-	<!-- Chapter 4 -->
-	<entity BaseHP="300" Boss="1" Group="Chapter 4" ID="62" Image="resources/Entities/62.1.0 - Scolex.png" Kind="Bosses" Name="Scolex" Subtype="0" Variant="1" />
-	<entity BaseHP="30" Boss="1" Group="Chapter 4" ID="76" Image="resources/Entities/76.0.0 - Blastocyst Small.png" Kind="Bosses" Name="Blastocyst Small" Subtype="0" Variant="0" />
-	<entity BaseHP="75" Boss="1" Group="Chapter 4" ID="75" Image="resources/Entities/75.0.0 - Blastocyst Medium.png" Kind="Bosses" Name="Blastocyst Medium" Subtype="0" Variant="0" />
-	<entity BaseHP="190" Boss="1" Group="Chapter 4" ID="74" Image="resources/Entities/74.0.0 - Blastocyst Big.png" Kind="Bosses" Name="Blastocyst Big" Subtype="0" Variant="0" />
-	<entity BaseHP="350" Boss="1" Group="Chapter 4" ID="69" Image="resources/Entities/69.1.0 - Lokii.png" Kind="Bosses" Name="Lokii" Subtype="0" Variant="1" />
-	<entity BaseHP="8" Boss="1" Group="Chapter 4" ID="73" Image="resources/Entities/73.1.0 - Teratoma Small.png" Kind="Bosses" Name="Teratoma Small" Subtype="0" Variant="1" />
-	<entity BaseHP="15" Boss="1" Group="Chapter 4" ID="72" Image="resources/Entities/72.1.0 - Teratoma Medium.png" Kind="Bosses" Name="Teratoma Medium" Subtype="0" Variant="1" />
-	<entity BaseHP="60" Boss="1" Group="Chapter 4" ID="71" Image="resources/Entities/71.1.0 - Teratoma Big.png" Kind="Bosses" Name="Teratoma Big" Subtype="0" Variant="1" />
-	<entity BaseHP="300" Boss="1" Group="Chapter 4" ID="101" Image="resources/Entities/101.0.0 - Daddy Long Legs.png" Kind="Bosses" Name="Daddy Long Legs" Subtype="0" Variant="0" />
-	<entity BaseHP="300" Boss="1" Group="Chapter 4" ID="101" Image="resources/Entities/101.1.0 - Triachnid.png" Kind="Bosses" Name="Triachnid" Subtype="0" Variant="1" />
-	<entity BaseHP="750" Boss="1" Group="Chapter 4" ID="266" Image="resources/Entities/266.0.0 - Mama Gurdy.png" Kind="Bosses" Name="Mama Gurdy" Subtype="0" Variant="0" />
-	<entity BaseHP="500" Boss="1" Group="Chapter 4" ID="270" Image="resources/Entities/270.0.0 - Mr. Fred.png" Kind="Bosses" Name="Mr. Fred" Subtype="0" Variant="0" />
-	<entity BaseHP="450" Boss="1" Group="Chapter 4" ID="66" Image="resources/Entities/66.0.0 - Death.png" Kind="Bosses" Name="Death" Subtype="0" Variant="0" />
-	<entity BaseHP="150" Boss="1" Group="Chapter 4" ID="66" Image="resources/Entities/66.20.0 - Death Horse.png" Kind="Bosses" Name="Death Horse" Subtype="0" Variant="20" />
-	<entity BaseHP="300" Boss="1" Group="Chapter 4" ID="66" Image="resources/Entities/66.30.0 - Death without Horse.png" Kind="Bosses" Name="Death without Horse" Subtype="0" Variant="30" />
-	<entity BaseHP="500" Boss="1" Group="Chapter 4" ID="65" Image="resources/Entities/65.1.0 - Conquest.png" Kind="Bosses" Name="Conquest" Subtype="0" Variant="1" />
-	<entity BaseHP="700" Boss="1" Group="Chapter 4" ID="413" Image="resources/Entities/413.0.0 - The Matriarch.png" Kind="Bosses" Name="The Matriarch" Subtype="0" Variant="0" />
-	
-	<!-- Chapter 4.5 -->
-	<entity BaseHP="950" Boss="1" Group="Chapter 4.5" ID="909" Image="resources/Entities/909.0.0 - The Scourge.png" Kind="Bosses" Name="The Scourge" Variant="0" Subtype="0" />
-	<entity BaseHP="1050" Boss="1" Group="Chapter 4.5" ID="910" Image="resources/Entities/910.0.0 - Chimera.png" Kind="Bosses" Name="Chimera" Variant="0" Subtype="0" />
-	<entity BaseHP="1050" Boss="1" Group="Chapter 4.5" ID="910" Image="resources/Entities/910.1.0 - Chimera (body).png" Kind="Bosses" Name="Chimera (body)" Variant="1" Subtype="0" />
-	<entity BaseHP="1050" Boss="1" Group="Chapter 4.5" ID="910" Image="resources/Entities/910.2.0 - Chimera (head).png" Kind="Bosses" Name="Chimera (head)" Variant="2" Subtype="0" />
-	<entity BaseHP="600" Boss="1" Group="Chapter 4.5" ID="911" Image="resources/Entities/911.0.0 - Rotgut.png" Kind="Bosses" Name="Rotgut" Variant="0" Subtype="0" />
-	<entity BaseHP="600" Boss="1" Group="Chapter 4.5" ID="911" Image="resources/Entities/911.1.0 - Rotgut (maggot).png" Kind="Bosses" Name="Rotgut (maggot)" Variant="1" Subtype="0" />
-	<entity BaseHP="600" Boss="1" Group="Chapter 4.5" ID="911" Image="resources/Entities/911.2.0 - Rotgut (heart).png" Kind="Bosses" Name="Rotgut (heart)" Variant="2" Subtype="0" />
-	
+	<group Name="Chapter 1 Bosses (Alt Path) Shared">
+		<entity BaseHP="200" ID="62" Image="Entities/62.3.0 - Wormwood.png" Name="Wormwood" Variant="3" Subtype="0" />
+		<entity BaseHP="200" ID="901" Image="Entities/901.0.0 - Lil Blub.png" Name="Lil Blub" Variant="0" Subtype="0" />
+	</group>
 
-	<!-- Special -->
-	<entity BaseHP="60" Boss="1" Group="Special" ID="82" Image="resources/Entities/82.0.0 - Headless Horseman Body.png" PlaceVisual="0.5,0" Kind="Bosses" Name="Headless Horseman Body" Subtype="0" Variant="0" />
-	<entity BaseHP="100" Boss="1" Group="Special" ID="83" Image="resources/Entities/83.0.0 - Headless Horsemans Head.png" Kind="Bosses" Name="Headless Horsemans Head" Subtype="0" Variant="0" />
-	<entity BaseHP="60" Boss="1" Group="Special" ID="81" Image="resources/Entities/81.1.0 - Krampus.png" Kind="Bosses" Name="Krampus" Subtype="0" Variant="1" />
-	<entity BaseHP="60" Boss="1" Group="Special" ID="81" Image="resources/Entities/81.0.0 - The Fallen.png" Kind="Bosses" Name="The Fallen" Subtype="0" Variant="0" />
-	<entity Boss="1" Group="Special" ID="271" Image="resources/Entities/271.0.0 - Uriel.png" Kind="Bosses" Name="Uriel" Subtype="0" Variant="0" />
-	<entity Boss="1" Group="Special" ID="271" Image="resources/Entities/271.0.1 - Fallen Uriel.png" Kind="Bosses" Name="Fallen Uriel" Subtype="0" Variant="1" />
-	<entity Boss="1" Group="Special" ID="272" Image="resources/Entities/272.0.0 - Gabriel.png" Kind="Bosses" Name="Gabriel" Subtype="0" Variant="0" />
-	<entity Boss="1" Group="Special" ID="272" Image="resources/Entities/272.0.1 - Fallen Gabriel.png" Kind="Bosses" Name="Fallen Gabriel" Subtype="0" Variant="1" />
+	<group Name="Downpour Bosses">
+		<entity BaseHP="240" ID="902" Image="Entities/902.0.0 - Rainmaker.png" Name="Rainmaker" Variant="0" Subtype="0" />
+		<entity BaseHP="280" ID="913" Image="Entities/913.0.0 - Min Min.png" Name="Min Min" Variant="0" Subtype="0" />
+	</group>
 
-	<!-- Story Bosses -->
-	<entity BaseHP="645" Boss="1" Group="Story Bosses" ID="45" Image="resources/Entities/45.0.0 - Mom.png" Kind="Bosses" Name="Mom" Subtype="0" Variant="0" />
-	<entity BaseHP="950" Boss="1" Group="Story Bosses" ID="78" Image="resources/Entities/78.0.0 - Mom's Heart.png" Kind="Bosses" Name="Mom's Heart" Subtype="0" Variant="0" />
-	<entity BaseHP="950" Boss="1" Group="Story Bosses" ID="78" Image="resources/Entities/78.1.0 - It Lives.png" Kind="Bosses" Name="It Lives" Subtype="0" Variant="1" />
-	<entity BaseHP="1000" Boss="1" Group="Story Bosses" ID="102" Image="resources/Entities/102.2.0 - Blue Baby (Alt).png" Kind="Bosses" Name="??? (Hush)" Subtype="0" Variant="2" />
-	<entity Boss="1" Group="Story Bosses" ID="407" Image="resources/Entities/407.0.0 - Hush.png" Kind="Bosses" Name="Hush" Subtype="0" Variant="0" />
-	<entity Boss="1" Group="Story Bosses" ID="408" Image="resources/Entities/408.0.0 - Skinless Hush.png" Kind="Bosses" Name="Skinless Hush" Subtype="0" Variant="0" />
-	<entity BaseHP="2000" Boss="1" Group="Story Bosses" ID="102" Image="resources/Entities/102.0.0 - Isaac (final boss).png" Kind="Bosses" Name="Isaac (boss)" Subtype="0" Variant="0" />
-	<entity BaseHP="2000" Boss="1" Group="Story Bosses" ID="102" Image="resources/Entities/102.1.0 - Blue Baby (final boss).png" Kind="Bosses" Name="??? (boss)" Subtype="0" Variant="1" />
-	<entity BaseHP="600" Boss="1" Group="Story Bosses" ID="84" Image="resources/Entities/84.0.0 - Satan.png" PlaceVisual="0,2" Kind="Bosses" Name="Satan" Subtype="0" Variant="0" />
-	<entity BaseHP="600" Boss="1" Group="Story Bosses" ID="84" Image="resources/Entities/84.10.0 - Satan Stomp.png" Kind="Bosses" Name="Satan Phase 2 (Stomp)" Subtype="0" Variant="10" />
-	<entity BaseHP="2000" Boss="1" Group="Story Bosses" ID="273" Image="resources/Entities/273.0.0 - The Lamb.png" Kind="Bosses" Name="The Lamb" Subtype="0" Variant="0" />
-	<entity BaseHP="3000" Boss="1" Group="Story Bosses" ID="274" Image="resources/Entities/274.0.0 - Mega Satan's Head.png" Kind="Bosses" Name="Mega Satan's Head" Subtype="0" Variant="0" />
-	<entity BaseHP="600" Boss="1" ID="274" Image="resources/Entities/274.1.0 - Mega Satan's Right Hand.png" Name="Mega Satan's Right Hand" Subtype="0" Variant="1" />
-	<entity BaseHP="600" Boss="1" ID="274" Image="resources/Entities/274.2.0 - Mega Satan's Left Hand.png" Name="Mega Satan's Left Hand" Subtype="0" Variant="2" />
-	<entity Group="Story Bosses" Kind="Bosses" ID="412" Variant="0" Subtype="0" Name="Delirium" BaseHP="10000" Boss="1" Image="resources/Entities/412.0.0 - Delirium.png" />
-	<entity BaseHP="250" Boss="1" Group="Story Bosses" ID="867" Image="resources/Entities/867.0.0 - Mother's Shadow.png" Kind="Bosses" Name="Mother's Shadow" Variant="0" Subtype="0" />
-	<entity BaseHP="2222" Boss="1" Group="Story Bosses" ID="912" Image="resources/Entities/912.0.0 - Mother.png" Kind="Bosses" Name="Mother" Variant="0" Subtype="0" />
-	<entity BaseHP="2000" Boss="1" Group="Story Bosses" ID="912" Image="resources/Entities/912.10.0 - Mother 2.png" Kind="Bosses" Name="Mother 2" Variant="10" Subtype="0" />
-	<entity BaseHP="40" Group="Story Bosses" ID="912" Image="resources/Entities/912.20.0 - Dead Isaac.png" Kind="Bosses" Name="Dead Isaac" Variant="20" Subtype="0" />
-<!-- 	<entity BaseHP="1" Boss="1" Group="Story Bosses" ID="912" Image="resources/Entities/912.30.0 - Mother Worm.png" Kind="Bosses" Name="Mother Worm" Variant="30" Subtype="0" /> -->
-	<entity BaseHP="10" Boss="1" Group="Story Bosses" ID="912" Image="resources/Entities/912.100.0 - Mother Ball.png" Kind="Bosses" Name="Mother Ball" Variant="100" Subtype="0" />
-	<entity BaseHP="10" Boss="1" Group="Story Bosses" ID="912" Image="resources/Entities/912.100.1 - Mother Ball (Medium).png" Kind="Bosses" Name="Mother Ball (Medium)" Variant="100" Subtype="1" />
-	<entity BaseHP="10" Boss="1" Group="Story Bosses" ID="912" Image="resources/Entities/912.100.2 - Mother Ball (Small).png" Kind="Bosses" Name="Mother Ball (Small)" Variant="100" Subtype="2" />
-	<entity BaseHP="1200" Boss="1" Group="Story Bosses" ID="950" Image="resources/Entities/950.0.0 - Dogma.png" Kind="Bosses" Name="Dogma" Variant="0" Subtype="0" />
-	<entity BaseHP="1200" Boss="1" Group="Story Bosses" ID="950" Image="resources/Entities/950.1.0 - Dogma's TV.png" Kind="Bosses" Name="Dogma's TV" Variant="1" Subtype="0" />
-	<entity BaseHP="1200" Boss="1" Group="Story Bosses" ID="950" Image="resources/Entities/950.2.0 - Dogma Angel.png" Kind="Bosses" Name="Dogma Angel" Variant="2" Subtype="0" />
-	<entity BaseHP="30" Group="Story Bosses" ID="950" Image="resources/Entities/950.10.0 - Dogma Angel Baby.png" Kind="Bosses" Name="Dogma Angel Baby" Variant="10" Subtype="0" />
-	
-	<entity BaseHP="10000" Boss="1" Group="Story Bosses - The Beast" ID="951" Image="resources/Entities/951.0.0 - The Beast.png" Kind="Bosses" Name="The Beast" Variant="0" Subtype="0" />
-	<entity BaseHP="2000" Boss="1" Group="Story Bosses - The Beast" ID="951" Image="resources/Entities/951.10.0 - Ultra Famine.png" Kind="Bosses" Name="Ultra Famine" Variant="10" Subtype="0" />
-	<entity BaseHP="10" Group="Story Bosses - The Beast" ID="951" Image="resources/Entities/951.11.0 - Ultra Famine Fly.png" Kind="Bosses" Name="Ultra Famine Fly" Variant="11" Subtype="0" />
-	<entity BaseHP="1800" Boss="1" Group="Story Bosses - The Beast" ID="951" Image="resources/Entities/951.20.0 - Ultra Pestilence.png" Kind="Bosses" Name="Ultra Pestilence" Variant="20" Subtype="0" />
-	<entity BaseHP="10" Group="Story Bosses - The Beast" ID="951" Image="resources/Entities/951.21.0 - Ultra Pestilence Fly.png" Kind="Bosses" Name="Ultra Pestilence Fly" Variant="21" Subtype="0" />
-	<entity Group="Story Bosses - The Beast" ID="951" Image="resources/Entities/951.22.0 - Ultra Pestilence Maggot.png" Kind="Bosses" Name="Ultra Pestilence Maggot" Variant="22" Subtype="0" />
-	<entity BaseHP="200" Group="Story Bosses - The Beast" ID="951" Image="resources/Entities/951.23.0 - Ultra Pestilence Fly Ball.png" Kind="Bosses" Name="Ultra Pestilence Fly Ball" Variant="23" Subtype="0" />
-	<entity BaseHP="2000" Boss="1" Group="Story Bosses - The Beast" ID="951" Image="resources/Entities/951.30.0 - Ultra War.png" Kind="Bosses" Name="Ultra War" Variant="30" Subtype="0" />
-	<entity BaseHP="200" Group="Story Bosses - The Beast" ID="951" Image="resources/Entities/951.31.0 - Ultra War Bomb.png" Kind="Bosses" Name="Ultra War Bomb" Variant="31" Subtype="0" />
-	<entity BaseHP="2000" Boss="1" Group="Story Bosses - The Beast" ID="951" Image="resources/Entities/951.40.0 - Ultra Death.png" Kind="Bosses" Name="Ultra Death" Variant="40" Subtype="0" />
-	<!-- <entity BaseHP="100" Group="Story Bosses - The Beast" ID="951" Image="resources/Entities/951.41.0 - Ultra Death Scythe.png" Kind="Bosses" Name="Ultra Death Scythe" Variant="41" Subtype="0" /> -->
-	<entity BaseHP="100" Group="Story Bosses - The Beast" ID="951" Image="resources/Entities/951.42.0 - Ultra Death Head.png" Kind="Bosses" Name="Ultra Death Head" Variant="42" Subtype="0" />
+	<group Name="Dross Bosses">
+		<entity BaseHP="420" ID="914" Image="Entities/914.0.0 - Clog.png" Name="Clog" Variant="0" Subtype="0" />
+		<entity BaseHP="380" ID="917" Image="Entities/917.0.0 - Colostomia.png" Name="Colostomia" Variant="0" Subtype="0" />
+		<entity BaseHP="190" ID="918" Image="Entities/918.0.0 - Turdlet.png" Name="Turdlet" Variant="0" Subtype="0" />
+	</group>
 
-	<!-- Ultra Greed -->
-	<entity BaseHP="3500" Boss="1" Group="Ultra Greed" ID="406" Image="resources/Entities/406.0.0 - Ultra Greed.png" Kind="Bosses" Name="Ultra Greed" Subtype="0" Variant="0" />
-	<entity Group="Ultra Greed" Kind="Bosses" ID="406" Variant="1" Subtype="0" Name="Ultra Greedier" BaseHP="2500" Boss="1" Image="resources/Entities/406.1.0 - UltraGreedier.png" />
-	<entity BaseHP="30" Group="Ultra Greed" ID="293" Image="resources/Entities/293.0.0 - Ultra Greed Coin (Spinner).png" Kind="Bosses" Name="Ultra Greed Coin (Spinner)" Subtype="0" Variant="0" />
-	<entity BaseHP="30" Group="Ultra Greed" ID="293" Image="resources/Entities/293.1.0 - Ultra Greed Coin (Key).png" Kind="Bosses" Name="Ultra Greed Coin (Key)" Subtype="0" Variant="1" />
-	<entity BaseHP="30" Group="Ultra Greed" ID="293" Image="resources/Entities/293.2.0 - Ultra Greed Coin (Bomb).png" Kind="Bosses" Name="Ultra Greed Coin (Bomb)" Subtype="0" Variant="2" />
-	<entity BaseHP="30" Group="Ultra Greed" ID="293" Image="resources/Entities/293.3.0 - Ultra Greed Coin (Heart).png" Kind="Bosses" Name="Ultra Greed Coin (Heart)" Subtype="0" Variant="3" />
-	
-	<!-- Unfinished -->
-	<entity BaseHP="792" Boss="1" Group="Unfinished" ID="919" Image="resources/Entities/919.0.0 - Raglich.png" Kind="Bosses" Name="Raglich" Variant="0" Subtype="0" />
-	<!-- <entity BaseHP="792" Boss="1" Group="Unfinished" ID="919" Image="resources/Entities/919.1.0 - Raglich Arm.png" Kind="Bosses" Name="Raglich Arm" Variant="1" Subtype="0" /> -->
-	<entity BaseHP="500" Boss="1" Group="Unfinished" ID="921" Image="resources/Entities/921.0.0 - Clutch.png" Kind="Bosses" Name="Clutch" Variant="0" Subtype="0" />
-	<!-- <entity BaseHP="200" Group="Unfinished" ID="921" Image="resources/Entities/921.1.0 - Clutch Orbital.png" Kind="Bosses" Name="Clutch Orbital" Variant="1" Subtype="0" /> -->
+	<group Name="Chapter 2 Bosses (Main Path) Shared">
+		<entity BaseHP="385" ID="916" Image="Entities/916.0.0 - Bumbino.png" Name="Bumbino" Variant="0" Subtype="0" />
+	</group>
 
-	<!-- The Sins -->
-	<entity BaseHP="60" Boss="1" Group="The Sins" ID="46" Image="resources/Entities/46.0.0 - Sloth.png" Kind="Bosses" Name="Sloth" Subtype="0" Variant="0" />
-	<entity BaseHP="60" Boss="1" Group="The Sins" ID="46" Image="resources/Entities/46.1.0 - Super Sloth.png" Kind="Bosses" Name="Super Sloth" Subtype="0" Variant="1" />
-	<entity BaseHP="60" Boss="1" Group="The Sins" ID="47" Image="resources/Entities/47.0.0 - Lust.png" Kind="Bosses" Name="Lust" Subtype="0" Variant="0" />
-	<entity BaseHP="60" Boss="1" Group="The Sins" ID="47" Image="resources/Entities/47.1.0 - Super Lust.png" Kind="Bosses" Name="Super Lust" Subtype="0" Variant="1" />
-	<entity BaseHP="60" Boss="1" Group="The Sins" ID="48" Image="resources/Entities/48.0.0 - Wrath.png" Kind="Bosses" Name="Wrath" Subtype="0" Variant="0" />
-	<entity BaseHP="60" Boss="1" Group="The Sins" ID="48" Image="resources/Entities/48.1.0 - Super Wrath.png" Kind="Bosses" Name="Super Wrath" Subtype="0" Variant="1" />
-	<entity BaseHP="60" Boss="1" Group="The Sins" ID="49" Image="resources/Entities/49.0.0 - Gluttony.png" Kind="Bosses" Name="Gluttony" Subtype="0" Variant="0" />
-	<entity BaseHP="60" Boss="1" Group="The Sins" ID="49" Image="resources/Entities/49.1.0 - Super Gluttony.png" Kind="Bosses" Name="Super Gluttony" Subtype="0" Variant="1" />
-	<entity BaseHP="60" Boss="1" Group="The Sins" ID="50" Image="resources/Entities/50.0.0 - Greed.png" Kind="Bosses" Name="Greed" Subtype="0" Variant="0" />
-	<entity BaseHP="60" Boss="1" Group="The Sins" ID="50" Image="resources/Entities/50.1.0 - Super Greed.png" Kind="Bosses" Name="Super Greed" Subtype="0" Variant="1" />
-	<entity BaseHP="60" Boss="1" Group="The Sins" ID="51" Image="resources/Entities/51.0.0 - Envy.png" Kind="Bosses" Name="Envy" Subtype="0" Variant="0" />
-	<entity BaseHP="60" Boss="1" Group="The Sins" ID="51" Image="resources/Entities/51.10.0 - Envy (1-2).png" Kind="Bosses" Name="Envy (1/2)" Subtype="0" Variant="10" />
-	<entity BaseHP="60" Boss="1" Group="The Sins" ID="51" Image="resources/Entities/51.20.0 - Envy (1-4).png" Kind="Bosses" Name="Envy (1/4)" Subtype="0" Variant="20" />
-	<entity BaseHP="60" Boss="1" Group="The Sins" ID="51" Image="resources/Entities/51.30.0 - Envy (1-8).png" Kind="Bosses" Name="Envy (1/8)" Subtype="0" Variant="30" />
-	<entity BaseHP="60" Boss="1" Champion="1" Group="The Sins" ID="51" Image="resources/Entities/51.1.0 - Super Envy.png" Kind="Bosses" Name="Super Envy" Subtype="0" Variant="1" />
-	<entity BaseHP="60" Boss="1" Group="The Sins" ID="52" Image="resources/Entities/52.0.0 - Pride.png" Kind="Bosses" Name="Pride" Subtype="0" Variant="0" />
-	<entity BaseHP="60" Boss="1" Group="The Sins" ID="52" Image="resources/Entities/52.1.0 - Super Pride.png" Kind="Bosses" Name="Super Pride" Subtype="0" Variant="1" />
-	<entity BaseHP="60" Boss="1" Group="The Sins" ID="46" Image="resources/Entities/46.2.0 - Ultra Pride.png" Kind="Bosses" Name="Ultra Pride" Subtype="0" Variant="2" />
-	<entity BaseHP="25" Boss="1" Champion="1" Group="The Sins" ID="38" Image="resources/Entities/38.2.0 - Ultra Pride Baby.png" Kind="Bosses" Name="Ultra Pride Baby" Subtype="0" Variant="2" />
+	<group Name="Chapter 2 Bosses">
+		<group Name="Chapter 2 Bosses (Alt Path)" Label="Chapter 2 (Alt Path)">
+			<group Name="Chapter 2 Bosses (Alt Path) Shared"/>
+			<group Name="Mines Bosses" Label="Mines"/>
+			<group Name="Ashpit Bosses" Label="Ashpit"/>
+		</group>
+	</group>
 
-	<!--——— Stage ———-->
+	<group Name="Chapter 2 Bosses (Alt Path) Shared">
+		<entity BaseHP="6" ID="907" Image="Entities/907.0.0 - Great Gideon.png" Name="Great Gideon" Variant="0" Subtype="0" />
+		<entity BaseHP="6" ID="907" Image="Entities/907.0.1 - Great Gideon (defeated).png" Name="Great Gideon (defeated)" Variant="0" Subtype="1" />
+	</group>
 
-	<!-- Bums -->
-	<entity Group="Bums" ID="6" Image="resources/Entities/6.4.0 - Beggar.png" Kind="Stage" Name="Beggar" Subtype="0" Variant="4" />
-	<entity Group="Bums" ID="6" Image="resources/Entities/6.5.0 - Devil Beggar.png" Kind="Stage" Name="Devil Beggar" Subtype="0" Variant="5" />
-	<entity Group="Bums" ID="6" Image="resources/Entities/6.7.0 - Key Master.png" Kind="Stage" Name="Key Master" Subtype="0" Variant="7" />
-	<entity Group="Bums" ID="6" Image="resources/Entities/6.9.0 - Bomb Bum.png" Kind="Stage" Name="Bomb Bum" Subtype="0" Variant="9" />
-	<entity Group="Bums" ID="6" Image="resources/Entities/6.13.0 - Battery Bum.png" Kind="Stage" Name="Battery Bum" Variant="13" Subtype="0" />
-	<entity Group="Bums" ID="6" Image="resources/Entities/6.18.0 - Rotten Beggar.png" Kind="Stage" Name="Rotten Beggar" Variant="18" Subtype="0" />
-	<entity Group="Bums" ID="6" Image="resources/Entities/6.6.0 - Shell Game.png" Kind="Stage" Name="Shell Game" Subtype="0" Variant="6" />
-	<entity Group="Bums" ID="6" Image="resources/Entities/6.15.0 - Hell Game.png" Kind="Stage" Name="Hell Game" Variant="15" Subtype="0" />
+	<group Name="Mines Bosses">
+		<entity BaseHP="35" ID="19" Image="Entities/19.2.0 - Tuff Twin.png" Name="Tuff Twin" Variant="2" Subtype="0" />
+		<entity BaseHP="690" ID="900" Image="Entities/900.0.0 - Reap Creep.png" Name="Reap Creep" Variant="0" Subtype="0" />
+		<entity BaseHP="240" ID="906" Image="Entities/906.0.0 - Hornfel.png" Name="Hornfel" Variant="0" Subtype="0" />
+	</group>
 
-	<!-- Fireplaces -->
-	<entity BaseHP="5" Group="Fireplaces" ID="33" Image="resources/Entities/33.0.0 - Fire Place.png" Kind="Stage" Name="Fire Place" Subtype="0" Variant="0" InEmptyRooms="1" IsGrid="1" />
-	<entity BaseHP="5" Group="Fireplaces" ID="33" Image="resources/Entities/33.1.0 - Red Fire Place.png" Kind="Stage" Name="Red Fire Place" Subtype="0" Variant="1" InEmptyRooms="1" IsGrid="1" />
-	<entity BaseHP="5" Group="Fireplaces" ID="33" Image="resources/Entities/33.2.0 - Blue Fire Place.png" Kind="Stage" Name="Blue Fire Place" Subtype="0" Variant="2" InEmptyRooms="1" IsGrid="1" />
-	<entity BaseHP="5" Group="Fireplaces" ID="33" Image="resources/Entities/33.3.0 - Purple Fire Place.png" Kind="Stage" Name="Purple Fire Place" Subtype="0" Variant="3" InEmptyRooms="1" IsGrid="1" />
-	<entity BaseHP="5" Group="Fireplaces" ID="33" Image="resources/Entities/33.4.0 - White Fire Place.png" Kind="Stage" Name="White Fire Place" Variant="4" Subtype="0" InEmptyRooms="1" IsGrid="1" />
-	<entity BaseHP="5" Group="Fireplaces" ID="33" Image="resources/Entities/33.10.0 - Moveable Fireplace.png" Kind="Stage" Name="Moveable Fireplace" Variant="10" Subtype="0" />
-	<entity BaseHP="5" Group="Fireplaces" ID="33" Image="resources/Entities/33.12.0 - Moveable Blue Fireplace.png" Kind="Stage" Name="Moveable Blue Fireplace" Variant="12" Subtype="0" />
-	<entity BaseHP="5" Group="Fireplaces" ID="33" Image="resources/Entities/33.13.0 - Moveable Purple Fireplace.png" Kind="Stage" Name="Moveable Purple Fireplace" Variant="13" Subtype="0" />
-	<entity BaseHP="15" Group="Fireplaces" ID="33" Image="resources/Entities/33.11.0 - Coal.png" Kind="Stage" Name="Coal (random)" Variant="11" Subtype="0" />
-	<entity BaseHP="15" Group="Fireplaces" ID="33" Image="resources/Entities/33.11.1 - Coal.png" Kind="Stage" Name="Coal (subtype 1)" Variant="11" Subtype="1" />
-	<entity BaseHP="15" Group="Fireplaces" ID="33" Image="resources/Entities/33.11.2 - Coal.png" Kind="Stage" Name="Coal (subtype 2)" Variant="11" Subtype="2" />
-	<entity BaseHP="15" Group="Fireplaces" ID="33" Image="resources/Entities/33.11.3 - Coal.png" Kind="Stage" Name="Coal (subtype 3)" Variant="11" Subtype="3" />
-	<entity Group="Fireplaces" ID="1400" Image="resources/Entities/33.0.0 - Fire Place.png" Kind="Stage" Name="Fire" Subtype="0" Variant="0" InEmptyRooms="1" IsGrid="1" />
-	<entity Group="Fireplaces" ID="1410" Image="resources/Entities/33.1.0 - Red Fire Place.png" Kind="Stage" Name="Red Fire" Subtype="0" Variant="0" InEmptyRooms="1" IsGrid="1" />
-	
+	<group Name="Ashpit Bosses">
+		<entity BaseHP="35" ID="19" Image="Entities/19.3.0 - The Shell.png" Name="The Shell" Variant="3" Subtype="0" />
+		<entity BaseHP="580" ID="269" Image="Entities/269.1.0 - The Pile.png" Name="The Pile" Variant="1" Subtype="0" />
+		<entity BaseHP="444" ID="915" Image="Entities/915.0.0 - Singe.png" Name="Singe" Variant="0" Subtype="0" />
+		<entity BaseHP="100" Tags="" ID="915" Image="Entities/915.1.0 - Singe's Ball.png" Name="Singe's Ball" Variant="1" Subtype="0" />
+	</group>
 
-	<!-- Grid -->
-	<entity Group="Grid" ID="1000" Image="resources/Entities/1000.0.0 - Rock.png" Kind="Stage" Name="Rock" Subtype="0" Variant="0" EditorImage="resources/Backgrounds/rocks_generic.png" InEmptyRooms="1" IsGrid="1" UseRockTiling="1" />
-	<entity Group="Grid" ID="1000" Image="resources/Entities/1000.0.1 - Rock (non-replaceable).png" Kind="Stage" Name="Rock (non-replaceable)" Subtype="1" Variant="0" IsGrid="1" />
-	<entity Group="Grid" ID="1001" Image="resources/Entities/1001.0.0 - Bomb Rock.png" Kind="Stage" Name="Bomb Rock" Subtype="0" Variant="0" InEmptyRooms="1" IsGrid="1" />
-	<entity Group="Grid" ID="1010" Image="resources/Entities/1010.0.0 - Spike Rock.png" Kind="Stage" Name="Spike Rock" Subtype="0" Variant="0" IsGrid="1" />
-	<entity Group="Grid" ID="1011" Image="resources/Entities/1011.0.0 - Fool's Gold Rock.png" Kind="Stage" Name="Fool's Gold Rock" Subtype="0" Variant="0" IsGrid="1" />
-	<entity Group="Grid" ID="1002" Image="resources/Entities/1002.0.0 - Pot.png" Kind="Stage" Name="Pot" Subtype="0" Variant="0" InEmptyRooms="1" IsGrid="1" />
-	<entity Group="Grid" ID="1008" Image="resources/Entities/1008.0.0 - Marked Skull.png" Kind="Stage" Name="Marked Skull" Subtype="0" Variant="0" InEmptyRooms="1" IsGrid="1" />
-	<entity Group="Grid" ID="1900" Image="resources/Entities/1900.0.0 - Block.png" Kind="Stage" Name="Block" Subtype="0" Variant="0" InEmptyRooms="1" IsGrid="1" />
-	<entity Group="Grid" ID="1901" Image="resources/Entities/1901.0.0 - Tall Block.png" Kind="Stage" Name="Tall Block" Variant="0" Subtype="0" InEmptyRooms="1" IsGrid="1" />
-	<entity Group="Grid" ID="1999" Image="resources/Entities/1999.0.0 - Invisible Block.png" Kind="Stage" Name="Invisible Block" Subtype="0" Variant="0" InEmptyRooms="1" IsGrid="1" />
-	<entity Group="Grid" ID="3000" Image="resources/Entities/3000.0.0 - Pit.png" Kind="Stage" Name="Pit" Subtype="0" Variant="0" EditorImage="resources/Backgrounds/pit_generic.png" InEmptyRooms="1" IsGrid="1" UsePitTiling="1" />
-	<entity Group="Grid" ID="1300" Image="resources/Entities/1300.0.0 - TNT.png" Kind="Stage" Name="TNT" Subtype="0" Variant="0" InEmptyRooms="1" IsGrid="1" />
-	<entity Group="Grid" ID="292" Image="resources/Entities/292.0.0 - Pushable TNT.png" Kind="Stage" Name="Pushable TNT" Subtype="0" Variant="0" InEmptyRooms="1" IsGrid="1" />
-	<entity Group="Grid" ID="1930" Image="resources/Entities/1930.0.0 - Spikes.png" Kind="Stage" Name="Spikes" Subtype="0" Variant="0" InEmptyRooms="1" IsGrid="1" />
-	<entity Group="Grid" ID="1931" Image="resources/Entities/1931.0.0 - Retracting Spikes.png" Kind="Stage" Name="Retracting Spikes" Subtype="0" Variant="0" IsGrid="1" />
-	<entity Group="Grid" ID="1931" Image="resources/Entities/1931.1.0 - Retracting Spikes (Down 1).png" Kind="Stage" Name="Retracting Spikes (Down 1/5)" Subtype="0" Variant="1" IsGrid="1" />
-	<entity Group="Grid" ID="1931" Image="resources/Entities/1931.2.0 - Retracting Spikes (Down 2).png" Kind="Stage" Name="Retracting Spikes (Down 2/5)" Subtype="0" Variant="2" IsGrid="1" />
-	<entity Group="Grid" ID="1931" Image="resources/Entities/1931.3.0 - Retracting Spikes (Down 3).png" Kind="Stage" Name="Retracting Spikes (Down 3/5)" Subtype="0" Variant="3" IsGrid="1" />
-	<entity Group="Grid" ID="1931" Image="resources/Entities/1931.4.0 - Retracting Spikes (Down 4).png" Kind="Stage" Name="Retracting Spikes (Down 4/5)" Subtype="0" Variant="4" IsGrid="1" />
-	<entity Group="Grid" ID="1931" Image="resources/Entities/1931.5.0 - Retracting Spikes (Down 5).png" Kind="Stage" Name="Retracting Spikes (Down 5/5)" Subtype="0" Variant="5" IsGrid="1" />
-	<entity Group="Grid" ID="1931" Image="resources/Entities/1931.6.0 - Retracting Spikes (Up 1).png" Kind="Stage" Name="Retracting Spikes (Up 1/5)" Subtype="0" Variant="6" IsGrid="1" />
-	<entity Group="Grid" ID="1931" Image="resources/Entities/1931.7.0 - Retracting Spikes (Up 2).png" Kind="Stage" Name="Retracting Spikes (Up 2/5)" Subtype="0" Variant="7" IsGrid="1" />
-	<entity Group="Grid" ID="1931" Image="resources/Entities/1931.8.0 - Retracting Spikes (Up 3).png" Kind="Stage" Name="Retracting Spikes (Up 3/5)" Subtype="0" Variant="8" IsGrid="1" />
-	<entity Group="Grid" ID="1931" Image="resources/Entities/1931.9.0 - Retracting Spikes (Up 4).png" Kind="Stage" Name="Retracting Spikes (Up 4/5)" Subtype="0" Variant="9" IsGrid="1" />
-	<entity Group="Grid" ID="1931" Image="resources/Entities/1931.10.0 - Retracting Spikes (Up 5).png" Kind="Stage" Name="Retracting Spikes (Up 5/5)" Subtype="0" Variant="10" IsGrid="1" />
-	<entity Group="Grid" ID="1940" Image="resources/Entities/1940.0.0 - Cobweb.png" Kind="Stage" Name="Cobweb" Subtype="0" Variant="0" InEmptyRooms="1" NoBlockDoors="1" IsGrid="1" />
-	<entity Group="Grid" ID="4000" Image="resources/Entities/4000.0.0 - Key Block.png" Kind="Stage" Name="Key Block" Subtype="0" Variant="0" IsGrid="1" />
-	<entity Group="Grid" ID="4500" Image="resources/Entities/4500.0.0 - Pressure Plate.png" Kind="Stage" Name="Pressure Plate (room clear)" Subtype="0" Variant="0" IsGrid="1" />
-	<entity Group="Grid" ID="4500" Image="resources/Entities/4500.0.1 - Reward Plate.png" Kind="Stage" Name="Reward Plate" Subtype="0" Variant="1" IsGrid="1" />
-	<entity Group="Grid" ID="4500" Image="resources/Entities/4500.0.2 - Greed Plate.png" Kind="Stage" Name="Greed Plate" Subtype="0" Variant="2" PlaceVisual="0,0.55" DisableOffsetIndicator="1" IsGrid="1" />
-	<entity Group="Grid" ID="4500" Image="resources/Entities/4500.0.9 - Kill Plate.png" Kind="Stage" Name="Kill Plate" Subtype="0" Variant="9" IsGrid="1" />
-	<entity Group="Grid" ID="4500" Image="resources/Entities/4500.3.0 - Rail Plate.png" Kind="Stage" Name="Rail Plate" Subtype="0" Variant="3" IsGrid="1" />
-	
-	<!-- Events -->
-	<entity Group="Events" ID="970" Image="resources/Entities/970.0.0 - Room Darkness.png" Kind="Stage" Name="Room Darkness" Subtype="0" Variant="0"/>
-	<entity Group="Events" ID="970" Image="resources/Entities/970.1.0 - Water Flow (left).png" Kind="Stage" Name="Water Flow (left)" Subtype="0" Variant="1"/>
-	<entity Group="Events" ID="970" Image="resources/Entities/970.1.1 - Water Flow (right).png" Kind="Stage" Name="Water Flow (right)" Subtype="1" Variant="1"/>
-	<entity Group="Events" ID="970" Image="resources/Entities/970.1.2 - Water Flow (up).png" Kind="Stage" Name="Water Flow (up)" Subtype="2" Variant="1"/>
-	<entity Group="Events" ID="970" Image="resources/Entities/970.1.3 - Water Flow (down).png" Kind="Stage" Name="Water Flow (down)" Subtype="3" Variant="1"/>
-	<entity Group="Events" ID="970" Image="resources/Entities/970.1.10 - Water Disabler.png" Kind="Stage" Name="Water Disabler" Subtype="10" Variant="1"/>
-	<entity Group="Events" ID="970" Image="resources/Entities/970.1.20 - Lava Disabler.png" Kind="Stage" Name="Lava Disabler" Subtype="20" Variant="1"/>
-	<entity Group="Events" ID="970" Image="resources/Entities/970.2.0 - Quest Door.png" Kind="Stage" Name="Quest Door" PlaceVisual="WallSnap" Subtype="0" Variant="2"/>
-	<entity Group="Events" ID="969" Image="resources/Entities/969.0.0 - Event (group 0).png" Kind="Stage" Name="Event (group 0)" Subtype="0" Variant="0" />
-	<entity Group="Events" ID="969" Image="resources/Entities/969.1.0 - Event (group 1).png" Kind="Stage" Name="Event (group 1)" Subtype="0" Variant="1" />
-	<entity Group="Events" ID="969" Image="resources/Entities/969.2.0 - Event (group 2).png" Kind="Stage" Name="Event (group 2)" Subtype="0" Variant="2" />
-	<entity Group="Events" ID="969" Image="resources/Entities/969.3.0 - Event (group 3).png" Kind="Stage" Name="Event (group 3)" Subtype="0" Variant="3" />
-	<entity Group="Events" ID="969" Image="resources/Entities/969.9.0 - Event (After Cleaning).png" Kind="Stage" Name="Event (Room Clear)" Subtype="0" Variant="9" />
-	<entity Group="Events" ID="1009" Image="resources/Entities/1009.0.0 - Rock (event).png" Kind="Stage" Name="Rock (event)" Subtype="0" Variant="0" IsGrid="1" />
-	<entity Group="Events" ID="3009" Image="resources/Entities/3009.0.0 - Pit (event).png" Kind="Stage" Name="Pit (event)" Subtype="0" Variant="0" IsGrid="1" />
-	<entity Group="Events" ID="3002" Image="resources/Entities/3002.0.0 - Button Rail.png" Kind="Stage" Name="Button Rail" Subtype="0" Variant="0" IsGrid="1" />
-	<entity Group="Events" ID="4500" Image="resources/Entities/4500.10.0 - Event Plate (group 0).png" Kind="Stage" Name="Event Plate (group 0)" Subtype="0" Variant="10" IsGrid="1" />
-	<entity Group="Events" ID="4500" Image="resources/Entities/4500.11.0 - Event Plate (group 1).png" Kind="Stage" Name="Event Plate (group 1)" Subtype="0" Variant="11" IsGrid="1" />
-	<entity Group="Events" ID="4500" Image="resources/Entities/4500.12.0 - Event Plate (group 2).png" Kind="Stage" Name="Event Plate (group 2)" Subtype="0" Variant="12" IsGrid="1" />
-	<entity Group="Events" ID="4500" Image="resources/Entities/4500.13.0 - Event Plate (group 3).png" Kind="Stage" Name="Event Plate (group 3)" Subtype="0" Variant="13" IsGrid="1" />
-	
-	<!-- Rails -->
-	<entity Group="Rails" ID="6000" Image="resources/Entities/6000.0.0 - Rail (left-to-right).png" Kind="Stage" Name="Rail (left-to-right)" Subtype="0" Variant="0" IsGrid="1" />
-	<entity Group="Rails" ID="6000" Image="resources/Entities/6000.1.0 - Rail (up-to-down).png" Kind="Stage" Name="Rail (up-to-down)" Subtype="0" Variant="1" IsGrid="1" />
-	<entity Group="Rails" ID="6000" Image="resources/Entities/6000.2.0 - Rail (up-to-right).png" Kind="Stage" Name="Rail (up-to-right)" Subtype="0" Variant="2" IsGrid="1" MirrorX="6000.3.0" MirrorY="6000.4.0" />
-	<entity Group="Rails" ID="6000" Image="resources/Entities/6000.3.0 - Rail (up-to-left).png" Kind="Stage" Name="Rail (up-to-left)" Subtype="0" Variant="3" IsGrid="1" MirrorX="6000.2.0" MirrorY="6000.5.0" />
-	<entity Group="Rails" ID="6000" Image="resources/Entities/6000.4.0 - Rail (left-to-up).png" Kind="Stage" Name="Rail (left-to-up)" Subtype="0" Variant="4" IsGrid="1" MirrorX="6000.5.0" MirrorY="6000.2.0" />
-	<entity Group="Rails" ID="6000" Image="resources/Entities/6000.5.0 - Rail (right-to-up).png" Kind="Stage" Name="Rail (right-to-up)" Subtype="0" Variant="5" IsGrid="1" MirrorX="6000.4.0" MirrorY="6000.3.0" />
-	<entity Group="Rails" ID="6000" Image="resources/Entities/6000.6.0 - Rail (crossroad).png" Kind="Stage" Name="Rail (crossroad)" Subtype="0" Variant="6" IsGrid="1" />
-	<entity Group="Rails" ID="6000" Image="resources/Entities/6000.7.0 - Rail (stop-to-right).png" Kind="Stage" Name="Rail (stop-to-right)" Subtype="0" Variant="7" IsGrid="1" MirrorX="6000.8.0" />
-	<entity Group="Rails" ID="6000" Image="resources/Entities/6000.8.0 - Rail (left-to-stop).png" Kind="Stage" Name="Rail (left-to-stop)" Subtype="0" Variant="8" IsGrid="1" MirrorX="6000.7.0" />
-	<entity Group="Rails" ID="6000" Image="resources/Entities/6000.9.0 - Rail (up-to-stop).png" Kind="Stage" Name="Rail (up-to-stop)" Subtype="0" Variant="9" IsGrid="1" MirrorY="6000.10.0" />
-	<entity Group="Rails" ID="6000" Image="resources/Entities/6000.10.0 - Rail (stop-to-down).png" Kind="Stage" Name="Rail (left-to-stop)" Subtype="0" Variant="10" IsGrid="1" MirrorY="6000.9.0" />
-	<entity Group="Rails" ID="6000" Image="resources/Entities/6000.16.0 - Rail (cart-left).png" Kind="Stage" Name="Rail (cart-left)" Subtype="0" Variant="16" IsGrid="1" MirrorX="6000.32.0" />
-	<entity Group="Rails" ID="6000" Image="resources/Entities/6000.32.0 - Rail (cart-right).png" Kind="Stage" Name="Rail (cart-right)" Subtype="0" Variant="32" IsGrid="1" MirrorX="6000.16.0" />
-	<entity Group="Rails" ID="6000" Image="resources/Entities/6000.17.0 - Rail (cart-up).png" Kind="Stage" Name="Rail (cart-up)" Subtype="0" Variant="17" IsGrid="1" MirrorY="6000.33.0" />
-	<entity Group="Rails" ID="6000" Image="resources/Entities/6000.33.0 - Rail (cart-down).png" Kind="Stage" Name="Rail (cart-down)" Subtype="0" Variant="33" IsGrid="1" MirrorY="6000.17.0" />
-	<entity Group="Rails" ID="6000" Image="resources/Entities/6000.80.0 - Rail (Mineshaft).png" Kind="Stage" Name="Rail (Mineshaft)" Subtype="0" Variant="80" IsGrid="1" />
-	<entity Group="Rails" ID="6000" Image="resources/Entities/6000.81.0 - Rail (Mineshaft).png" Kind="Stage" Name="Rail (Mineshaft)" Subtype="0" Variant="81" IsGrid="1" />
-	<entity Group="Rails" ID="6000" Image="resources/Entities/6000.82.0 - Rail (Mineshaft).png" Kind="Stage" Name="Rail (Mineshaft)" Subtype="0" Variant="82" IsGrid="1" />
-	<entity Group="Rails" ID="6000" Image="resources/Entities/6000.83.0 - Rail (Mineshaft).png" Kind="Stage" Name="Rail (Mineshaft)" Subtype="0" Variant="83" IsGrid="1" />
-	<entity Group="Rails" ID="6000" Image="resources/Entities/6000.84.0 - Rail (Mineshaft).png" Kind="Stage" Name="Rail (Mineshaft)" Subtype="0" Variant="84" IsGrid="1" />
-	<entity Group="Rails" ID="6000" Image="resources/Entities/6000.85.0 - Rail (Mineshaft).png" Kind="Stage" Name="Rail (Mineshaft)" Subtype="0" Variant="85" IsGrid="1" />
-	<entity Group="Rails" ID="6000" Image="resources/Entities/6000.96.0 - Rail (Mineshaft).png" Kind="Stage" Name="Rail (Mineshaft)" Subtype="0" Variant="96" IsGrid="1" />
-	<entity Group="Rails" ID="6000" Image="resources/Entities/6000.97.0 - Rail (Mineshaft).png" Kind="Stage" Name="Rail (Mineshaft)" Subtype="0" Variant="97" IsGrid="1" />
-	<entity Group="Rails" ID="6000" Image="resources/Entities/6000.98.0 - Rail (Mineshaft).png" Kind="Stage" Name="Rail (Mineshaft)" Subtype="0" Variant="98" IsGrid="1" />
-	<entity Group="Rails" ID="6000" Image="resources/Entities/6000.99.0 - Rail (Mineshaft).png" Kind="Stage" Name="Rail (Mineshaft)" Subtype="0" Variant="99" IsGrid="1" />
-	<entity Group="Rails" ID="6000" Image="resources/Entities/6000.100.0 - Rail (Mineshaft).png" Kind="Stage" Name="Rail (Mineshaft)" Subtype="0" Variant="100" IsGrid="1" />
-	<entity Group="Rails" ID="6000" Image="resources/Entities/6000.101.0 - Rail (Mineshaft).png" Kind="Stage" Name="Rail (Mineshaft)" Subtype="0" Variant="101" IsGrid="1" />
-	<entity Group="Rails" ID="6000" Image="resources/Entities/6000.112.0 - Rail (Mineshaft).png" Kind="Stage" Name="Rail (Mineshaft)" Subtype="0" Variant="112" IsGrid="1" />
-	<entity Group="Rails" ID="6000" Image="resources/Entities/6000.113.0 - Rail (Mineshaft).png" Kind="Stage" Name="Rail (Mineshaft)" Subtype="0" Variant="113" IsGrid="1" />
+	<group Name="Depths Bosses">
+		<entity Name="Reap Creep"/>
+	</group>
 
-	<entity Group="Rails" ID="6001" Image="resources/Entities/6001.0.0 - Rail (Pit) (left-to-right).png" Kind="Stage" Name="Rail (Pit) (left-to-right)" Subtype="0" Variant="0" IsGrid="1" />
-	<entity Group="Rails" ID="6001" Image="resources/Entities/6001.1.0 - Rail (Pit) (up-to-down).png" Kind="Stage" Name="Rail (Pit) (up-to-down)" Subtype="0" Variant="1" IsGrid="1" />
-	<entity Group="Rails" ID="6001" Image="resources/Entities/6001.2.0 - Rail (Pit) (up-to-right).png" Kind="Stage" Name="Rail (Pit) (up-to-right)" Subtype="0" Variant="2" IsGrid="1" MirrorX="6001.3.0" MirrorY="6001.4.0" />
-	<entity Group="Rails" ID="6001" Image="resources/Entities/6001.3.0 - Rail (Pit) (up-to-left).png" Kind="Stage" Name="Rail (Pit) (up-to-left)" Subtype="0" Variant="3" IsGrid="1" MirrorX="6001.2.0" MirrorY="6001.5.0" />
-	<entity Group="Rails" ID="6001" Image="resources/Entities/6001.4.0 - Rail (Pit) (left-to-up).png" Kind="Stage" Name="Rail (Pit) (left-to-up)" Subtype="0" Variant="4" IsGrid="1" MirrorX="6001.5.0" MirrorY="6001.2.0" />
-	<entity Group="Rails" ID="6001" Image="resources/Entities/6001.5.0 - Rail (Pit) (right-to-up).png" Kind="Stage" Name="Rail (Pit) (right-to-up)" Subtype="0" Variant="5" IsGrid="1" MirrorX="6001.4.0" MirrorY="6001.3.0" />
-	<entity Group="Rails" ID="6001" Image="resources/Entities/6001.6.0 - Rail (Pit) (crossroad).png" Kind="Stage" Name="Rail (Pit) (crossroad)" Subtype="0" Variant="6" IsGrid="1"/>
-	<entity Group="Rails" ID="6001" Image="resources/Entities/6001.16.0 - Rail (Pit) (cart-left).png" Kind="Stage" Name="Rail (Pit) (cart-left)" Subtype="0" Variant="16" IsGrid="1" MirrorX="6001.32.0" />
-	<entity Group="Rails" ID="6001" Image="resources/Entities/6001.32.0 - Rail (Pit) (cart-right).png" Kind="Stage" Name="Rail (Pit) (cart-right)" Subtype="0" Variant="32" IsGrid="1" MirrorX="6000.16.0" />
-	<entity Group="Rails" ID="6001" Image="resources/Entities/6001.17.0 - Rail (Pit) (cart-up).png" Kind="Stage" Name="Rail (Pit) (cart-up)" Subtype="0" Variant="17" IsGrid="1" MirrorY="6001.33.0" />
-	<entity Group="Rails" ID="6001" Image="resources/Entities/6001.33.0 - Rail (Pit) (cart-down).png" Kind="Stage" Name="Rail (Pit) (cart-down)" Subtype="0" Variant="33" IsGrid="1" MirrorY="6001.17.0" />
-	
-	<!-- Teleporters -->
-	<entity Group="Teleporters" ID="6100" Image="resources/Entities/6100.0.0 - Teleporter(Square).png" Kind="Stage" Name="Teleporter(Square)" Subtype="0" Variant="0" IsGrid="1" />
-	<entity Group="Teleporters" ID="6100" Image="resources/Entities/6100.1.0 - Teleporter(Moon).png" Kind="Stage" Name="Teleporter(Moon)" Subtype="0" Variant="1" IsGrid="1" />
-	<entity Group="Teleporters" ID="6100" Image="resources/Entities/6100.2.0 - Teleporter(Rhombus).png" Kind="Stage" Name="Teleporter(Rhombus)" Subtype="0" Variant="2" IsGrid="1" />
-	<entity Group="Teleporters" ID="6100" Image="resources/Entities/6100.3.0 - Teleporter(M).png" Kind="Stage" Name="Teleporter(M)" Subtype="0" Variant="3" IsGrid="1" />
-	<entity Group="Teleporters" ID="6100" Image="resources/Entities/6100.4.0 - Teleporter(Pentagram).png" Kind="Stage" Name="Teleporter(Pentagram)" Subtype="0" Variant="4" IsGrid="1" />
-	<entity Group="Teleporters" ID="6100" Image="resources/Entities/6100.5.0 - Teleporter(Cross).png" Kind="Stage" Name="Teleporter(Cross)" Subtype="0" Variant="5" IsGrid="1" />
-	<entity Group="Teleporters" ID="6100" Image="resources/Entities/6100.6.0 - Teleporter(Triangle).png" Kind="Stage" Name="Teleporter(Triangle)" Subtype="0" Variant="6" IsGrid="1" />
+	<group Name="Necropolis Bosses">
+		<entity Name="The Pile"/>
+	</group>
 
-	<entity Group="Teleporters" ID="6100" Image="resources/Entities/6100.0.1 - Teleporter(Square-off).png" Kind="Stage" Name="Teleporter(Square-off)" Subtype="1" Variant="0" IsGrid="1" />
-	<entity Group="Teleporters" ID="6100" Image="resources/Entities/6100.1.1 - Teleporter(Moon-off).png" Kind="Stage" Name="Teleporter(Moon-off)" Subtype="1" Variant="1" IsGrid="1" />
-	<entity Group="Teleporters" ID="6100" Image="resources/Entities/6100.2.1 - Teleporter(Rhombus-off).png" Kind="Stage" Name="Teleporter(Rhombus-off)" Subtype="1" Variant="2" IsGrid="1" />
-	<entity Group="Teleporters" ID="6100" Image="resources/Entities/6100.3.1 - Teleporter(M-off).png" Kind="Stage" Name="Teleporter(M-off)" Subtype="1" Variant="3" IsGrid="1" />
-	<entity Group="Teleporters" ID="6100" Image="resources/Entities/6100.4.1 - Teleporter(Pentagram-off).png" Kind="Stage" Name="Teleporter(Pentagram-off)" Subtype="1" Variant="4" IsGrid="1" />
-	<entity Group="Teleporters" ID="6100" Image="resources/Entities/6100.5.1 - Teleporter(Cross-off).png" Kind="Stage" Name="Teleporter(Cross-off)" Subtype="1" Variant="5" IsGrid="1" />
-	<entity Group="Teleporters" ID="6100" Image="resources/Entities/6100.6.1 - Teleporter(Triangle-off).png" Kind="Stage" Name="Teleporter(Triangle-off)" Subtype="1" Variant="6" IsGrid="1" />
+	<group Name="Dank Depths Bosses">
+		<entity Name="Reap Creep"/>
+	</group>
 
-	<!-- Live Bombs -->
-	<entity Group="Live Bombs" ID="4" Image="resources/Entities/4.0.0 - Bomb.png" Kind="Stage" Name="Active Bomb" Subtype="0" Variant="0" />
-	<entity Group="Live Bombs" ID="4" Image="resources/Entities/4.0.1 - Big Bomb.png" Kind="Stage" Name="Big Bomb" Subtype="0" Variant="1" />
-	<entity Group="Live Bombs" ID="4" Image="resources/Entities/4.0.2 - Decoy Bomb.png" Kind="Stage" Name="Decoy Bomb" Subtype="0" Variant="2" />
-	<entity Group="Live Bombs" ID="4" Image="resources/Entities/4.0.5 - Poison Bomb.png" Kind="Stage" Name="Poison Bomb" Subtype="0" Variant="5" />
-	<entity Group="Live Bombs" ID="4" Image="resources/Entities/4.0.6 - Big Poison Bomb.png" Kind="Stage" Name="Big Poison Bomb" Subtype="0" Variant="6" />
-	<entity Group="Live Bombs" ID="4" Image="resources/Entities/4.0.7 - Sad Bomb.png" Kind="Stage" Name="Sad Bomb" Subtype="0" Variant="7" />
-	<entity Group="Live Bombs" ID="4" Image="resources/Entities/4.0.8 - Fire Bomb.png" Kind="Stage" Name="Fire Bomb" Subtype="0" Variant="8" />
-	<entity Group="Live Bombs" ID="4" Image="resources/Entities/4.0.9 - Butt Bomb.png" Kind="Stage" Name="Butt Bomb" Subtype="0" Variant="9" />
-	<entity Group="Live Bombs" ID="4" Image="resources/Entities/4.0.10 - Mr Mega Bomb.png" Kind="Stage" Name="Mr Mega Bomb" Subtype="0" Variant="10" />
-	<entity Group="Live Bombs" ID="4" Image="resources/Entities/4.0.11 - Bobby Bomb.png" Kind="Stage" Name="Bobby Bomb" Subtype="0" Variant="11" />
-	<entity Group="Live Bombs" ID="4" Image="resources/Entities/4.12.0 - Glitter Bomb.png" Kind="Stage" Name="Glitter Bomb" Variant="12" Subtype="0" />
-	<entity Group="Live Bombs" ID="4" Image="resources/Entities/4.13.0 - Throwable Bomb.png" Kind="Stage" Name="Throwable Bomb" Variant="13" Subtype="0" />
-	<entity Group="Live Bombs" ID="4" Image="resources/Entities/4.14.0 - Small Bomb.png" Kind="Stage" Name="Small Bomb" Variant="14" Subtype="0" />
-	<entity Group="Live Bombs" ID="4" Image="resources/Entities/4.15.0 - Brimstone Bomb.png" Kind="Stage" Name="Brimstone Bomb" Variant="15" Subtype="0" />
-	<entity Group="Live Bombs" ID="4" Image="resources/Entities/4.16.0 - Bloody Sad Bomb.png" Kind="Stage" Name="Bloody Sad Bomb" Variant="16" Subtype="0" />
-	<entity Group="Live Bombs" ID="4" Image="resources/Entities/4.17.0 - Giga Bomb.png" Kind="Stage" Name="Giga Bomb" Variant="17" Subtype="0" />
-	<entity Group="Live Bombs" ID="4" Image="resources/Entities/4.19.0 - Rocket.png" Kind="Stage" Name="Rocket" Variant="19" Subtype="0" />
-	<entity Group="Live Bombs" ID="4" Image="resources/Entities/4.20.0 - Giga Rocket.png" Kind="Stage" Name="Giga Rocket" Variant="20" Subtype="0" />
+	<group Name="Chapter 3 Bosses">
+		<group Name="Chapter 3 Bosses (Alt Path)" Label="Chapter 3 (Alt Path)">
+			<group Name="Chapter 3 Bosses (Alt Path) Shared"/>
+			<group Name="Mausoleum Bosses" Label="Mausoleum"/>
+			<group Name="Gehenna Bosses" Label="Gehenna"/>
+		</group>
+	</group>
 
-	<!-- Machines -->
-	<entity Group="Machines" ID="6" Image="resources/Entities/6.1.0 - Slot Machine.png" Kind="Stage" Name="Slot Machine" Subtype="0" Variant="1" />
-	<entity Group="Machines" ID="6" Image="resources/Entities/6.2.0 - Blood Donation Machine.png" Kind="Stage" Name="Blood Donation Machine" Subtype="0" Variant="2" />
-	<entity Group="Machines" ID="6" Image="resources/Entities/6.3.0 - Fortune Telling Machine.png" Kind="Stage" Name="Fortune Telling Machine" Subtype="0" Variant="3" />
-	<entity Group="Machines" ID="6" Image="resources/Entities/6.10.0 - Shop Restock Machine.png" Kind="Stage" Name="Shop Restock Machine" Subtype="0" Variant="10" />
-	<entity Group="Machines" ID="6" Image="resources/Entities/6.8.0 - Donation Machine.png" Kind="Stage" Name="Donation Machine" Subtype="0" Variant="8" />
-	<entity Group="Machines" ID="6" Image="resources/Entities/6.11.0 - Greed Machine.png" Kind="Stage" Name="Greed Machine" Subtype="0" Variant="11" />
-	<entity Group="Machines" ID="6" Image="resources/Entities/6.12.0 - Mom's Dressing Table.png" Kind="Stage" Name="Mom's Dressing Table" Subtype="0" Variant="12" />
-	<entity Group="Machines" ID="6" Image="resources/Entities/6.16.0 - Crane Game.png" Kind="Stage" Name="Crane Game" Variant="16" Subtype="0" />
-	<entity Group="Machines" ID="6" Image="resources/Entities/6.17.0 - Confessional.png" Kind="Stage" Name="Confessional" Variant="17" Subtype="0" />
+	<group Name="Mausoleum Bosses">
+		<entity BaseHP="666" ID="904" Image="Entities/904.0.0 - Siren.png" Name="Siren" Variant="0" Subtype="0" />
+		<entity BaseHP="20" Tags="" ID="904" Image="Entities/904.1.0 - Siren's Skull.png" Name="Siren's Skull" Variant="1" Subtype="0" />
+		<entity BaseHP="789" ID="905" Image="Entities/905.0.0 - The Heretic.png" Name="The Heretic" Variant="0" Subtype="0" />
+	</group>
 
-	<!-- Other -->
-	<entity Group="Other" ID="10000" Image="resources/Entities/10000.0.0 - Gravity.png" Kind="Stage" Name="Gravity" Subtype="0" Variant="0" IsGrid="1" />
-	<entity BaseHP="0" Group="Other" ID="291" Image="resources/Entities/291.0.0 - Pitfall.png" Kind="Stage" Name="Pitfall" Subtype="0" Variant="0" IsGrid="1" />
-	<entity BaseHP="0" Group="Other" ID="291" Image="resources/Entities/291.1.0 - Suction Pitfall.png" Kind="Stage" Name="Suction Pitfall" Subtype="0" Variant="1" IsGrid="1" />
-	<entity BaseHP="0" Group="Other" ID="291" Image="resources/Entities/291.2.0 - Teleport Pitfall.png" Kind="Stage" Name="Teleport Pitfall" Subtype="0" Variant="2" IsGrid="1" />
-	<entity BaseHP="0" Group="Other" ID="291" Image="resources/Entities/291.3.0 - Blue Hush Pitfall.png" Kind="Stage" Name="Blue Hush Pitfall" Subtype="0" Variant="3" IsGrid="1" />
-	<entity BaseHP="100" Group="Other" ID="866" Image="resources/Entities/866.1.0 - Dark Esau's Pit.png" Kind="Stage" Name="Dark Esau's Pit" Variant="1" Subtype="0" />
-	<entity BaseHP="0" Group="Other" ID="965" Image="resources/Entities/965.10.0 - Quest Minecart.png" Kind="Stage" Name="Quest Minecart" Variant="10" Subtype="0" />
-	<entity BaseHP="0" Group="Other" ID="999" Image="resources/Entities/1000.116.0 - Dirt Patch.png" Kind="Stage" Name="Dirt Patch" Subtype="0" Variant="116" PlaceVisual="0,0.2" IsGrid="1" />
-	<entity Group="Other" ID="999" Image="resources/Entities/1000.141.1 - Smoke Cloud.png" Kind="Stage" Name="Smoke Cloud" Variant="141" Subtype="1" />
-	<entity ID="2" Kind="Stage" Group="Other" Image="resources/Entities/2.9.0 - Chaos Tear.png" Name="Chaos Tear" Subtype="0" Variant="9" />
-	<entity Group="Other" ID="6" Image="resources/Entities/6.14.0 - Isaac (secret).png" Kind="Stage" Name="Isaac (secret)" Variant="14" Subtype="0" />
+	<group Name="Gehenna Bosses">
+		<entity BaseHP="620" ID="903" Image="Entities/903.0.0 - Visage Heart.png" Name="Visage Heart" Variant="0" Subtype="0" />
+		<entity BaseHP="100" ID="903" Image="Entities/903.1.0 - Visage Mask.png" Name="Visage Mask" Variant="1" Subtype="0" />
+		<entity BaseHP="707" ID="920" Image="Entities/920.0.0 - Horny Boys.png" Name="Horny Boys" Variant="0" Subtype="0" />
+	</group>
 
-	<!-- Poop -->
-	<entity Group="Poop" ID="1500" Image="resources/Entities/1500.0.0 - Poop.png" Kind="Stage" Name="Poop" Subtype="0" Variant="0" InEmptyRooms="1" IsGrid="1" />
-	<entity Group="Poop" ID="1500" Image="resources/Entities/1500.0.1 - Poop (non-replaceable).png" Kind="Stage" Name="Poop (non-replaceable)" Subtype="1" Variant="0" IsGrid="1" />
-	<entity Group="Poop" ID="1495" Image="resources/Entities/1495.0.0 - Chunky Poop.png" Kind="Stage" Name="Chunky Poop" Subtype="0" Variant="0" InEmptyRooms="1" IsGrid="1" />
-	<entity Group="Poop" ID="1490" Image="resources/Entities/1490.0.0 - Red Poop.png" Kind="Stage" Name="Red Poop" Subtype="0" Variant="0" InEmptyRooms="1" IsGrid="1" />
-	<entity Group="Poop" ID="1496" Image="resources/Entities/1496.0.0 - Golden Poop.png" Kind="Stage" Name="Golden Poop" Subtype="0" Variant="0" InEmptyRooms="1" IsGrid="1" />
-	<entity Group="Poop" ID="1494" Image="resources/Entities/1494.0.0 - Rainbow Poop.png" Kind="Stage" Name="Rainbow Poop" Subtype="0" Variant="0" InEmptyRooms="1" IsGrid="1" />
-	<entity Group="Poop" ID="1497" Image="resources/Entities/1497.0.0 - Black Poop.png" Kind="Stage" Name="Black Poop" Subtype="0" Variant="0" InEmptyRooms="1" IsGrid="1" />
-	<entity Group="Poop" ID="1498" Image="resources/Entities/1498.0.0 - Holy Poop.png" Kind="Stage" Name="Holy Poop" Subtype="0" Variant="0" InEmptyRooms="1" IsGrid="1" />
-	<entity Group="Poop" ID="1499" Image="resources/Entities/1499.0.0 - Giant Poop.png" Kind="Stage" Name="Giant Poop" Subtype="0" Variant="0" InEmptyRooms="1" IsGrid="1" />
-	<entity Group="Poop" ID="1501" Image="resources/Entities/1501.0.0 - Charming Poop.png" Kind="Stage" Name="Charming Poop" Subtype="0" Variant="0" InEmptyRooms="1" IsGrid="1" />
+	<group Name="Chapter 4 Bosses">
+		<group Name="Chapter 4 Bosses (Alt Path)" Label="Chapter 4 (Alt Path)">
+			<group Name="Chapter 4 Bosses (Alt Path) Shared"/>
+			<group Name="Corpse Bosses" Label="Corpse"/>
+		</group>
+	</group>
 
-	<!-- Props -->
-	<entity Group="Props" ID="0" Image="resources/Entities/0.10.0 - Random Props A.png" Kind="Stage" Name="Random Props A" Subtype="0" Variant="10" InEmptyRooms="1" NoBlockDoors="1" IsGrid="1" />
-	<entity Group="Props" ID="0" Image="resources/Entities/0.20.0 - Random Props B.png" Kind="Stage" Name="Random Props B" Subtype="0" Variant="20" InEmptyRooms="1" NoBlockDoors="1" IsGrid="1" />
-	<entity Group="Props" ID="0" Image="resources/Entities/0.30.0 - Random Props C.png" Kind="Stage" Name="Random Props C" Subtype="0" Variant="30" InEmptyRooms="1" NoBlockDoors="1" IsGrid="1" />
-	<entity Group="Props" ID="5" Image="resources/Entities/5.380.0 - Isaac's Bed.png" PlaceVisual="0,1" Kind="Stage" Name="Isaac's Bed" Subtype="0" Variant="380" IsGrid="1" />
-	<entity Group="Props" Kind="Stage" Image="resources/Entities/1000.74.0 - Isaacs Carpet.png" ID="999" Name="Isaac's Carpet" Variant="74" Subtype="0" PlaceVisual="0,1.5" NoBlockDoors="1" IsGrid="1" />
-	<entity BaseHP="5" Group="Props" ID="17" Image="resources/Entities/17.0.0 - Keeper.png" Kind="Stage" Name="Keeper" Subtype="0" Variant="0" />
-	<entity BaseHP="5" Group="Props" ID="17" Image="resources/Entities/17.1.0 - Hanging Keeper.png" Kind="Stage" Name="Hanging Keeper" Subtype="0" Variant="1" />
-	<entity BaseHP="5" Group="Props" ID="17" Image="resources/Entities/17.2.0 - Error Room Keeper.png" Kind="Stage" Name="Error Room Keeper" Subtype="0" Variant="2" />
-	<entity BaseHP="5" Group="Props" ID="17" Image="resources/Entities/17.3.0 - Special Keeper.png" Kind="Stage" Name="Special Keeper" Subtype="0" Variant="3" />
-	<entity BaseHP="5" Group="Props" ID="17" Image="resources/Entities/17.4.0 - Special Hanging Keeper.png" Kind="Stage" Name="Special Hanging Keeper" Subtype="0" Variant="4" />
-	<entity Group="Props" ID="5000" Image="resources/Entities/5000.0.0 - Devil Statue.png" Kind="Stage" Name="Devil Statue" Subtype="0" Variant="0" IsGrid="1" />
-	<entity Group="Props" ID="5001" Image="resources/Entities/5001.0.0 - Angel Statue.png" Kind="Stage" Name="Angel Statue" Subtype="0" Variant="0" IsGrid="1" />
-	<entity Group="Props" Kind="Stage" Image="resources/Entities/1000.76.0 - Dice Floor.png" ID="999" Name="Dice Room Floor" Variant="76" Subtype="0" PlaceVisual="0,2.5" NoBlockDoors="1" IsGrid="1" />
-	
-	<entity Group="Props" ID="5" Image="resources/Entities/5.380.10 - Mom's Bed.png" Kind="Stage" Name="Mom's Bed" Variant="380" Subtype="10" />
-	<entity Group="Props" ID="5" Image="resources/Entities/5.390.0 - Mom's Chest.png" Kind="Stage" Name="Mom's Chest" Variant="390" Subtype="0" />
-	<entity BaseHP="1" Group="Props" ID="960" Image="resources/Entities/960.1.0 - Mom's Dresser.png" Kind="Stage" Name="Mom's Dresser" Variant="1" Subtype="0" />
-	<entity BaseHP="1" Group="Props" ID="960" Image="resources/Entities/960.2.0 - Mom's Vanity.png" Kind="Stage" Name="Mom's Vanity" Variant="2" Subtype="0" />
-	<entity BaseHP="1" Group="Props" ID="960" Image="resources/Entities/960.3.0 - Couch.png" Kind="Stage" Name="Couch" Variant="3" Subtype="0" />
-	<entity BaseHP="1" Group="Props" ID="960" Image="resources/Entities/960.4.0 - TV.png" Kind="Stage" Name="TV" Variant="4" Subtype="0" />
-	<entity Group="Props" ID="999" Image="resources/Entities/1000.74.1 - Moms Room Carpet.png" Kind="Stage" Name="Moms Room Carpet" Variant="74" Subtype="1" PlaceVisual="0,1.5" NoBlockDoors="1" IsGrid="1" />
-	<entity Group="Props" ID="999" Image="resources/Entities/1000.74.2 - Living Room Carpet.png" Kind="Stage" Name="Living Room Carpet" Variant="74" Subtype="2" PlaceVisual="0,1.5" NoBlockDoors="1" IsGrid="1" />
+	<group Name="Corpse Bosses">
+		<entity BaseHP="950" ID="909" Image="Entities/909.0.0 - The Scourge.png" Name="The Scourge" Variant="0" Subtype="0" />
+		<entity BaseHP="1050" ID="910" Image="Entities/910.0.0 - Chimera.png" Name="Chimera" Variant="0" Subtype="0" />
+		<entity BaseHP="1050" ID="910" Image="Entities/910.1.0 - Chimera (body).png" Name="Chimera (body)" Variant="1" Subtype="0" />
+		<entity BaseHP="1050" ID="910" Image="Entities/910.2.0 - Chimera (head).png" Name="Chimera (head)" Variant="2" Subtype="0" />
+		<entity BaseHP="600" ID="911" Image="Entities/911.0.0 - Rotgut.png" Name="Rotgut" Variant="0" Subtype="0" />
+		<entity BaseHP="600" ID="911" Image="Entities/911.1.0 - Rotgut (maggot).png" Name="Rotgut (maggot)" Variant="1" Subtype="0" />
+		<entity BaseHP="600" ID="911" Image="Entities/911.2.0 - Rotgut (heart).png" Name="Rotgut (heart)" Variant="2" Subtype="0" />
+	</group>
 
-	<!-- Special Exits -->
-	<entity Group="Special Exits" ID="5" Image="resources/Entities/5.340.0 - Big Chest.png" Kind="Stage" Name="Big Chest" Subtype="0" Variant="340" />
-	<entity Group="Special Exits" ID="5" Image="resources/Entities/5.370.0 - Trophy.png" Kind="Stage" Name="Trophy" Subtype="0" Variant="370" />
-	<entity Group="Special Exits" ID="9000" Image="resources/Entities/9000.0.0 - Trap Door.png" Kind="Stage" Name="Trap Door" Subtype="0" Variant="0" PlaceVisual="0,0.1" IsGrid="1" />
-	<entity Group="Special Exits" ID="9100" Image="resources/Entities/9100.0.0 - Ladder Door.png" Kind="Stage" Name="Ladder Door" Subtype="0" Variant="0" PlaceVisual="0,0.1" IsGrid="1" />
-	<!-- Troll Bombs -->
-	<entity ID="4" Image="resources/Entities/4.0.3 - Troll Bomb.png" Name="Troll Bomb (player)" Subtype="0" Variant="3" />
-	<entity Group="Troll Bombs" ID="5" Image="resources/Entities/4.0.3 - Troll Bomb.png" Kind="Stage" Name="Troll Bomb" Subtype="3" Variant="40" />
-	<entity ID="4" Image="resources/Entities/4.0.4 - Megatroll Bomb.png" Name="Megatroll Bomb (player)" Subtype="0" Variant="4" />
-	<entity Group="Troll Bombs" ID="5" Image="resources/Entities/4.0.4 - Megatroll Bomb.png" Kind="Stage" Name="Megatroll Bomb" Subtype="5" Variant="40" />
-	<entity ID="4" Image="resources/Entities/4.18.0 - Golden Troll Bomb.png" Name="Golden Troll Bomb (player)" Variant="18" Subtype="0" />
-	<entity Group="Troll Bombs" ID="5" Image="resources/Entities/5.40.6 - Golden Troll Bomb.png" Kind="Stage" Name="Golden Troll Bomb" Variant="40" Subtype="6" />
+	<group Name="Story Bosses">
+		<entity BaseHP="250" ID="867" Image="Entities/867.0.0 - Mother's Shadow.png" Name="Mother's Shadow" Variant="0" Subtype="0" />
+		<entity BaseHP="2222" ID="912" Image="Entities/912.0.0 - Mother.png" Name="Mother" Variant="0" Subtype="0" />
+		<entity BaseHP="2000" ID="912" Image="Entities/912.10.0 - Mother 2.png" Name="Mother 2" Variant="10" Subtype="0" />
+		<entity BaseHP="40" Tags="" ID="912" Image="Entities/912.20.0 - Dead Isaac.png" Name="Dead Isaac" Variant="20" Subtype="0" />
+		<entity BaseHP="10" ID="912" Image="Entities/912.100.0 - Mother Ball.png" Name="Mother Ball" Variant="100" Subtype="0" />
+		<entity BaseHP="10" ID="912" Image="Entities/912.100.1 - Mother Ball (Medium).png" Name="Mother Ball (Medium)" Variant="100" Subtype="1" />
+		<entity BaseHP="10" ID="912" Image="Entities/912.100.2 - Mother Ball (Small).png" Name="Mother Ball (Small)" Variant="100" Subtype="2" />
+		<entity BaseHP="1200" ID="950" Image="Entities/950.0.0 - Dogma.png" Name="Dogma" Variant="0" Subtype="0" />
+		<entity BaseHP="1200" ID="950" Image="Entities/950.1.0 - Dogma's TV.png" Name="Dogma's TV" Variant="1" Subtype="0" />
+		<entity BaseHP="1200" ID="950" Image="Entities/950.2.0 - Dogma Angel.png" Name="Dogma Angel" Variant="2" Subtype="0" />
+		<entity BaseHP="30" Tags="" ID="950" Image="Entities/950.10.0 - Dogma Angel Baby.png" Name="Dogma Angel Baby" Variant="10" Subtype="0" />
+	</group>
 
-	<!--——— Collect ———-->
+	<group Name="Other Bosses">
+		<group Label="The Beast">
+			<entity BaseHP="10000" ID="951" Image="Entities/951.0.0 - The Beast.png" Name="The Beast" Variant="0" Subtype="0" />
+			<entity BaseHP="2000" ID="951" Image="Entities/951.10.0 - Ultra Famine.png" Name="Ultra Famine" Variant="10" Subtype="0" />
+			<entity BaseHP="10" Tags="" ID="951" Image="Entities/951.11.0 - Ultra Famine Fly.png" Name="Ultra Famine Fly" Variant="11" Subtype="0" />
+			<entity BaseHP="1800" ID="951" Image="Entities/951.20.0 - Ultra Pestilence.png" Name="Ultra Pestilence" Variant="20" Subtype="0" />
+			<entity BaseHP="10" Tags="" ID="951" Image="Entities/951.21.0 - Ultra Pestilence Fly.png" Name="Ultra Pestilence Fly" Variant="21" Subtype="0" />
+			<entity ID="951" Tags="" Image="Entities/951.22.0 - Ultra Pestilence Maggot.png" Name="Ultra Pestilence Maggot" Variant="22" Subtype="0" />
+			<entity BaseHP="200" Tags="" ID="951" Image="Entities/951.23.0 - Ultra Pestilence Fly Ball.png" Name="Ultra Pestilence Fly Ball" Variant="23" Subtype="0" />
+			<entity BaseHP="2000" ID="951" Image="Entities/951.30.0 - Ultra War.png" Name="Ultra War" Variant="30" Subtype="0" />
+			<entity BaseHP="200" Tags="" ID="951" Image="Entities/951.31.0 - Ultra War Bomb.png" Name="Ultra War Bomb" Variant="31" Subtype="0" />
+			<entity BaseHP="2000" ID="951" Image="Entities/951.40.0 - Ultra Death.png" Name="Ultra Death" Variant="40" Subtype="0" />
+			<entity BaseHP="100" Tags="" ID="951" Image="Entities/951.42.0 - Ultra Death Head.png" Name="Ultra Death Head" Variant="42" Subtype="0" />
+		</group>
+	</group>
 
-	<!-- Random -->
-	<entity Group=" Random" ID="5" Image="resources/Entities/Items/5.100.0 - Random.png" Kind="Collect" Name="Random Collectible" Subtype="0" Variant="100" />
-	<entity Group=" Random" ID="5" Image="resources/Entities/Items/5.150.0 - Random.png" Kind="Collect" Name="Random Shop Item" Subtype="0" Variant="150" />
-	<entity Group=" Random" ID="5" Image="resources/Entities/5.350.0 - Trinket.png" Kind="Collect" Name="Random Trinket" Subtype="0" Variant="350" />
-
-	<!-- Active Items -->
-	<entity Group="Active Items" ID="5" Image="resources/Entities/Items/5.100.33 - The Bible.png" Kind="Collect" Name="The Bible" Subtype="33" Variant="100" />
-	<entity Group="Active Items" ID="5" Image="resources/Entities/Items/5.100.34 - The Book of Belial.png" Kind="Collect" Name="The Book of Belial" Subtype="34" Variant="100" />
-	<entity Group="Active Items" ID="5" Image="resources/Entities/Items/5.100.35 - The Necronomicon.png" Kind="Collect" Name="The Necronomicon" Subtype="35" Variant="100" />
-	<entity Group="Active Items" ID="5" Image="resources/Entities/Items/5.100.36 - The Poop.png" Kind="Collect" Name="The Poop" Subtype="36" Variant="100" />
-	<entity Group="Active Items" ID="5" Image="resources/Entities/Items/5.100.37 - Mr. Boom.png" Kind="Collect" Name="Mr. Boom" Subtype="37" Variant="100" />
-	<entity Group="Active Items" ID="5" Image="resources/Entities/Items/5.100.38 - Tammy's Head.png" Kind="Collect" Name="Tammy's Head" Subtype="38" Variant="100" />
-	<entity Group="Active Items" ID="5" Image="resources/Entities/Items/5.100.39 - Mom's Bra.png" Kind="Collect" Name="Mom's Bra" Subtype="39" Variant="100" />
-	<entity Group="Active Items" ID="5" Image="resources/Entities/Items/5.100.40 - Kamikaze!.png" Kind="Collect" Name="Kamikaze!" Subtype="40" Variant="100" />
-	<entity Group="Active Items" ID="5" Image="resources/Entities/Items/5.100.41 - Mom's Pad.png" Kind="Collect" Name="Mom's Pad" Subtype="41" Variant="100" />
-	<entity Group="Active Items" ID="5" Image="resources/Entities/Items/5.100.42 - Bob's Rotten Head.png" Kind="Collect" Name="Bob's Rotten Head" Subtype="42" Variant="100" />
-	<entity Group="Active Items" ID="5" Image="resources/Entities/Items/5.100.44 - Teleport!.png" Kind="Collect" Name="Teleport!" Subtype="44" Variant="100" />
-	<entity Group="Active Items" ID="5" Image="resources/Entities/Items/5.100.45 - Yum Heart.png" Kind="Collect" Name="Yum Heart" Subtype="45" Variant="100" />
-	<entity Group="Active Items" ID="5" Image="resources/Entities/Items/5.100.47 - Doctor's Remote.png" Kind="Collect" Name="Doctor's Remote" Subtype="47" Variant="100" />
-	<entity Group="Active Items" ID="5" Image="resources/Entities/Items/5.100.49 - Shoop da Whoop!.png" Kind="Collect" Name="Shoop da Whoop!" Subtype="49" Variant="100" />
-	<entity Group="Active Items" ID="5" Image="resources/Entities/Items/5.100.56 - Lemon Mishap.png" Kind="Collect" Name="Lemon Mishap" Subtype="56" Variant="100" />
-	<entity Group="Active Items" ID="5" Image="resources/Entities/Items/5.100.58 - Book of Shadows.png" Kind="Collect" Name="Book of Shadows" Subtype="58" Variant="100" />
-	<entity Group="Active Items" ID="5" Image="resources/Entities/Items/5.100.65 - Anarchist Cookbook.png" Kind="Collect" Name="Anarchist Cookbook" Subtype="65" Variant="100" />
-	<entity Group="Active Items" ID="5" Image="resources/Entities/Items/5.100.66 - The Hourglass.png" Kind="Collect" Name="The Hourglass" Subtype="66" Variant="100" />
-	<entity Group="Active Items" ID="5" Image="resources/Entities/Items/5.100.77 - My Little Unicorn.png" Kind="Collect" Name="My Little Unicorn" Subtype="77" Variant="100" />
-	<entity Group="Active Items" ID="5" Image="resources/Entities/Items/5.100.78 - Book of Revelations.png" Kind="Collect" Name="Book of Revelations" Subtype="78" Variant="100" />
-	<entity Group="Active Items" ID="5" Image="resources/Entities/Items/5.100.83 - The Nail.png" Kind="Collect" Name="The Nail" Subtype="83" Variant="100" />
-	<entity Group="Active Items" ID="5" Image="resources/Entities/Items/5.100.84 - We Need To Go Deeper!.png" Kind="Collect" Name="We Need To Go Deeper!" Subtype="84" Variant="100" />
-	<entity Group="Active Items" ID="5" Image="resources/Entities/Items/5.100.85 - Deck of Cards.png" Kind="Collect" Name="Deck of Cards" Subtype="85" Variant="100" />
-	<entity Group="Active Items" ID="5" Image="resources/Entities/Items/5.100.86 - Monstro's Tooth.png" Kind="Collect" Name="Monstro's Tooth" Subtype="86" Variant="100" />
-	<entity Group="Active Items" ID="5" Image="resources/Entities/Items/5.100.93 - The Gamekid.png" Kind="Collect" Name="The Gamekid" Subtype="93" Variant="100" />
-	<entity Group="Active Items" ID="5" Image="resources/Entities/Items/5.100.97 - The Book of Sin.png" Kind="Collect" Name="The Book of Sin" Subtype="97" Variant="100" />
-	<entity Group="Active Items" ID="5" Image="resources/Entities/Items/5.100.102 - Mom's Bottle of Pills.png" Kind="Collect" Name="Mom's Bottle of Pills" Subtype="102" Variant="100" />
-	<entity Group="Active Items" ID="5" Image="resources/Entities/Items/5.100.105 - The D6.png" Kind="Collect" Name="The D6" Subtype="105" Variant="100" />
-	<entity Group="Active Items" ID="5" Image="resources/Entities/Items/5.100.107 - The Pinking Shears.png" Kind="Collect" Name="The Pinking Shears" Subtype="107" Variant="100" />
-	<entity Group="Active Items" ID="5" Image="resources/Entities/Items/5.100.111 - The Bean.png" Kind="Collect" Name="The Bean" Subtype="111" Variant="100" />
-	<entity Group="Active Items" ID="5" Image="resources/Entities/Items/5.100.123 - Monster Manual.png" Kind="Collect" Name="Monster Manual" Subtype="123" Variant="100" />
-	<entity Group="Active Items" ID="5" Image="resources/Entities/Items/5.100.124 - Dead Sea Scrolls.png" Kind="Collect" Name="Dead Sea Scrolls" Subtype="124" Variant="100" />
-	<entity Group="Active Items" ID="5" Image="resources/Entities/Items/5.100.126 - Razor Blade.png" Kind="Collect" Name="Razor Blade" Subtype="126" Variant="100" />
-	<entity Group="Active Items" ID="5" Image="resources/Entities/Items/5.100.127 - Forget Me Now.png" Kind="Collect" Name="Forget Me Now" Subtype="127" Variant="100" />
-	<entity Group="Active Items" ID="5" Image="resources/Entities/Items/5.100.130 - A Pony.png" Kind="Collect" Name="A Pony" Subtype="130" Variant="100" />
-	<entity Group="Active Items" ID="5" Image="resources/Entities/Items/5.100.133 - Guppy's Paw.png" Kind="Collect" Name="Guppy's Paw" Subtype="133" Variant="100" />
-	<entity Group="Active Items" ID="5" Image="resources/Entities/Items/5.100.135 - IV Bag.png" Kind="Collect" Name="IV Bag" Subtype="135" Variant="100" />
-	<entity Group="Active Items" ID="5" Image="resources/Entities/Items/5.100.136 - Best Friend.png" Kind="Collect" Name="Best Friend" Subtype="136" Variant="100" />
-	<entity Group="Active Items" ID="5" Image="resources/Entities/Items/5.100.137 - Remote Detonator.png" Kind="Collect" Name="Remote Detonator" Subtype="137" Variant="100" />
-	<entity Group="Active Items" ID="5" Image="resources/Entities/Items/5.100.145 - Guppy's Head.png" Kind="Collect" Name="Guppy's Head" Subtype="145" Variant="100" />
-	<entity Group="Active Items" ID="5" Image="resources/Entities/Items/5.100.146 - Prayer Card.png" Kind="Collect" Name="Prayer Card" Subtype="146" Variant="100" />
-	<entity Group="Active Items" ID="5" Image="resources/Entities/Items/5.100.147 - Notched Axe.png" Kind="Collect" Name="Notched Axe" Subtype="147" Variant="100" />
-	<entity Group="Active Items" ID="5" Image="resources/Entities/Items/5.100.158 - Crystal Ball.png" Kind="Collect" Name="Crystal Ball" Subtype="158" Variant="100" />
-	<entity Group="Active Items" ID="5" Image="resources/Entities/Items/5.100.160 - Crack the Sky.png" Kind="Collect" Name="Crack the Sky" Subtype="160" Variant="100" />
-	<entity Group="Active Items" ID="5" Image="resources/Entities/Items/5.100.164 - The Candle.png" Kind="Collect" Name="The Candle" Subtype="164" Variant="100" />
-	<entity Group="Active Items" ID="5" Image="resources/Entities/Items/5.100.166 - D20.png" Kind="Collect" Name="D20" Subtype="166" Variant="100" />
-	<entity Group="Active Items" ID="5" Image="resources/Entities/Items/5.100.171 - Spider Butt.png" Kind="Collect" Name="Spider Butt" Subtype="171" Variant="100" />
-	<entity Group="Active Items" ID="5" Image="resources/Entities/Items/5.100.175 - Dad's Key.png" Kind="Collect" Name="Dad's Key" Subtype="175" Variant="100" />
-	<entity Group="Active Items" ID="5" Image="resources/Entities/Items/5.100.177 - Portable Slot.png" Kind="Collect" Name="Portable Slot" Subtype="177" Variant="100" />
-	<entity Group="Active Items" ID="5" Image="resources/Entities/Items/5.100.181 - White Pony.png" Kind="Collect" Name="White Pony" Subtype="181" Variant="100" />
-	<entity Group="Active Items" ID="5" Image="resources/Entities/Items/5.100.186 - Blood Rights.png" Kind="Collect" Name="Blood Rights" Subtype="186" Variant="100" />
-	<entity Group="Active Items" ID="5" Image="resources/Entities/Items/5.100.192 - Telepathy For Dummies.png" Kind="Collect" Name="Telepathy For Dummies" Subtype="192" Variant="100" />
-	<entity Group="Active Items" ID="5" Image="resources/Entities/Items/5.100.263 - Clear Rune.png" Kind="Collect" Name="Clear Rune" Subtype="263" Variant="100" />
-	<entity Group="Active Items" ID="5" Image="resources/Entities/Items/5.100.282 - How to Jump.png" Kind="Collect" Name="How to Jump" Subtype="282" Variant="100" />
-	<entity Group="Active Items" ID="5" Image="resources/Entities/Items/5.100.283 - D100.png" Kind="Collect" Name="D100" Subtype="283" Variant="100" />
-	<entity Group="Active Items" ID="5" Image="resources/Entities/Items/5.100.284 - D4.png" Kind="Collect" Name="D4" Subtype="284" Variant="100" />
-	<entity Group="Active Items" ID="5" Image="resources/Entities/Items/5.100.285 - D10.png" Kind="Collect" Name="D10" Subtype="285" Variant="100" />
-	<entity Group="Active Items" ID="5" Image="resources/Entities/Items/5.100.286 - Blank Card.png" Kind="Collect" Name="Blank Card" Subtype="286" Variant="100" />
-	<entity Group="Active Items" ID="5" Image="resources/Entities/Items/5.100.287 - Book of Secrets.png" Kind="Collect" Name="Book of Secrets" Subtype="287" Variant="100" />
-	<entity Group="Active Items" ID="5" Image="resources/Entities/Items/5.100.288 - Box of Spiders.png" Kind="Collect" Name="Box of Spiders" Subtype="288" Variant="100" />
-	<entity Group="Active Items" ID="5" Image="resources/Entities/Items/5.100.289 - Red Candle.png" Kind="Collect" Name="Red Candle" Subtype="289" Variant="100" />
-	<entity Group="Active Items" ID="5" Image="resources/Entities/Items/5.100.290 - The Jar.png" Kind="Collect" Name="The Jar" Subtype="290" Variant="100" />
-	<entity Group="Active Items" ID="5" Image="resources/Entities/Items/5.100.291 - Flush!.png" Kind="Collect" Name="Flush!" Subtype="291" Variant="100" />
-	<entity Group="Active Items" ID="5" Image="resources/Entities/Items/5.100.292 - Satanic Bible.png" Kind="Collect" Name="Satanic Bible" Subtype="292" Variant="100" />
-	<entity Group="Active Items" ID="5" Image="resources/Entities/Items/5.100.293 - Head of Krampus.png" Kind="Collect" Name="Head of Krampus" Subtype="293" Variant="100" />
-	<entity Group="Active Items" ID="5" Image="resources/Entities/Items/5.100.294 - Butter Bean.png" Kind="Collect" Name="Butter Bean" Subtype="294" Variant="100" />
-	<entity Group="Active Items" ID="5" Image="resources/Entities/Items/5.100.295 - Magic Fingers.png" Kind="Collect" Name="Magic Fingers" Subtype="295" Variant="100" />
-	<entity Group="Active Items" ID="5" Image="resources/Entities/Items/5.100.296 - Converter.png" Kind="Collect" Name="Converter" Subtype="296" Variant="100" />
-	<entity Group="Active Items" ID="5" Image="resources/Entities/Items/5.100.297 - Pandora's Box.png" Kind="Collect" Name="Pandora's Box" Subtype="297" Variant="100" />
-	<entity Group="Active Items" ID="5" Image="resources/Entities/Items/5.100.298 - Unicorn Stump.png" Kind="Collect" Name="Unicorn Stump" Subtype="298" Variant="100" />
-	<entity Group="Active Items" ID="5" Image="resources/Entities/Items/5.100.323 - Isaac's Tears.png" Kind="Collect" Name="Isaac's Tears" Subtype="323" Variant="100" />
-	<entity Group="Active Items" ID="5" Image="resources/Entities/Items/5.100.324 - Undefined.png" Kind="Collect" Name="Undefined" Subtype="324" Variant="100" />
-	<entity Group="Active Items" ID="5" Image="resources/Entities/Items/5.100.325 - Scissors.png" Kind="Collect" Name="Scissors" Subtype="325" Variant="100" />
-	<entity Group="Active Items" ID="5" Image="resources/Entities/Items/5.100.326 - Breath of Life.png" Kind="Collect" Name="Breath of Life" Subtype="326" Variant="100" />
-	<entity Group="Active Items" ID="5" Image="resources/Entities/Items/5.100.338 - The Boomerang.png" Kind="Collect" Name="The Boomerang" Subtype="338" Variant="100" />
-	<entity Group="Active Items" ID="5" Image="resources/Entities/Items/5.100.347 - Diplopia.png" Kind="Collect" Name="Diplopia" Subtype="347" Variant="100" />
-	<entity Group="Active Items" ID="5" Image="resources/Entities/Items/5.100.348 - Placebo.png" Kind="Collect" Name="Placebo" Subtype="348" Variant="100" />
-	<entity Group="Active Items" ID="5" Image="resources/Entities/Items/5.100.349 - Wooden Nickel.png" Kind="Collect" Name="Wooden Nickel" Subtype="349" Variant="100" />
-	<entity Group="Active Items" ID="5" Image="resources/Entities/Items/5.100.351 - Mega Bean.png" Kind="Collect" Name="Mega Bean" Subtype="351" Variant="100" />
-	<entity Group="Active Items" ID="5" Image="resources/Entities/Items/5.100.352 - Glass Cannon.png" Kind="Collect" Name="Glass Cannon" Subtype="352" Variant="100" />
-	<entity Group="Active Items" ID="5" Image="resources/Entities/Items/5.100.357 - Box of Friends.png" Kind="Collect" Name="Box of Friends" Subtype="357" Variant="100" />
-	<entity Group="Active Items" ID="5" Image="resources/Entities/Items/5.100.382 - Friendly Ball.png" Kind="Collect" Name="Friendly Ball" Subtype="382" Variant="100" />
-	<entity Group="Active Items" ID="5" Image="resources/Entities/Items/5.100.383 - Tear Detonator.png" Kind="Collect" Name="Tear Detonator" Subtype="383" Variant="100" />
-	<entity Group="Active Items" ID="5" Image="resources/Entities/Items/5.100.386 - D12.png" Kind="Collect" Name="D12" Subtype="386" Variant="100" />
-	<entity Group="Active Items" ID="5" Image="resources/Entities/Items/5.100.396 - Ventricle Razor.png" Kind="Collect" Name="Ventricle Razor" Subtype="396" Variant="100" />
-	<entity Group="Active Items" ID="5" Image="resources/Entities/Items/5.100.406 - D8.png" Kind="Collect" Name="D8" Subtype="406" Variant="100" />
-	<entity Group="Active Items" ID="5" Image="resources/Entities/Items/5.100.419 - Teleport 2.0.png" Kind="Collect" Name="Teleport 2.0" Subtype="419" Variant="100" />
-	<entity Group="Active Items" ID="5" Image="resources/Entities/Items/5.100.421 - Kidney Bean.png" Kind="Collect" Name="Kidney Bean" Subtype="421" Variant="100" />
-	<entity Group="Active Items" ID="5" Image="resources/Entities/Items/5.100.422 - Glowing Hour Glass.png" Kind="Collect" Name="Glowing Hour Glass" Subtype="422" Variant="100" />
-	<entity Group="Active Items" ID="5" Image="resources/Entities/Items/5.100.427 - Mine Crafter.png" Kind="Collect" Name="Mine Crafter" Subtype="427" Variant="100" />
-	<entity Group="Active Items" ID="5" Image="resources/Entities/Items/5.100.434 - Jar of Flies.png" Kind="Collect" Name="Jar of Flies" Subtype="434" Variant="100" />
-	<entity Group="Active Items" ID="5" Image="resources/Entities/Items/5.100.437 - D7.png" Kind="Collect" Name="D7" Subtype="437" Variant="100" />
-	<entity Group="Active Items" ID="5" Image="resources/Entities/Items/5.100.439 - Mom's Box.png" Kind="Collect" Name="Mom's Box" Subtype="439" Variant="100" />
-	<entity Group="Active Items" ID="5" Image="resources/Entities/Items/5.100.441 - Mega Blast.png" Kind="Collect" Name="Mega Blast" Subtype="441" Variant="100" />
-	<entity Group="Active Items" ID="5" Image="resources/Entities/Items/5.100.475 - Plan C.png" Kind="Collect" Name="Plan C" Subtype="475" Variant="100" />
-	<entity Group="Active Items" ID="5" Image="resources/Entities/Items/5.100.476 - D1.png" Kind="Collect" Name="D1" Subtype="476" Variant="100" />
-	<entity Group="Active Items" ID="5" Image="resources/Entities/Items/5.100.477 - Void.png" Kind="Collect" Name="Void" Subtype="477" Variant="100" />
-	<entity Group="Active Items" ID="5" Image="resources/Entities/Items/5.100.478 - Pause.png" Kind="Collect" Name="Pause" Subtype="478" Variant="100" />
-	<entity Group="Active Items" ID="5" Image="resources/Entities/Items/5.100.479 - Smelter.png" Kind="Collect" Name="Smelter" Subtype="479" Variant="100" />
-	<entity Group="Active Items" ID="5" Image="resources/Entities/Items/5.100.480 - Compost.png" Kind="Collect" Name="Compost" Subtype="480" Variant="100" />
-	<entity Group="Active Items" ID="5" Image="resources/Entities/Items/5.100.481 - Dataminer.png" Kind="Collect" Name="Dataminer" Subtype="481" Variant="100" />
-	<entity Group="Active Items" ID="5" Image="resources/Entities/Items/5.100.482 - Clicker.png" Kind="Collect" Name="Clicker" Subtype="482" Variant="100" />
-	<entity Group="Active Items" ID="5" Image="resources/Entities/Items/5.100.483 - MaMa Mega!.png" Kind="Collect" Name="MaMa Mega!" Subtype="483" Variant="100" />
-	<entity Group="Active Items" ID="5" Image="resources/Entities/Items/5.100.484 - Wait What.png" Kind="Collect" Name="Wait What?" Subtype="484" Variant="100" />
-	<entity Group="Active Items" ID="5" Image="resources/Entities/Items/5.100.485 - Crooked Penny.png" Kind="Collect" Name="Crooked Penny" Subtype="485" Variant="100" />
-	<entity Group="Active Items" ID="5" Image="resources/Entities/Items/5.100.486 - Dull Razor.png" Kind="Collect" Name="Dull Razor" Subtype="486" Variant="100" />
-	<entity Group="Active Items" ID="5" Image="resources/Entities/Items/5.100.487 - Potato Peeler.png" Kind="Collect" Name="Potato Peeler" Subtype="487" Variant="100" />
-	<entity Group="Active Items" ID="5" Image="resources/Entities/Items/5.100.488 - Metronome.png" Kind="Collect" Name="Metronome" Subtype="488" Variant="100" />
-	<entity Group="Active Items" ID="5" Image="resources/Entities/Items/5.100.489 - D infinity.png" Kind="Collect" Name="D infinity" Subtype="489" Variant="100" />
-	<entity Group="Active Items" ID="5" Image="resources/Entities/Items/5.100.490 - Eden's Soul.png" Kind="Collect" Name="Eden's Soul" Subtype="490" Variant="100" />
-	<entity Group="Active Items" ID="5" Image="resources/Entities/Items/5.100.504 - Brown Nugget.png" Kind="Collect" Name="Brown Nugget" Subtype="504" Variant="100" />
-	<entity Group="Active Items" ID="5" Image="resources/Entities/Items/5.100.507 - Sharp Straw.png" Kind="Collect" Name="Sharp Straw" Subtype="507" Variant="100" />
-	<entity Group="Active Items" ID="5" Image="resources/Entities/Items/5.100.510 - Delirious.png" Kind="Collect" Name="Delirious" Subtype="510" Variant="100" />
-	<entity Group="Active Items" ID="5" Image="resources/Entities/Items/5.100.512 - Black Hole.png" Kind="Collect" Name="Black Hole" Subtype="512" Variant="100" />
-	<entity Group="Active Items" ID="5" Image="resources/Entities/Items/5.100.515 - Mystery Gift.png" Kind="Collect" Name="Mystery Gift" Subtype="515" Variant="100" />
-	<entity Group="Active Items" ID="5" Image="resources/Entities/Items/5.100.516 - Sprinkler.png" Kind="Collect" Name="Sprinkler" Subtype="516" Variant="100" />
-	<entity Group="Active Items" ID="5" Image="resources/Entities/Items/5.100.521 - Coupon.png" Kind="Collect" Name="Coupon" Subtype="521" Variant="100" />
-	<entity Group="Active Items" ID="5" Image="resources/Entities/Items/5.100.522 - Telekinesis.png" Kind="Collect" Name="Telekinesis" Subtype="522" Variant="100" />
-	<entity Group="Active Items" ID="5" Image="resources/Entities/Items/5.100.523 - Moving Box.png" Kind="Collect" Name="Moving Box" Subtype="523" Variant="100" />
-	<entity Group="Active Items" ID="5" Image="resources/Entities/Items/5.100.527 - Mr. ME!.png" Kind="Collect" Name="Mr. ME!" Subtype="527" Variant="100" />
-	<entity Group="Active Items" ID="5" Image="resources/Entities/Items/5.100.534 - Schoolbag.png" Kind="Collect" Name="Schoolbag" Subtype="534" Variant="100" />
-	<entity Group="Active Items" ID="5" Image="resources/Entities/Items/5.100.536 - Sacrificial Altar.png" Kind="Collect" Name="Schoolbag" Subtype="536" Variant="100" />
-	<entity Group="Active Items" ID="5" Image="resources/Entities/Items/5.100.545 - Book of the Dead.png" Kind="Collect" Name="Book of the Dead" Subtype="545" Variant="100" />
-	<entity Group="Active Items" ID="5" Image="resources/Entities/Items/5.100.550 - Broken Shovel.png" Kind="Collect" Name="Broken Shovel" Subtype="550" Variant="100" />
-	<entity Group="Active Items" ID="5" Image="resources/Entities/Items/5.100.552 - Mom's Shovel.png" Kind="Collect" Name="Mom's Shovel" Subtype="552" Variant="100" />
-	<entity Group="Active Items" ID="5" Image="resources/Entities/Items/5.100.555 - Golden Razor.png" Kind="Collect" Name="Golden Razor" Subtype="555" Variant="100" />
-	<entity Group="Active Items" ID="5" Image="resources/Entities/Items/5.100.556 - Sulfur.png" Kind="Collect" Name="Sulfur" Subtype="556" Variant="100" />
-	<entity Group="Active Items" ID="5" Image="resources/Entities/Items/5.100.557 - Fortune Cookie.png" Kind="Collect" Name="Fortune Cookie" Subtype="557" Variant="100" />
-	<entity Group="Active Items" ID="5" Image="resources/Entities/Items/5.100.577 - Damocles.png" Kind="Collect" Name="Damocles" Subtype="577" Variant="100" />
-	<entity Group="Active Items" ID="5" Image="resources/Entities/Items/5.100.578 - Free Lemonade.png" Kind="Collect" Name="Free Lemonade" Subtype="578" Variant="100" />
-	<entity Group="Active Items" ID="5" Image="resources/Entities/Items/5.100.580 - Red Key.png" Kind="Collect" Name="Red Key" Subtype="580" Variant="100" />
-	<entity Group="Active Items" ID="5" Image="resources/Entities/Items/5.100.582 - Wavy Cap.png" Kind="Collect" Name="Wavy Cap" Subtype="582" Variant="100" />
-	<entity Group="Active Items" ID="5" Image="resources/Entities/Items/5.100.585 - Alabaster Box.png" Kind="Collect" Name="Alabaster Box" Subtype="585" Variant="100" />
-	<entity Group="Active Items" ID="5" Image="resources/Entities/Items/5.100.604 - Moms Bracelet.png" Kind="Collect" Name="Mom's Bracelet" Subtype="604" Variant="100" />
-	<entity Group="Active Items" ID="5" Image="resources/Entities/Items/5.100.605 - The Scooper.png" Kind="Collect" Name="The Scooper" Subtype="605" Variant="100" />
-	<entity Group="Active Items" ID="5" Image="resources/Entities/Items/5.100.609 - Florians D6.png" Kind="Collect" Name="Eternal D6" Subtype="609" Variant="100" />
-	<entity Group="Active Items" ID="5" Image="resources/Entities/Items/5.100.611 - Larynx.png" Kind="Collect" Name="Larynx" Subtype="611" Variant="100" />
-	<entity Group="Active Items" ID="5" Image="resources/Entities/Items/5.100.623 - Sharp Key.png" Kind="Collect" Name="Sharp Key" Subtype="623" Variant="100" />
-	<entity Group="Active Items" ID="5" Image="resources/Entities/Items/5.100.625 - Mega Mush.png" Kind="Collect" Name="Mega Mush" Subtype="625" Variant="100" />
-	<entity Group="Active Items" ID="5" Image="resources/Entities/Items/5.100.628 - Death Certificate.png" Kind="Collect" Name="Death Certificate" Subtype="628" Variant="100" />
-	<entity Group="Active Items" ID="5" Image="resources/Entities/Items/5.100.631 - Meat Cleaver.png" Kind="Collect" Name="Meat Cleaver" Subtype="631" Variant="100" />
-	<entity Group="Active Items" ID="5" Image="resources/Entities/Items/5.100.635 - Stitches.png" Kind="Collect" Name="Stitches" Subtype="635" Variant="100" />
-	<entity Group="Active Items" ID="5" Image="resources/Entities/Items/5.100.636 - R Key.png" Kind="Collect" Name="R Key" Subtype="636" Variant="100" />
-	<entity Group="Active Items" ID="5" Image="resources/Entities/Items/5.100.638 - Eraser.png" Kind="Collect" Name="Eraser" Subtype="638" Variant="100" />
-	<entity Group="Active Items" ID="5" Image="resources/Entities/Items/5.100.639 - Yuck Heart.png" Kind="Collect" Name="Yuck Heart" Subtype="639" Variant="100" />
-	<entity Group="Active Items" ID="5" Image="resources/Entities/Items/5.100.640 - Urn of Souls.png" Kind="Collect" Name="Urn of Souls" Subtype="640" Variant="100" />
-	<entity Group="Active Items" ID="5" Image="resources/Entities/Items/5.100.642 - Magic Skin.png" Kind="Collect" Name="Magic Skin" Subtype="642" Variant="100" />
-	<entity Group="Active Items" ID="5" Image="resources/Entities/Items/5.100.650 - Plum Flute.png" Kind="Collect" Name="Plum Flute" Subtype="650" Variant="100" />
-	<entity Group="Active Items" ID="5" Image="resources/Entities/Items/5.100.653 - Vade Retro.png" Kind="Collect" Name="Vade Retro" Subtype="653" Variant="100" />
-	<entity Group="Active Items" ID="5" Image="resources/Entities/Items/5.100.655 - Spin to Win.png" Kind="Collect" Name="Spin to Win" Subtype="655" Variant="100" />
-	<entity Group="Active Items" ID="5" Image="resources/Entities/Items/5.100.685 - Jar of Wisps.png" Kind="Collect" Name="Jar of Wisps" Subtype="685" Variant="100" />
-	<entity Group="Active Items" ID="5" Image="resources/Entities/Items/5.100.687 - Friend Finder.png" Kind="Collect" Name="Friend Finder" Subtype="687" Variant="100" />
-	<entity Group="Active Items" ID="5" Image="resources/Entities/Items/5.100.703 - Esau Jr.png" Kind="Collect" Name="Esau Jr" Subtype="703" Variant="100" />
-	<entity Group="Active Items" ID="5" Image="resources/Entities/Items/5.100.704 - Berserk.png" Kind="Collect" Name="Berserk!" Subtype="704" Variant="100" />
-	<entity Group="Active Items" ID="5" Image="resources/Entities/Items/5.100.705 - Dark Arts.png" Kind="Collect" Name="Dark Arts" Subtype="705" Variant="100" />
-	<entity Group="Active Items" ID="5" Image="resources/Entities/Items/5.100.706 - Abyss.png" Kind="Collect" Name="Abyss" Subtype="706" Variant="100" />
-	<entity Group="Active Items" ID="5" Image="resources/Entities/Items/5.100.709 - Suplex.png" Kind="Collect" Name="Suplex!" Subtype="709" Variant="100" />
-	<entity Group="Active Items" ID="5" Image="resources/Entities/Items/5.100.710 - Bag of Crafting.png" Kind="Collect" Name="Bag of Crafting" Subtype="710" Variant="100" />
-	<entity Group="Active Items" ID="5" Image="resources/Entities/Items/5.100.711 - Flip.png" Kind="Collect" Name="Flip" Subtype="711" Variant="100" />
-	<entity Group="Active Items" ID="5" Image="resources/Entities/Items/5.100.712 - Lemegeton.png" Kind="Collect" Name="Lemegeton" Subtype="712" Variant="100" />
-	<entity Group="Active Items" ID="5" Image="resources/Entities/Items/5.100.713 - Sumptorium.png" Kind="Collect" Name="Sumptorium" Subtype="713" Variant="100" />
-	<entity Group="Active Items" ID="5" Image="resources/Entities/Items/5.100.714 - Recall.png" Kind="Collect" Name="Recall" Subtype="714" Variant="100" />
-	<entity Group="Active Items" ID="5" Image="resources/Entities/Items/5.100.715 - Hold.png" Kind="Collect" Name="Hold" Subtype="715" Variant="100" />
-	<entity Group="Active Items" ID="5" Image="resources/Entities/Items/5.100.719 - Keepers Box.png" Kind="Collect" Name="Keeper's Box" Subtype="719" Variant="100" />
-	<entity Group="Active Items" ID="5" Image="resources/Entities/Items/5.100.720 - Everything Jar.png" Kind="Collect" Name="Everything Jar" Subtype="720" Variant="100" />
-	<entity Group="Active Items" ID="5" Image="resources/Entities/Items/5.100.722 - Anima Sola.png" Kind="Collect" Name="Anima Sola" Subtype="722" Variant="100" />
-	<entity Group="Active Items" ID="5" Image="resources/Entities/Items/5.100.723 - Spindown Dice.png" Kind="Collect" Name="Spindown Dice" Subtype="723" Variant="100" />
-	<entity Group="Active Items" ID="5" Image="resources/Entities/Items/5.100.728 - Gello.png" Kind="Collect" Name="Gello" Subtype="728" Variant="100" />
-	<entity Group="Active Items" ID="5" Image="resources/Entities/Items/5.100.729 - Decap Attack.png" Kind="Collect" Name="Decap Attack" Subtype="729" Variant="100" />
-	<!-- Familiars -->
-	<entity Group="Familiars" ID="5" Image="resources/Entities/Items/5.100.8 - Brother Bobby.png" Kind="Collect" Name="Brother Bobby" Subtype="8" Variant="100" />
-	<entity Group="Familiars" ID="5" Image="resources/Entities/Items/5.100.10 - Halo of Flies.png" Kind="Collect" Name="Halo of Flies" Subtype="10" Variant="100" />
-	<entity Group="Familiars" ID="5" Image="resources/Entities/Items/5.100.11 - 1up!.png" Kind="Collect" Name="1up!" Subtype="11" Variant="100" />
-	<entity Group="Familiars" ID="5" Image="resources/Entities/Items/5.100.57 - Distant Admiration.png" Kind="Collect" Name="Distant Admiration" Subtype="57" Variant="100" />
-	<entity Group="Familiars" ID="5" Image="resources/Entities/Items/5.100.67 - Sister Maggy.png" Kind="Collect" Name="Sister Maggy" Subtype="67" Variant="100" />
-	<entity Group="Familiars" ID="5" Image="resources/Entities/Items/5.100.73 - Cube of Meat.png" Kind="Collect" Name="Cube of Meat" Subtype="73" Variant="100" />
-	<entity Group="Familiars" ID="5" Image="resources/Entities/Items/5.100.81 - Dead Cat.png" Kind="Collect" Name="Dead Cat" Subtype="81" Variant="100" />
-	<entity Group="Familiars" ID="5" Image="resources/Entities/Items/5.100.88 - Little Chubby.png" Kind="Collect" Name="Little Chubby" Subtype="88" Variant="100" />
-	<entity Group="Familiars" ID="5" Image="resources/Entities/Items/5.100.94 - Sack of Pennies.png" Kind="Collect" Name="Sack of Pennies" Subtype="94" Variant="100" />
-	<entity Group="Familiars" ID="5" Image="resources/Entities/Items/5.100.95 - Robo-Baby.png" Kind="Collect" Name="Robo-Baby" Subtype="95" Variant="100" />
-	<entity Group="Familiars" ID="5" Image="resources/Entities/Items/5.100.96 - Little C.H.A.D..png" Kind="Collect" Name="Little C.H.A.D." Subtype="96" Variant="100" />
-	<entity Group="Familiars" ID="5" Image="resources/Entities/Items/5.100.98 - The Relic.png" Kind="Collect" Name="The Relic" Subtype="98" Variant="100" />
-	<entity Group="Familiars" ID="5" Image="resources/Entities/Items/5.100.99 - Little Gish.png" Kind="Collect" Name="Little Gish" Subtype="99" Variant="100" />
-	<entity Group="Familiars" ID="5" Image="resources/Entities/Items/5.100.100 - Little Steven.png" Kind="Collect" Name="Little Steven" Subtype="100" Variant="100" />
-	<entity Group="Familiars" ID="5" Image="resources/Entities/Items/5.100.112 - Guardian Angel.png" Kind="Collect" Name="Guardian Angel" Subtype="112" Variant="100" />
-	<entity Group="Familiars" ID="5" Image="resources/Entities/Items/5.100.113 - Demon Baby.png" Kind="Collect" Name="Demon Baby" Subtype="113" Variant="100" />
-	<entity Group="Familiars" ID="5" Image="resources/Entities/Items/5.100.128 - Forever alone.png" Kind="Collect" Name="Forever alone" Subtype="128" Variant="100" />
-	<entity Group="Familiars" ID="5" Image="resources/Entities/Items/5.100.131 - Bomb Bag.png" Kind="Collect" Name="Bomb Bag" Subtype="131" Variant="100" />
-	<entity Group="Familiars" ID="5" Image="resources/Entities/Items/5.100.144 - Bum Friend.png" Kind="Collect" Name="Bum Friend" Subtype="144" Variant="100" />
-	<entity Group="Familiars" ID="5" Image="resources/Entities/Items/5.100.155 - The Peeper.png" Kind="Collect" Name="The Peeper" Subtype="155" Variant="100" />
-	<entity Group="Familiars" ID="5" Image="resources/Entities/Items/5.100.163 - Ghost Baby.png" Kind="Collect" Name="Ghost Baby" Subtype="163" Variant="100" />
-	<entity Group="Familiars" ID="5" Image="resources/Entities/Items/5.100.167 - Harlequin Baby.png" Kind="Collect" Name="Harlequin Baby" Subtype="167" Variant="100" />
-	<entity Group="Familiars" ID="5" Image="resources/Entities/Items/5.100.170 - Daddy Longlegs.png" Kind="Collect" Name="Daddy Longlegs" Subtype="170" Variant="100" />
-	<entity Group="Familiars" ID="5" Image="resources/Entities/Items/5.100.172 - Sacrificial Dagger.png" Kind="Collect" Name="Sacrificial Dagger" Subtype="172" Variant="100" />
-	<entity Group="Familiars" ID="5" Image="resources/Entities/Items/5.100.174 - Rainbow Baby.png" Kind="Collect" Name="Rainbow Baby" Subtype="174" Variant="100" />
-	<entity Group="Familiars" ID="5" Image="resources/Entities/Items/5.100.178 - Holy Water.png" Kind="Collect" Name="Holy Water" Subtype="178" Variant="100" />
-	<entity Group="Familiars" ID="5" Image="resources/Entities/Items/5.100.187 - Guppy's Hairball.png" Kind="Collect" Name="Guppy's Hairball" Subtype="187" Variant="100" />
-	<entity Group="Familiars" ID="5" Image="resources/Entities/Items/5.100.188 - Abel.png" Kind="Collect" Name="Abel" Subtype="188" Variant="100" />
-	<entity Group="Familiars" ID="5" Image="resources/Entities/Items/5.100.206 - Guillotine.png" Kind="Collect" Name="Guillotine" Subtype="206" Variant="100" />
-	<entity Group="Familiars" ID="5" Image="resources/Entities/Items/5.100.207 - Ball of Bandages.png" Kind="Collect" Name="Ball of Bandages" Subtype="207" Variant="100" />
-	<entity Group="Familiars" ID="5" Image="resources/Entities/Items/5.100.238 - Key Piece 1.png" Kind="Collect" Name="Key Piece 1" Subtype="238" Variant="100" />
-	<entity Group="Familiars" ID="5" Image="resources/Entities/Items/5.100.239 - Key Piece 2.png" Kind="Collect" Name="Key Piece 2" Subtype="239" Variant="100" />
-	<entity Group="Familiars" ID="5" Image="resources/Entities/Items/5.100.264 - Smart Fly.png" Kind="Collect" Name="Smart Fly" Subtype="264" Variant="100" />
-	<entity Group="Familiars" ID="5" Image="resources/Entities/Items/5.100.265 - Dry Baby.png" Kind="Collect" Name="Dry Baby" Subtype="265" Variant="100" />
-	<entity Group="Familiars" ID="5" Image="resources/Entities/Items/5.100.266 - Juicy Sack.png" Kind="Collect" Name="Juicy Sack" Subtype="266" Variant="100" />
-	<entity Group="Familiars" ID="5" Image="resources/Entities/Items/5.100.267 - Robo-Baby 2.0.png" Kind="Collect" Name="Robo-Baby 2.0" Subtype="267" Variant="100" />
-	<entity Group="Familiars" ID="5" Image="resources/Entities/Items/5.100.268 - Rotten Baby.png" Kind="Collect" Name="Rotten Baby" Subtype="268" Variant="100" />
-	<entity Group="Familiars" ID="5" Image="resources/Entities/Items/5.100.269 - Headless Baby.png" Kind="Collect" Name="Headless Baby" Subtype="269" Variant="100" />
-	<entity Group="Familiars" ID="5" Image="resources/Entities/Items/5.100.270 - Leech.png" Kind="Collect" Name="Leech" Subtype="270" Variant="100" />
-	<entity Group="Familiars" ID="5" Image="resources/Entities/Items/5.100.271 - Mystery Sack.png" Kind="Collect" Name="Mystery Sack" Subtype="271" Variant="100" />
-	<entity Group="Familiars" ID="5" Image="resources/Entities/Items/5.100.272 - BBF.png" Kind="Collect" Name="BBF" Subtype="272" Variant="100" />
-	<entity Group="Familiars" ID="5" Image="resources/Entities/Items/5.100.273 - Bob's Brain.png" Kind="Collect" Name="Bob's Brain" Subtype="273" Variant="100" />
-	<entity Group="Familiars" ID="5" Image="resources/Entities/Items/5.100.274 - Best Bud.png" Kind="Collect" Name="Best Bud" Subtype="274" Variant="100" />
-	<entity Group="Familiars" ID="5" Image="resources/Entities/Items/5.100.275 - Lil' Brimstone.png" Kind="Collect" Name="Lil' Brimstone" Subtype="275" Variant="100" />
-	<entity Group="Familiars" ID="5" Image="resources/Entities/Items/5.100.276 - Isaac's Heart.png" Kind="Collect" Name="Isaac's Heart" Subtype="276" Variant="100" />
-	<entity Group="Familiars" ID="5" Image="resources/Entities/Items/5.100.277 - Lil' Haunt.png" Kind="Collect" Name="Lil' Haunt" Subtype="277" Variant="100" />
-	<entity Group="Familiars" ID="5" Image="resources/Entities/Items/5.100.278 - Dark Bum.png" Kind="Collect" Name="Dark Bum" Subtype="278" Variant="100" />
-	<entity Group="Familiars" ID="5" Image="resources/Entities/Items/5.100.279 - Big Fan.png" Kind="Collect" Name="Big Fan" Subtype="279" Variant="100" />
-	<entity Group="Familiars" ID="5" Image="resources/Entities/Items/5.100.280 - Sissy Longlegs.png" Kind="Collect" Name="Sissy Longlegs" Subtype="280" Variant="100" />
-	<entity Group="Familiars" ID="5" Image="resources/Entities/Items/5.100.281 - Punching Bag.png" Kind="Collect" Name="Punching Bag" Subtype="281" Variant="100" />
-	<entity Group="Familiars" ID="5" Image="resources/Entities/Items/5.100.318 - Gemini.png" Kind="Collect" Name="Gemini" Subtype="318" Variant="100" />
-	<entity Group="Familiars" ID="5" Image="resources/Entities/Items/5.100.319 - Cain's Other Eye.png" Kind="Collect" Name="Cain's Other Eye" Subtype="319" Variant="100" />
-	<entity Group="Familiars" ID="5" Image="resources/Entities/Items/5.100.320 - Blue Baby's Only Friend.png" Kind="Collect" Name="???'s Only Friend" Subtype="320" Variant="100" />
-	<entity Group="Familiars" ID="5" Image="resources/Entities/Items/5.100.321 - Samson's Chains.png" Kind="Collect" Name="Samson's Chains" Subtype="321" Variant="100" />
-	<entity Group="Familiars" ID="5" Image="resources/Entities/Items/5.100.322 - Mongo Baby.png" Kind="Collect" Name="Mongo Baby" Subtype="322" Variant="100" />
-	<entity Group="Familiars" ID="5" Image="resources/Entities/Items/5.100.360 - Incubus.png" Kind="Collect" Name="Incubus" Subtype="360" Variant="100" />
-	<entity Group="Familiars" ID="5" Image="resources/Entities/Items/5.100.361 - Fate's reward.png" Kind="Collect" Name="Fate's reward" Subtype="361" Variant="100" />
-	<entity Group="Familiars" ID="5" Image="resources/Entities/Items/5.100.362 - Lil Chest.png" Kind="Collect" Name="Lil Chest" Subtype="362" Variant="100" />
-	<entity Group="Familiars" ID="5" Image="resources/Entities/Items/5.100.363 - Sworn Protector.png" Kind="Collect" Name="Sworn Protector" Subtype="363" Variant="100" />
-	<entity Group="Familiars" ID="5" Image="resources/Entities/Items/5.100.364 - Friend Zone.png" Kind="Collect" Name="Friend Zone" Subtype="364" Variant="100" />
-	<entity Group="Familiars" ID="5" Image="resources/Entities/Items/5.100.365 - Lost Fly.png" Kind="Collect" Name="Lost Fly" Subtype="365" Variant="100" />
-	<entity Group="Familiars" ID="5" Image="resources/Entities/Items/5.100.372 - Charged Baby.png" Kind="Collect" Name="Charged Baby" Subtype="372" Variant="100" />
-	<entity Group="Familiars" ID="5" Image="resources/Entities/Items/5.100.384 - Lil Gurdy.png" Kind="Collect" Name="Lil Gurdy" Subtype="384" Variant="100" />
-	<entity Group="Familiars" ID="5" Image="resources/Entities/Items/5.100.385 - Bumbo.png" Kind="Collect" Name="Bumbo" Subtype="385" Variant="100" />
-	<entity Group="Familiars" ID="5" Image="resources/Entities/Items/5.100.387 - Censer.png" Kind="Collect" Name="Censer" Subtype="387" Variant="100" />
-	<entity Group="Familiars" ID="5" Image="resources/Entities/Items/5.100.388 - Key Bum.png" Kind="Collect" Name="Key Bum" Subtype="388" Variant="100" />
-	<entity Group="Familiars" ID="5" Image="resources/Entities/Items/5.100.389 - Rune Bag.png" Kind="Collect" Name="Rune Bag" Subtype="389" Variant="100" />
-	<entity Group="Familiars" ID="5" Image="resources/Entities/Items/5.100.390 - Seraphim.png" Kind="Collect" Name="Seraphim" Subtype="390" Variant="100" />
-	<entity Group="Familiars" ID="5" Image="resources/Entities/Items/5.100.403 - Spider Mod.png" Kind="Collect" Name="Spider Mod" Subtype="403" Variant="100" />
-	<entity Group="Familiars" ID="5" Image="resources/Entities/Items/5.100.404 - Farting Baby.png" Kind="Collect" Name="Farting Baby" Subtype="404" Variant="100" />
-	<entity Group="Familiars" ID="5" Image="resources/Entities/Items/5.100.405 - GB Bug.png" Kind="Collect" Name="GB Bug" Subtype="405" Variant="100" />
-	<entity Group="Familiars" ID="5" Image="resources/Entities/Items/5.100.417 - Succubus.png" Kind="Collect" Name="Succubus" Subtype="417" Variant="100" />
-	<entity Group="Familiars" ID="5" Image="resources/Entities/Items/5.100.426 - Obsessed Fan.png" Kind="Collect" Name="Obsessed Fan" Subtype="426" Variant="100" />
-	<entity Group="Familiars" ID="5" Image="resources/Entities/Items/5.100.430 - Papa Fly.png" Kind="Collect" Name="Papa Fly" Subtype="430" Variant="100" />
-	<entity Group="Familiars" ID="5" Image="resources/Entities/Items/5.100.431 - Multidimensional Baby.png" Kind="Collect" Name="Multidimensional Baby" Subtype="431" Variant="100" />
-	<entity Group="Familiars" ID="5" Image="resources/Entities/Items/5.100.435 - Lil Loki.png" Kind="Collect" Name="Lil Loki" Subtype="435" Variant="100" />
-	<entity Group="Familiars" ID="5" Image="resources/Entities/Items/5.100.436 - Milk!.png" Kind="Collect" Name="Milk!" Subtype="436" Variant="100" />
-	<entity Group="Familiars" ID="5" Image="resources/Entities/Items/5.100.467 - Finger!.png" Kind="Collect" Name="Finger!" Subtype="467" Variant="100" />
-	<entity Group="Familiars" ID="5" Image="resources/Entities/Items/5.100.468 - Shade.png" Kind="Collect" Name="Shade" Subtype="468" Variant="100" />
-	<entity Group="Familiars" ID="5" Image="resources/Entities/Items/5.100.469 - Depression.png" Kind="Collect" Name="Depression" Subtype="469" Variant="100" />
-	<entity Group="Familiars" ID="5" Image="resources/Entities/Items/5.100.470 - Hushy.png" Kind="Collect" Name="Hushy" Subtype="470" Variant="100" />
-	<entity Group="Familiars" ID="5" Image="resources/Entities/Items/5.100.471 - Lil Monstro.png" Kind="Collect" Name="Lil Monstro" Subtype="471" Variant="100" />
-	<entity Group="Familiars" ID="5" Image="resources/Entities/Items/5.100.472 - King Baby.png" Kind="Collect" Name="King Baby" Subtype="472" Variant="100" />
-	<entity Group="Familiars" ID="5" Image="resources/Entities/Items/5.100.473 - Big Chubby.png" Kind="Collect" Name="Big Chubby" Subtype="473" Variant="100" />
-	<entity Group="Familiars" ID="5" Image="resources/Entities/Items/5.100.474 - Tonsil.png" Kind="Collect" Name="Tonsil" Subtype="474" Variant="100" />
-	<entity Group="Familiars" ID="5" Image="resources/Entities/Items/5.100.491 - Acid Baby.png" Kind="Collect" Name="Acid Baby" Subtype="491" Variant="100" />
-	<entity Group="Familiars" ID="5" Image="resources/Entities/Items/5.100.492 - YO LISTEN!.png" Kind="Collect" Name="YO LISTEN!" Subtype="492" Variant="100" />
-	<entity Group="Familiars" ID="5" Image="resources/Entities/Items/5.100.500 - Sack of Sacks.png" Kind="Collect" Name="Sack of Sacks" Subtype="500" Variant="100" />
-	<entity Group="Familiars" ID="5" Image="resources/Entities/Items/5.100.508 - Mom's Razor.png" Kind="Collect" Name="Mom's Razor" Subtype="508" Variant="100" />
-	<entity Group="Familiars" ID="5" Image="resources/Entities/Items/5.100.509 - Bloodshot Eye.png" Kind="Collect" Name="Bloodshot Eye" Subtype="509" Variant="100" />
-	<entity Group="Familiars" ID="5" Image="resources/Entities/Items/5.100.511 - Angry Fly.png" Kind="Collect" Name="Angry Fly" Subtype="511" Variant="100" />
-	<entity Group="Familiars" ID="5" Image="resources/Entities/Items/5.100.518 - Buddy in a Box.png" Kind="Collect" Name="Buddy in a Box" Subtype="518" Variant="100" />
-	<entity Group="Familiars" ID="5" Image="resources/Entities/Items/5.100.519 - Lil Delirium.png" Kind="Collect" Name="Lil Delirium" Subtype="519" Variant="100" />
-	<entity Group="Familiars" ID="5" Image="resources/Entities/Items/5.100.526 - 7 Seals.png" Kind="Collect" Name="7 Seals" Subtype="526" Variant="100" />
-	<entity Group="Familiars" ID="5" Image="resources/Entities/Items/5.100.528 - Angelic Prism.png" Kind="Collect" Name="Angelic Prism" Subtype="528" Variant="100" />
-	<entity Group="Familiars" ID="5" Image="resources/Entities/Items/5.100.537 - Lil Spewer.png" Kind="Collect" Name="Lil Spewer" Subtype="537" Variant="100" />
-	<entity Group="Familiars" ID="5" Image="resources/Entities/Items/5.100.539 - Mystery Egg.png" Kind="Collect" Name="Mystery Egg" Subtype="539" Variant="100" />
-	<entity Group="Familiars" ID="5" Image="resources/Entities/Items/5.100.542 - Slipped Rib.png" Kind="Collect" Name="Slipped Rib" Subtype="542" Variant="100" />
-	<entity Group="Familiars" ID="5" Image="resources/Entities/Items/5.100.543 - Hallowed Ground.png" Kind="Collect" Name="Hallowed Ground" Subtype="543" Variant="100" />
-	<entity Group="Familiars" ID="5" Image="resources/Entities/Items/5.100.544 - Pointy Rib.png" Kind="Collect" Name="Pointy Rib" Subtype="544" Variant="100" />
-	<entity Group="Familiars" ID="5" Image="resources/Entities/Items/5.100.548 - Jaw Bone.png" Kind="Collect" Name="Jaw Bone" Subtype="548" Variant="100" />
-	<entity Group="Familiars" ID="5" Image="resources/Entities/Items/5.100.565 - Blood Puppy.png" Kind="Collect" Name="Blood Puppy" Subtype="565" Variant="100" />
-	<entity Group="Familiars" ID="5" Image="resources/Entities/Items/5.100.607 - Boiled Baby.png" Kind="Collect" Name="Boiled Baby" Subtype="607" Variant="100" />
-	<entity Group="Familiars" ID="5" Image="resources/Entities/Items/5.100.608 - Freezer Baby.png" Kind="Collect" Name="Freezer Baby" Subtype="608" Variant="100" />
-	<entity Group="Familiars" ID="5" Image="resources/Entities/Items/5.100.610 - Bird Cage.png" Kind="Collect" Name="Bird Cage" Subtype="610" Variant="100" />
-	<entity Group="Familiars" ID="5" Image="resources/Entities/Items/5.100.612 - Lost Soul.png" Kind="Collect" Name="Lost Soul" Subtype="612" Variant="100" />
-	<entity Group="Familiars" ID="5" Image="resources/Entities/Items/5.100.615 - Lil Dumpy.png" Kind="Collect" Name="Lil Dumpy" Subtype="615" Variant="100" />
-	<entity Group="Familiars" ID="5" Image="resources/Entities/Items/5.100.626 - Knife Piece 1.png" Kind="Collect" Name="Knife Piece 1" Subtype="626" Variant="100" />
-	<entity Group="Familiars" ID="5" Image="resources/Entities/Items/5.100.627 - Knife Piece 2.png" Kind="Collect" Name="Knife Piece 2" Subtype="627" Variant="100" />
-	<entity Group="Familiars" ID="5" Image="resources/Entities/Items/5.100.629 - Bot FLy.png" Kind="Collect" Name="Bot FLy" Subtype="629" Variant="100" />
-	<entity Group="Familiars" ID="5" Image="resources/Entities/Items/5.100.645 - Tinytoma.png" Kind="Collect" Name="Tinytoma" Subtype="645" Variant="100" />
-	<entity Group="Familiars" ID="5" Image="resources/Entities/Items/5.100.649 - Fruity Plum.png" Kind="Collect" Name="Fruity Plum" Subtype="649" Variant="100" />
-	<entity Group="Familiars" ID="5" Image="resources/Entities/Items/5.100.651 - Star of Bethlehem.png" Kind="Collect" Name="Star of Bethlehem" Subtype="651" Variant="100" />
-	<entity Group="Familiars" ID="5" Image="resources/Entities/Items/5.100.652 - Cube Baby.png" Kind="Collect" Name="Cube Baby" Subtype="652" Variant="100" />
-	<entity Group="Familiars" ID="5" Image="resources/Entities/Items/5.100.667 - Strawman.png" Kind="Collect" Name="Strawman" Subtype="667" Variant="100" />
-	<entity Group="Familiars" ID="5" Image="resources/Entities/Items/5.100.679 - Lil Abaddon.png" Kind="Collect" Name="Lil Abaddon" Subtype="679" Variant="100" />
-	<entity Group="Familiars" ID="5" Image="resources/Entities/Items/5.100.681 - Lil Portal.png" Kind="Collect" Name="Lil Portal" Subtype="681" Variant="100" />
-	<entity Group="Familiars" ID="5" Image="resources/Entities/Items/5.100.682 - Worm Friend.png" Kind="Collect" Name="Worm Friend" Subtype="682" Variant="100" />
-	<entity Group="Familiars" ID="5" Image="resources/Entities/Items/5.100.697 - Vanishing Twin.png" Kind="Collect" Name="Vanishing Twin" Subtype="697" Variant="100" />
-	<entity Group="Familiars" ID="5" Image="resources/Entities/Items/5.100.698 - Twisted Pair.png" Kind="Collect" Name="Twisted Pair" Subtype="698" Variant="100" />
-	<!-- Passive Items -->
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.1 - The Sad Onion.png" Kind="Collect" Name="The Sad Onion" Subtype="1" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.2 - The Inner Eye.png" Kind="Collect" Name="The Inner Eye" Subtype="2" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.3 - Spoon Bender.png" Kind="Collect" Name="Spoon Bender" Subtype="3" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.4 - Cricket's Head.png" Kind="Collect" Name="Cricket's Head" Subtype="4" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.5 - My Reflection.png" Kind="Collect" Name="My Reflection" Subtype="5" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.6 - Number One.png" Kind="Collect" Name="Number One" Subtype="6" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.7 - Blood of the Martyr.png" Kind="Collect" Name="Blood of the Martyr" Subtype="7" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.9 - Skatole.png" Kind="Collect" Name="Skatole" Subtype="9" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.12 - Magic Mushroom.png" Kind="Collect" Name="Magic Mushroom" Subtype="12" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.13 - The Virus.png" Kind="Collect" Name="The Virus" Subtype="13" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.14 - Roid Rage.png" Kind="Collect" Name="Roid Rage" Subtype="14" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.15 - Heart.png" Kind="Collect" Name="&lt;3" Subtype="15" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.16 - Raw Liver.png" Kind="Collect" Name="Raw Liver" Subtype="16" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.17 - Skeleton Key.png" Kind="Collect" Name="Skeleton Key" Subtype="17" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.18 - A Dollar.png" Kind="Collect" Name="A Dollar" Subtype="18" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.19 - Boom!.png" Kind="Collect" Name="Boom!" Subtype="19" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.20 - Transcendence.png" Kind="Collect" Name="Transcendence" Subtype="20" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.21 - The Compass.png" Kind="Collect" Name="The Compass" Subtype="21" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.22 - Lunch.png" Kind="Collect" Name="Lunch" Subtype="22" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.23 - Dinner.png" Kind="Collect" Name="Dinner" Subtype="23" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.24 - Dessert.png" Kind="Collect" Name="Dessert" Subtype="24" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.25 - Breakfast.png" Kind="Collect" Name="Breakfast" Subtype="25" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.26 - Rotten Meat.png" Kind="Collect" Name="Rotten Meat" Subtype="26" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.27 - Wooden Spoon.png" Kind="Collect" Name="Wooden Spoon" Subtype="27" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.28 - The Belt.png" Kind="Collect" Name="The Belt" Subtype="28" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.29 - Mom's Underwear.png" Kind="Collect" Name="Mom's Underwear" Subtype="29" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.30 - Mom's Heels.png" Kind="Collect" Name="Mom's Heels" Subtype="30" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.31 - Mom's Lipstick.png" Kind="Collect" Name="Mom's Lipstick" Subtype="31" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.32 - Wire Coat Hanger.png" Kind="Collect" Name="Wire Coat Hanger" Subtype="32" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.46 - Lucky Foot.png" Kind="Collect" Name="Lucky Foot" Subtype="46" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.48 - Cupid's Arrow.png" Kind="Collect" Name="Cupid's Arrow" Subtype="48" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.50 - Steven.png" Kind="Collect" Name="Steven" Subtype="50" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.51 - Pentagram.png" Kind="Collect" Name="Pentagram" Subtype="51" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.52 - Dr. Fetus.png" Kind="Collect" Name="Dr. Fetus" Subtype="52" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.53 - Magneto.png" Kind="Collect" Name="Magneto" Subtype="53" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.54 - Treasure Map.png" Kind="Collect" Name="Treasure Map" Subtype="54" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.55 - Mom's Eye.png" Kind="Collect" Name="Mom's Eye" Subtype="55" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.60 - The Ladder.png" Kind="Collect" Name="The Ladder" Subtype="60" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.62 - Charm of the Vampire.png" Kind="Collect" Name="Charm of the Vampire" Subtype="62" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.63 - The Battery.png" Kind="Collect" Name="The Battery" Subtype="63" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.64 - Steam Sale.png" Kind="Collect" Name="Steam Sale" Subtype="64" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.68 - Technology.png" Kind="Collect" Name="Technology" Subtype="68" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.69 - Chocolate Milk.png" Kind="Collect" Name="Chocolate Milk" Subtype="69" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.70 - Growth Hormones.png" Kind="Collect" Name="Growth Hormones" Subtype="70" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.71 - Mini Mush.png" Kind="Collect" Name="Mini Mush" Subtype="71" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.72 - Rosary.png" Kind="Collect" Name="Rosary" Subtype="72" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.74 - A Quarter.png" Kind="Collect" Name="A Quarter" Subtype="74" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.75 - PHD.png" Kind="Collect" Name="PHD" Subtype="75" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.76 - X-Ray Vision.png" Kind="Collect" Name="X-Ray Vision" Subtype="76" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.79 - The Mark.png" Kind="Collect" Name="The Mark" Subtype="79" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.80 - The Pact.png" Kind="Collect" Name="The Pact" Subtype="80" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.82 - Lord of the Pit.png" Kind="Collect" Name="Lord of the Pit" Subtype="82" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.87 - Loki's Horns.png" Kind="Collect" Name="Loki's Horns" Subtype="87" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.89 - Spider Bite.png" Kind="Collect" Name="Spider Bite" Subtype="89" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.90 - The Small Rock.png" Kind="Collect" Name="The Small Rock" Subtype="90" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.91 - Spelunker Hat.png" Kind="Collect" Name="Spelunker Hat" Subtype="91" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.92 - Super Bandage.png" Kind="Collect" Name="Super Bandage" Subtype="92" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.101 - The Halo.png" Kind="Collect" Name="The Halo" Subtype="101" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.103 - The Common Cold.png" Kind="Collect" Name="The Common Cold" Subtype="103" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.104 - The Parasite.png" Kind="Collect" Name="The Parasite" Subtype="104" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.106 - Mr. Mega.png" Kind="Collect" Name="Mr. Mega" Subtype="106" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.108 - The Wafer.png" Kind="Collect" Name="The Wafer" Subtype="108" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.109 - Money = Power.png" Kind="Collect" Name="Money = Power" Subtype="109" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.110 - Mom's Contacts.png" Kind="Collect" Name="Mom's Contacts" Subtype="110" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.114 - Mom's Knife.png" Kind="Collect" Name="Mom's Knife" Subtype="114" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.115 - Ouija Board.png" Kind="Collect" Name="Ouija Board" Subtype="115" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.116 - 9 Volt.png" Kind="Collect" Name="9 Volt" Subtype="116" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.117 - Dead Bird.png" Kind="Collect" Name="Dead Bird" Subtype="117" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.118 - Brimstone.png" Kind="Collect" Name="Brimstone" Subtype="118" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.119 - Blood Bag.png" Kind="Collect" Name="Blood Bag" Subtype="119" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.120 - Odd Mushroom.png" Kind="Collect" Name="Odd Mushroom" Subtype="120" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.121 - Odd Mushroom.png" Kind="Collect" Name="Odd Mushroom" Subtype="121" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.122 - Whore of Babylon.png" Kind="Collect" Name="Whore of Babylon" Subtype="122" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.125 - Bobby-Bomb.png" Kind="Collect" Name="Bobby-Bomb" Subtype="125" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.129 - Bucket of Lard.png" Kind="Collect" Name="Bucket of Lard" Subtype="129" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.132 - A Lump of Coal.png" Kind="Collect" Name="A Lump of Coal" Subtype="132" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.134 - Guppy's Tail.png" Kind="Collect" Name="Guppy's Tail" Subtype="134" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.138 - Stigmata.png" Kind="Collect" Name="Stigmata" Subtype="138" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.139 - Mom's Purse.png" Kind="Collect" Name="Mom's Purse" Subtype="139" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.140 - Bobs Curse.png" Kind="Collect" Name="Bob's Curse" Subtype="140" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.141 - Pageant Boy.png" Kind="Collect" Name="Pageant Boy" Subtype="141" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.142 - Scapular.png" Kind="Collect" Name="Scapular" Subtype="142" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.143 - Speed Ball.png" Kind="Collect" Name="Speed Ball" Subtype="143" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.148 - Infestation.png" Kind="Collect" Name="Infestation" Subtype="148" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.149 - Ipecac.png" Kind="Collect" Name="Ipecac" Subtype="149" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.150 - Tough Love.png" Kind="Collect" Name="Tough Love" Subtype="150" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.151 - The Mulligan.png" Kind="Collect" Name="The Mulligan" Subtype="151" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.152 - Technology 2.png" Kind="Collect" Name="Technology 2" Subtype="152" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.153 - Mutant Spider.png" Kind="Collect" Name="Mutant Spider" Subtype="153" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.154 - Chemical Peel.png" Kind="Collect" Name="Chemical Peel" Subtype="154" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.156 - Habit.png" Kind="Collect" Name="Habit" Subtype="156" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.157 - Bloody Lust.png" Kind="Collect" Name="Bloody Lust" Subtype="157" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.159 - Spirit of the Night.png" Kind="Collect" Name="Spirit of the Night" Subtype="159" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.161 - Ankh.png" Kind="Collect" Name="Ankh" Subtype="161" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.162 - Celtic Cross.png" Kind="Collect" Name="Celtic Cross" Subtype="162" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.165 - Cat-o-nine-tails.png" Kind="Collect" Name="Cat-o-nine-tails" Subtype="165" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.168 - Epic Fetus.png" Kind="Collect" Name="Epic Fetus" Subtype="168" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.169 - Polyphemus.png" Kind="Collect" Name="Polyphemus" Subtype="169" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.173 - Mitre.png" Kind="Collect" Name="Mitre" Subtype="173" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.176 - Stem Cells.png" Kind="Collect" Name="Stem Cells" Subtype="176" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.179 - Fate.png" Kind="Collect" Name="Fate" Subtype="179" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.180 - The Black Bean.png" Kind="Collect" Name="The Black Bean" Subtype="180" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.182 - Sacred Heart.png" Kind="Collect" Name="Sacred Heart" Subtype="182" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.183 - Tooth Picks.png" Kind="Collect" Name="Tooth Picks" Subtype="183" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.184 - Holy Grail.png" Kind="Collect" Name="Holy Grail" Subtype="184" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.185 - Dead Dove.png" Kind="Collect" Name="Dead Dove" Subtype="185" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.189 - SMB Super Fan.png" Kind="Collect" Name="SMB Super Fan" Subtype="189" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.190 - Pyro.png" Kind="Collect" Name="Pyro" Subtype="190" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.191 - 3 Dollar Bill.png" Kind="Collect" Name="3 Dollar Bill" Subtype="191" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.193 - MEAT!.png" Kind="Collect" Name="MEAT!" Subtype="193" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.194 - Magic 8 Ball.png" Kind="Collect" Name="Magic 8 Ball" Subtype="194" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.195 - Mom's Coin Purse.png" Kind="Collect" Name="Mom's Coin Purse" Subtype="195" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.196 - Squeezy.png" Kind="Collect" Name="Squeezy" Subtype="196" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.197 - Jesus Juice.png" Kind="Collect" Name="Jesus Juice" Subtype="197" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.198 - Box.png" Kind="Collect" Name="Box" Subtype="198" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.199 - Mom's Key.png" Kind="Collect" Name="Mom's Key" Subtype="199" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.200 - Mom's Eyeshadow.png" Kind="Collect" Name="Mom's Eyeshadow" Subtype="200" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.201 - Iron Bar.png" Kind="Collect" Name="Iron Bar" Subtype="201" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.202 - Midas' Touch.png" Kind="Collect" Name="Midas' Touch" Subtype="202" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.203 - Humbleing Bundle.png" Kind="Collect" Name="Humbleing Bundle" Subtype="203" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.204 - Fanny Pack.png" Kind="Collect" Name="Fanny Pack" Subtype="204" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.205 - Sharp Plug.png" Kind="Collect" Name="Sharp Plug" Subtype="205" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.208 - Champion Belt.png" Kind="Collect" Name="Champion Belt" Subtype="208" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.209 - Butt Bombs.png" Kind="Collect" Name="Butt Bombs" Subtype="209" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.210 - Gnawed Leaf.png" Kind="Collect" Name="Gnawed Leaf" Subtype="210" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.211 - Spiderbaby.png" Kind="Collect" Name="Spiderbaby" Subtype="211" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.212 - Guppy's Collar.png" Kind="Collect" Name="Guppy's Collar" Subtype="212" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.213 - Lost Contact.png" Kind="Collect" Name="Lost Contact" Subtype="213" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.214 - Anemic.png" Kind="Collect" Name="Anemic" Subtype="214" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.215 - Goat Head.png" Kind="Collect" Name="Goat Head" Subtype="215" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.216 - Ceremonial Robes.png" Kind="Collect" Name="Ceremonial Robes" Subtype="216" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.217 - Mom's Wig.png" Kind="Collect" Name="Mom's Wig" Subtype="217" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.218 - Placenta.png" Kind="Collect" Name="Placenta" Subtype="218" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.219 - Old Bandage.png" Kind="Collect" Name="Old Bandage" Subtype="219" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.220 - Sad Bombs.png" Kind="Collect" Name="Sad Bombs" Subtype="220" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.221 - Rubber Cement.png" Kind="Collect" Name="Rubber Cement" Subtype="221" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.222 - Anti-Gravity.png" Kind="Collect" Name="Anti-Gravity" Subtype="222" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.223 - Pyromaniac.png" Kind="Collect" Name="Pyromaniac" Subtype="223" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.224 - Cricket's Body.png" Kind="Collect" Name="Cricket's Body" Subtype="224" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.225 - Gimpy.png" Kind="Collect" Name="Gimpy" Subtype="225" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.226 - Black Lotus.png" Kind="Collect" Name="Black Lotus" Subtype="226" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.227 - Piggy Bank.png" Kind="Collect" Name="Piggy Bank" Subtype="227" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.228 - Mom's Perfume.png" Kind="Collect" Name="Mom's Perfume" Subtype="228" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.229 - Monstro's Lung.png" Kind="Collect" Name="Monstro's Lung" Subtype="229" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.230 - Abaddon.png" Kind="Collect" Name="Abaddon" Subtype="230" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.231 - Ball of Tar.png" Kind="Collect" Name="Ball of Tar" Subtype="231" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.232 - Stop Watch.png" Kind="Collect" Name="Stop Watch" Subtype="232" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.233 - Tiny Planet.png" Kind="Collect" Name="Tiny Planet" Subtype="233" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.234 - Infestation 2.png" Kind="Collect" Name="Infestation 2" Subtype="234" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.236 - E. Coli.png" Kind="Collect" Name="E. Coli" Subtype="236" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.237 - Death's Touch.png" Kind="Collect" Name="Death's Touch" Subtype="237" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.240 - Experimental Treatment.png" Kind="Collect" Name="Experimental Treatment" Subtype="240" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.241 - Contract from Below.png" Kind="Collect" Name="Contract from Below" Subtype="241" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.242 - Infamy.png" Kind="Collect" Name="Infamy" Subtype="242" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.243 - Trinity Shield.png" Kind="Collect" Name="Trinity Shield" Subtype="243" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.244 - Tech.5.png" Kind="Collect" Name="Tech.5" Subtype="244" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.245 - 20-20.png" Kind="Collect" Name="20/20" Subtype="245" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.246 - Blue Map.png" Kind="Collect" Name="Blue Map" Subtype="246" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.247 - BFFS!.png" Kind="Collect" Name="BFFS!" Subtype="247" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.248 - Hive Mind.png" Kind="Collect" Name="Hive Mind" Subtype="248" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.249 - There's Options.png" Kind="Collect" Name="There's Options" Subtype="249" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.250 - BOGO Bombs.png" Kind="Collect" Name="BOGO Bombs" Subtype="250" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.251 - Starter Deck.png" Kind="Collect" Name="Starter Deck" Subtype="251" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.252 - Little Baggy.png" Kind="Collect" Name="Little Baggy" Subtype="252" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.253 - Magic Scab.png" Kind="Collect" Name="Magic Scab" Subtype="253" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.254 - Blood Clot.png" Kind="Collect" Name="Blood Clot" Subtype="254" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.255 - Screw.png" Kind="Collect" Name="Screw" Subtype="255" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.256 - Hot Bombs.png" Kind="Collect" Name="Hot Bombs" Subtype="256" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.257 - Fire Mind.png" Kind="Collect" Name="Fire Mind" Subtype="257" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.258 - Missing No..png" Kind="Collect" Name="Missing No." Subtype="258" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.259 - Dark Matter.png" Kind="Collect" Name="Dark Matter" Subtype="259" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.260 - Black Candle.png" Kind="Collect" Name="Black Candle" Subtype="260" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.261 - Proptosis.png" Kind="Collect" Name="Proptosis" Subtype="261" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.262 - Missing Page 2.png" Kind="Collect" Name="Missing Page 2" Subtype="262" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.299 - Taurus.png" Kind="Collect" Name="Taurus" Subtype="299" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.300 - Aries.png" Kind="Collect" Name="Aries" Subtype="300" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.301 - Cancer.png" Kind="Collect" Name="Cancer" Subtype="301" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.302 - Leo.png" Kind="Collect" Name="Leo" Subtype="302" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.303 - Virgo.png" Kind="Collect" Name="Virgo" Subtype="303" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.304 - Libra.png" Kind="Collect" Name="Libra" Subtype="304" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.305 - Scorpio.png" Kind="Collect" Name="Scorpio" Subtype="305" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.306 - Sagittarius.png" Kind="Collect" Name="Sagittarius" Subtype="306" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.307 - Capricorn.png" Kind="Collect" Name="Capricorn" Subtype="307" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.308 - Aquarius.png" Kind="Collect" Name="Aquarius" Subtype="308" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.309 - Pisces.png" Kind="Collect" Name="Pisces" Subtype="309" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.310 - Eve's Mascara.png" Kind="Collect" Name="Eve's Mascara" Subtype="310" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.311 - Judas' Shadow.png" Kind="Collect" Name="Judas' Shadow" Subtype="311" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.312 - Maggy's Bow.png" Kind="Collect" Name="Maggy's Bow" Subtype="312" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.313 - Holy Mantle.png" Kind="Collect" Name="Holy Mantle" Subtype="313" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.314 - Thunder Thighs.png" Kind="Collect" Name="Thunder Thighs" Subtype="314" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.315 - Strange Attractor.png" Kind="Collect" Name="Strange Attractor" Subtype="315" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.316 - Cursed Eye.png" Kind="Collect" Name="Cursed Eye" Subtype="316" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.317 - Mysterious Liquid.png" Kind="Collect" Name="Mysterious Liquid" Subtype="317" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.327 - The Polaroid.png" Kind="Collect" Name="The Polaroid" Subtype="327" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.328 - The Negative.png" Kind="Collect" Name="The Negative" Subtype="328" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.329 - The Ludovico Technique.png" Kind="Collect" Name="The Ludovico Technique" Subtype="329" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.330 - Soy Milk.png" Kind="Collect" Name="Soy Milk" Subtype="330" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.331 - Godhead.png" Kind="Collect" Name="Godhead" Subtype="331" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.332 - Lazarus' Rags.png" Kind="Collect" Name="Lazarus' Rags" Subtype="332" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.333 - The Mind.png" Kind="Collect" Name="The Mind" Subtype="333" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.334 - The Body.png" Kind="Collect" Name="The Body" Subtype="334" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.335 - The Soul.png" Kind="Collect" Name="The Soul" Subtype="335" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.336 - Dead Onion.png" Kind="Collect" Name="Dead Onion" Subtype="336" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.337 - Broken Watch.png" Kind="Collect" Name="Broken Watch" Subtype="337" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.339 - Safety Pin.png" Kind="Collect" Name="Safety Pin" Subtype="339" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.340 - Caffeine Pill.png" Kind="Collect" Name="Caffeine Pill" Subtype="340" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.341 - Torn Photo.png" Kind="Collect" Name="Torn Photo" Subtype="341" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.342 - Blue Cap.png" Kind="Collect" Name="Blue Cap" Subtype="342" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.343 - Latch Key.png" Kind="Collect" Name="Latch Key" Subtype="343" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.344 - Match Book.png" Kind="Collect" Name="Match Book" Subtype="344" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.345 - Synthoil.png" Kind="Collect" Name="Synthoil" Subtype="345" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.346 - A Snack.png" Kind="Collect" Name="A Snack" Subtype="346" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.350 - Toxic Shock.png" Kind="Collect" Name="Toxic Shock" Subtype="350" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.353 - Bomber Boy.png" Kind="Collect" Name="Bomber Boy" Subtype="353" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.354 - Crack Jacks.png" Kind="Collect" Name="Crack Jacks" Subtype="354" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.355 - Mom's Pearls.png" Kind="Collect" Name="Mom's Pearls" Subtype="355" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.356 - Car Battery.png" Kind="Collect" Name="Car Battery" Subtype="356" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.358 - The Wiz.png" Kind="Collect" Name="The Wiz" Subtype="358" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.359 - 8 Inch Nails.png" Kind="Collect" Name="8 Inch Nails" Subtype="359" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.366 - Scatter Bombs.png" Kind="Collect" Name="Scatter Bombs" Subtype="366" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.367 - Sticky Bombs.png" Kind="Collect" Name="Sticky Bombs" Subtype="367" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.368 - Epiphora.png" Kind="Collect" Name="Epiphora" Subtype="368" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.369 - Continuum.png" Kind="Collect" Name="Continuum" Subtype="369" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.370 - Mr. Dolly.png" Kind="Collect" Name="Mr. Dolly" Subtype="370" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.371 - Curse of the tower.png" Kind="Collect" Name="Curse of the tower" Subtype="371" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.373 - Dead Eye.png" Kind="Collect" Name="Dead Eye" Subtype="373" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.374 - Holy Light.png" Kind="Collect" Name="Holy Light" Subtype="374" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.375 - Host Hat.png" Kind="Collect" Name="Host Hat" Subtype="375" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.376 - Restock.png" Kind="Collect" Name="Restock" Subtype="376" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.377 - Bursting Sack.png" Kind="Collect" Name="Bursting Sack" Subtype="377" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.378 - No. 2.png" Kind="Collect" Name="No. 2" Subtype="378" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.379 - Pupula Duplex.png" Kind="Collect" Name="Pupula Duplex" Subtype="379" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.380 - Pay To Play.png" Kind="Collect" Name="Pay To Play" Subtype="380" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.381 - Eden's Blessing.png" Kind="Collect" Name="Eden's Blessing" Subtype="381" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.391 - Betrayal.png" Kind="Collect" Name="Betrayal" Subtype="391" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.392 - Zodiac.png" Kind="Collect" Name="Zodiac" Subtype="392" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.393 - Serpent's Kiss.png" Kind="Collect" Name="Serpent's Kiss" Subtype="393" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.394 - Marked.png" Kind="Collect" Name="Marked" Subtype="394" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.395 - Tech X.png" Kind="Collect" Name="Tech X" Subtype="395" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.397 - Tractor Beam.png" Kind="Collect" Name="Tractor Beam" Subtype="397" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.398 - God's Flesh.png" Kind="Collect" Name="God's Flesh" Subtype="398" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.399 - Maw Of The Void.png" Kind="Collect" Name="Maw Of The Void" Subtype="399" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.400 - Spear Of Destiny.png" Kind="Collect" Name="Spear Of Destiny" Subtype="400" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.401 - Explosivo.png" Kind="Collect" Name="Explosivo" Subtype="401" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.402 - Chaos.png" Kind="Collect" Name="Chaos" Subtype="402" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.407 - Purity.png" Kind="Collect" Name="Purity" Subtype="407" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.408 - Athame.png" Kind="Collect" Name="Athame" Subtype="408" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.409 - Empty Vessel.png" Kind="Collect" Name="Empty Vessel" Subtype="409" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.410 - Evil Eye.png" Kind="Collect" Name="Evil Eye" Subtype="410" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.411 - Lusty Blood.png" Kind="Collect" Name="Lusty Blood" Subtype="411" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.412 - Cambion Conception.png" Kind="Collect" Name="Cambion Conception" Subtype="412" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.413 - Immaculate Conception.png" Kind="Collect" Name="Immaculate Conception" Subtype="413" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.414 - More Options.png" Kind="Collect" Name="More Options" Subtype="414" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.415 - Crown Of Light.png" Kind="Collect" Name="Crown Of Light" Subtype="415" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.416 - Deep Pockets.png" Kind="Collect" Name="Deep Pockets" Subtype="416" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.418 - Fruit Cake.png" Kind="Collect" Name="Fruit Cake" Subtype="418" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.420 - Black Powder.png" Kind="Collect" Name="Black Powder" Subtype="420" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.423 - Circle of Protection.png" Kind="Collect" Name="Circle of Protection" Subtype="423" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.424 - Sack Head.png" Kind="Collect" Name="Sack Head" Subtype="424" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.425 - Night Light.png" Kind="Collect" Name="Night Light" Subtype="425" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.428 - PJs.png" Kind="Collect" Name="PJs" Subtype="428" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.429 - Head of the Keeper.png" Kind="Collect" Name="Head of the Keeper" Subtype="429" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.432 - Glitter Bombs.png" Kind="Collect" Name="Glitter Bombs" Subtype="432" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.433 - My Shadow.png" Kind="Collect" Name="My Shadow" Subtype="433" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.438 - Binky.png" Kind="Collect" Name="Binky" Subtype="438" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.440 - Kidney Stone.png" Kind="Collect" Name="Kidney Stone" Subtype="440" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.442 - Dark Princes Crown.png" Kind="Collect" Name="Dark Princes Crown" Subtype="442" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.443 - Apple!.png" Kind="Collect" Name="Apple!" Subtype="443" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.444 - Lead Pencil.png" Kind="Collect" Name="Lead Pencil" Subtype="444" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.445 - Dog Tooth.png" Kind="Collect" Name="Dog Tooth" Subtype="445" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.446 - Dead Tooth.png" Kind="Collect" Name="Dead Tooth" Subtype="446" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.447 - Linger Bean.png" Kind="Collect" Name="Linger Bean" Subtype="447" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.448 - Shard of Glass.png" Kind="Collect" Name="Shard of Glass" Subtype="448" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.449 - Metal Plate.png" Kind="Collect" Name="Metal Plate" Subtype="449" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.450 - Eye of Greed.png" Kind="Collect" Name="Eye of Greed" Subtype="450" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.451 - Tarot Cloth.png" Kind="Collect" Name="Tarot Cloth" Subtype="451" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.452 - Varicose Veins.png" Kind="Collect" Name="Varicose Veins" Subtype="452" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.453 - Compound Fracture.png" Kind="Collect" Name="Compound Fracture" Subtype="453" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.454 - Polydactyly.png" Kind="Collect" Name="Polydactyly" Subtype="454" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.455 - Dads Lost Coin.png" Kind="Collect" Name="Dad's Lost Coin" Subtype="455" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.456 - Moldy Bread.png" Kind="Collect" Name="Moldy Bread" Subtype="456" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.457 - Cone Head.png" Kind="Collect" Name="Cone Head" Subtype="457" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.458 - Belly Button.png" Kind="Collect" Name="Belly Button" Subtype="458" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.459 - Sinus Infection.png" Kind="Collect" Name="Sinus Infection" Subtype="459" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.460 - Glaucoma.png" Kind="Collect" Name="Glaucoma" Subtype="460" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.461 - Parasitoid.png" Kind="Collect" Name="Parasitoid" Subtype="461" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.462 - Eye of Belial.png" Kind="Collect" Name="Eye of Belial" Subtype="462" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.463 - Sulfuric Acid.png" Kind="Collect" Name="Sulfuric Acid" Subtype="463" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.464 - Glyph of Balance.png" Kind="Collect" Name="Glyph of Balance" Subtype="464" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.465 - Analog Stick.png" Kind="Collect" Name="Analog Stick" Subtype="465" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.466 - Contagion.png" Kind="Collect" Name="Contagion" Subtype="466" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.493 - Adderline.png" Kind="Collect" Name="Adderline" Subtype="493" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.494 - Jacob's Ladder.png" Kind="Collect" Name="Jacob's Ladder" Subtype="494" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.495 - Ghost Pepper.png" Kind="Collect" Name="Ghost Pepper" Subtype="495" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.496 - Euthanasia.png" Kind="Collect" Name="Euthanasia" Subtype="496" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.497 - Camo Undies.png" Kind="Collect" Name="Camo Undies" Subtype="497" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.498 - Duality.png" Kind="Collect" Name="Duality" Subtype="498" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.499 - Eucharist.png" Kind="Collect" Name="Eucharist" Subtype="499" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.501 - Greed's Gullet.png" Kind="Collect" Name="Greed's Gullet" Subtype="501" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.502 - Large Zit.png" Kind="Collect" Name="Large Zit" Subtype="502" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.503 - Little Horn.png" Kind="Collect" Name="Little Horn" Subtype="503" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.505 - Poke Go.png" Kind="Collect" Name="Poke Go" Subtype="505" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.506 - BackStabber.png" Kind="Collect" Name="BackStabber" Subtype="506" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.513 - Bozo.png" Kind="Collect" Name="Bozo" Subtype="513" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.514 - Broken Modem.png" Kind="Collect" Name="Broken Modem" Subtype="514" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.517 - Fast Bombs.png" Kind="Collect" Name="Fast Bombs" Subtype="517" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.520 - Jumper Cables.png" Kind="Collect" Name="Jumper Cables" Subtype="520" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.524 - Technology Zero.png" Kind="Collect" Name="Technology Zero" Subtype="524" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.525 - Leprosy.png" Kind="Collect" Name="Leprosy" Subtype="525" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.529 - Pop!.png" Kind="Collect" Name="Pop!" Subtype="529" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.530 - Death's List.png" Kind="Collect" Name="Death's List" Subtype="530" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.531 - Haemolacria.png" Kind="Collect" Name="Haemolacria" Subtype="531" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.532 - Lachryphagy.png" Kind="Collect" Name="Lachryphagy" Subtype="532" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.533 - Trisagion.png" Kind="Collect" Name="Trisagion" Subtype="533" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.535 - Blanket.png" Kind="Collect" Name="Blanket" Subtype="535" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.538 - Marbles.png" Kind="Collect" Name="Marbles" Subtype="538" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.540 - Flat Stone.png" Kind="Collect" Name="Flat Stone" Subtype="540" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.541 - Marrow.png" Kind="Collect" Name="Marrow" Subtype="541" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.546 - Dad's Ring.png" Kind="Collect" Name="Dad's Ring" Subtype="546" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.547 - Divorce Papers.png" Kind="Collect" Name="Divorce Papers" Subtype="547" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.549 - Brittle Bones.png" Kind="Collect" Name="Brittle Bones" Subtype="549" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.551 - Broken Shovel.png" Kind="Collect" Name="Broken Shovel" Subtype="551" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.553 - Mucormycosis.png" Kind="Collect" Name="Mucormycosis" Subtype="553" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.554 - 2Spooky.png" Kind="Collect" Name="2Spooky" Subtype="554" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.558 - Eye Sore.png" Kind="Collect" Name="Eye Sore" Subtype="558" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.559 - 120 Volt.png" Kind="Collect" Name="120 Volt" Subtype="559" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.560 - It Hurts.png" Kind="Collect" Name="It Hurts" Subtype="560" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.561 - Almond Milk.png" Kind="Collect" Name="Almond Milk" Subtype="561" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.562 - Rock Bottom.png" Kind="Collect" Name="Rock Bottom" Subtype="562" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.563 - Enigma Bombs.png" Kind="Collect" Name="Nancy Bombs" Subtype="563" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.564 - Bar of Soap.png" Kind="Collect" Name="A Bar of Soap" Subtype="564" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.566 - Dream Catcher.png" Kind="Collect" Name="Dream Catcher" Subtype="566" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.567 - Paschal Candle.png" Kind="Collect" Name="Paschal Candle" Subtype="567" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.568 - Divine Intervention.png" Kind="Collect" Name="Divine Intervention" Subtype="568" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.569 - Blood Oath.png" Kind="Collect" Name="Blood Oath" Subtype="569" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.570 - Playdoh Cookie.png" Kind="Collect" Name="Playdough Cookie" Subtype="570" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.571 - Socks.png" Kind="Collect" Name="Orphan Socks" Subtype="571" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.572 - Occult Eye.png" Kind="Collect" Name="Eye of the Occult" Subtype="572" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.573 - Immaculate Heart.png" Kind="Collect" Name="Immaculate Heart" Subtype="573" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.574 - Monstrance.png" Kind="Collect" Name="Monstrance" Subtype="574" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.575 - The Intruder.png" Kind="Collect" Name="The Intruder" Subtype="575" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.576 - Dirty Mind.png" Kind="Collect" Name="Dirty Mind" Subtype="576" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.579 - Spirit Sword.png" Kind="Collect" Name="Spirit Sword" Subtype="579" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.581 - Psy Fly.png" Kind="Collect" Name="Psy Fly" Subtype="581" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.583 - Rocket in a Jar.png" Kind="Collect" Name="Rocket in a Jar" Subtype="583" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.584 - Book of Virtues.png" Kind="Collect" Name="Book of Virtues" Subtype="584" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.586 - The Stairway.png" Kind="Collect" Name="The Stairway" Subtype="586" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.588 - Sol.png" Kind="Collect" Name="Sol" Subtype="588" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.589 - Luna.png" Kind="Collect" Name="Luna" Subtype="589" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.590 - Mercurius.png" Kind="Collect" Name="Mercurius" Subtype="590" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.591 - Venus.png" Kind="Collect" Name="Venus" Subtype="591" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.592 - Terra.png" Kind="Collect" Name="Terra" Subtype="592" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.593 - Mars.png" Kind="Collect" Name="Mars" Subtype="593" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.594 - Jupiter.png" Kind="Collect" Name="Jupiter" Subtype="594" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.595 - Saturnus.png" Kind="Collect" Name="Saturnus" Subtype="595" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.596 - Uranus.png" Kind="Collect" Name="Uranus" Subtype="596" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.597 - Neptunus.png" Kind="Collect" Name="Neptunus" Subtype="597" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.598 - Pluto.png" Kind="Collect" Name="Pluto" Subtype="598" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.599 - Voodoo Head.png" Kind="Collect" Name="Voodoo Head" Subtype="599" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.600 - Eye Drops.png" Kind="Collect" Name="Eye Drops" Subtype="600" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.601 - Act of Contrition.png" Kind="Collect" Name="Act of Contrition" Subtype="601" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.602 - Member Card.png" Kind="Collect" Name="Member Card" Subtype="602" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.603 - Battery Pack.png" Kind="Collect" Name="Battery Pack" Subtype="603" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.606 - Ocular Rift.png" Kind="Collect" Name="Ocular Rift" Subtype="606" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.614 - Blood Bombs.png" Kind="Collect" Name="Blood Bombs" Subtype="614" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.616 - Birds Eye.png" Kind="Collect" Name="Birds Eye" Subtype="616" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.617 - Lodestone.png" Kind="Collect" Name="Lodestone" Subtype="617" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.618 - Rotten Tomato.png" Kind="Collect" Name="Rotten Tomato" Subtype="618" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.619 - Birth Right.png" Kind="Collect" Name="Birthright" Subtype="619" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.621 - Red Stew.png" Kind="Collect" Name="Red Stew" Subtype="621" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.622 - Genesis.png" Kind="Collect" Name="Genesis" Subtype="622" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.624 - Booster Pack.png" Kind="Collect" Name="Booster Pack" Subtype="624" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.632 - Evil Charm.png" Kind="Collect" Name="Evil Charm" Subtype="632" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.633 - Dogma.png" Kind="Collect" Name="Dogma" Subtype="633" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.634 - Purgatory.png" Kind="Collect" Name="Purgatory" Subtype="634" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.637 - Knockout Drops.png" Kind="Collect" Name="Knockout Drops" Subtype="637" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.641 - Akeldama.png" Kind="Collect" Name="Akeldama" Subtype="641" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.643 - Revelation.png" Kind="Collect" Name="Revelation" Subtype="643" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.644 - Consolation Prize.png" Kind="Collect" Name="Consolation Prize" Subtype="644" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.646 - Brimstone Bombs.png" Kind="Collect" Name="Brimstone Bombs" Subtype="646" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.647 - Assault Battery.png" Kind="Collect" Name="4.5 Volt" Subtype="647" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.654 - False Phd.png" Kind="Collect" Name="False Phd" Subtype="654" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.657 - Vasculitis.png" Kind="Collect" Name="Vasculitis" Subtype="657" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.658 - Giant Cell.png" Kind="Collect" Name="Giant Cell" Subtype="658" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.659 - Tropicamide.png" Kind="Collect" Name="Tropicamide" Subtype="659" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.660 - Card Reading.png" Kind="Collect" Name="Card Reading" Subtype="660" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.661 - Quints.png" Kind="Collect" Name="Quints" Subtype="661" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.663 - Tooth and Nail.png" Kind="Collect" Name="Tooth and Nail" Subtype="663" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.664 - Binge Eater.png" Kind="Collect" Name="Binge Eater" Subtype="664" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.665 - Guppys Eye.png" Kind="Collect" Name="Guppy's Eye" Subtype="665" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.668 - Dads Note.png" Kind="Collect" Name="Dad's Note" Subtype="668" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.669 - Sausage.png" Kind="Collect" Name="Sausage" Subtype="669" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.670 - Options.png" Kind="Collect" Name="Options?" Subtype="670" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.671 - Candy Heart.png" Kind="Collect" Name="Candy Heart" Subtype="671" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.672 - Pound of Flesh.png" Kind="Collect" Name="A Pound of Flesh" Subtype="672" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.673 - Redemption.png" Kind="Collect" Name="Redemption" Subtype="673" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.674 - Spirit Shackles.png" Kind="Collect" Name="Spirit Shackles" Subtype="674" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.675 - Cracked Orb.png" Kind="Collect" Name="Cracked Orb" Subtype="675" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.676 - Empty Heart.png" Kind="Collect" Name="Empty Heart" Subtype="676" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.677 - Astral Projection.png" Kind="Collect" Name="Astral Projection" Subtype="677" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.678 - C Section.png" Kind="Collect" Name="C Section" Subtype="678" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.680 - Montezumas Revenge.png" Kind="Collect" Name="Montezuma's Revenge" Subtype="680" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.683 - Bone Spurs.png" Kind="Collect" Name="Bone Spurs" Subtype="683" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.684 - Hungry Soul.png" Kind="Collect" Name="Hungry Soul" Subtype="684" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.686 - Soul Locket.png" Kind="Collect" Name="Soul Locket" Subtype="686" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.688 - Inner Child.png" Kind="Collect" Name="Inner Child" Subtype="688" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.689 - Glitched Crown.png" Kind="Collect" Name="Glitched Crown" Subtype="689" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.690 - Belly Jelly.png" Kind="Collect" Name="Belly Jelly" Subtype="690" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.691 - Sacred Orb.png" Kind="Collect" Name="Sacred Orb" Subtype="691" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.692 - Sanguine Bond.png" Kind="Collect" Name="Sanguine Bond" Subtype="692" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.693 - The Swarm.png" Kind="Collect" Name="The Swarm" Subtype="693" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.694 - Heartbreak.png" Kind="Collect" Name="Heartbreak" Subtype="694" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.695 - Bloody Gust.png" Kind="Collect" Name="Bloody Gust" Subtype="695" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.696 - Salvation.png" Kind="Collect" Name="Salvation" Subtype="696" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.699 - Azazels Rage.png" Kind="Collect" Name="Azazel's Rage" Subtype="699" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.700 - Echo Chamber.png" Kind="Collect" Name="Echo Chamber" Subtype="700" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.701 - Isaacs Tomb.png" Kind="Collect" Name="Isaac's Tomb" Subtype="701" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.702 - Vengeful Spirit.png" Kind="Collect" Name="Vengeful Spirit" Subtype="702" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.707 - Supper.png" Kind="Collect" Name="Supper" Subtype="707" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.708 - Stapler.png" Kind="Collect" Name="Stapler" Subtype="708" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.716 - Keepers Sack.png" Kind="Collect" Name="Keeper's Sack" Subtype="716" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.717 - Keepers Kin.png" Kind="Collect" Name="Keeper's Kin" Subtype="717" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.721 - Tmtrainer.png" Kind="Collect" Name="Tmtrainer" Subtype="721" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.724 - Hypercoagulation.png" Kind="Collect" Name="Hypercoagulation" Subtype="724" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.725 - Ibs.png" Kind="Collect" Name="Ibs" Subtype="725" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.726 - Hemoptysis.png" Kind="Collect" Name="Hemoptysis" Subtype="726" Variant="100" />
-	<entity Group="Passive Items" ID="5" Image="resources/Entities/Items/5.100.727 - Ghost Bombs.png" Kind="Collect" Name="Ghost Bombs" Subtype="727" Variant="100" />
-	<!-- Trinkets -->
-	<entity Group="Trinkets" ID="5" Image="resources/Entities/Trinkets/5.350.001 - Swallowed Penny.png" Kind="Collect" Name="Swallowed Penny" Subtype="1" Variant="350" />
-	<entity Group="Trinkets" ID="5" Image="resources/Entities/Trinkets/5.350.002 - Petrified Poop.png" Kind="Collect" Name="Petrified Poop" Subtype="2" Variant="350" />
-	<entity Group="Trinkets" ID="5" Image="resources/Entities/Trinkets/5.350.003 - AAA Battery.png" Kind="Collect" Name="AAA Battery" Subtype="3" Variant="350" />
-	<entity Group="Trinkets" ID="5" Image="resources/Entities/Trinkets/5.350.004 - Broken Remote.png" Kind="Collect" Name="Broken Remote" Subtype="4" Variant="350" />
-	<entity Group="Trinkets" ID="5" Image="resources/Entities/Trinkets/5.350.005 - Purple Heart.png" Kind="Collect" Name="Purple Heart" Subtype="5" Variant="350" />
-	<entity Group="Trinkets" ID="5" Image="resources/Entities/Trinkets/5.350.006 - Broken Magnet.png" Kind="Collect" Name="Broken Magnet" Subtype="6" Variant="350" />
-	<entity Group="Trinkets" ID="5" Image="resources/Entities/Trinkets/5.350.007 - Rosary Bead.png" Kind="Collect" Name="Rosary Bead" Subtype="7" Variant="350" />
-	<entity Group="Trinkets" ID="5" Image="resources/Entities/Trinkets/5.350.008 - Cartridge.png" Kind="Collect" Name="Cartridge" Subtype="8" Variant="350" />
-	<entity Group="Trinkets" ID="5" Image="resources/Entities/Trinkets/5.350.009 - Pulse Worm.png" Kind="Collect" Name="Pulse Worm" Subtype="9" Variant="350" />
-	<entity Group="Trinkets" ID="5" Image="resources/Entities/Trinkets/5.350.010 - Wiggle Worm.png" Kind="Collect" Name="Wiggle Worm" Subtype="10" Variant="350" />
-	<entity Group="Trinkets" ID="5" Image="resources/Entities/Trinkets/5.350.011 - Ring Worm.png" Kind="Collect" Name="Ring Worm" Subtype="11" Variant="350" />
-	<entity Group="Trinkets" ID="5" Image="resources/Entities/Trinkets/5.350.012 - Flat Worm.png" Kind="Collect" Name="Flat Worm" Subtype="12" Variant="350" />
-	<entity Group="Trinkets" ID="5" Image="resources/Entities/Trinkets/5.350.013 - Store Credit.png" Kind="Collect" Name="Store Credit" Subtype="13" Variant="350" />
-	<entity Group="Trinkets" ID="5" Image="resources/Entities/Trinkets/5.350.014 - Callus.png" Kind="Collect" Name="Callus" Subtype="14" Variant="350" />
-	<entity Group="Trinkets" ID="5" Image="resources/Entities/Trinkets/5.350.015 - Lucky Rock.png" Kind="Collect" Name="Lucky Rock" Subtype="15" Variant="350" />
-	<entity Group="Trinkets" ID="5" Image="resources/Entities/Trinkets/5.350.016 - Mom's Toenail.png" Kind="Collect" Name="Mom's Toenail" Subtype="16" Variant="350" />
-	<entity Group="Trinkets" ID="5" Image="resources/Entities/Trinkets/5.350.017 - Black Lipstick.png" Kind="Collect" Name="Black Lipstick" Subtype="17" Variant="350" />
-	<entity Group="Trinkets" ID="5" Image="resources/Entities/Trinkets/5.350.018 - Bible Tract.png" Kind="Collect" Name="Bible Tract" Subtype="18" Variant="350" />
-	<entity Group="Trinkets" ID="5" Image="resources/Entities/Trinkets/5.350.019 - Paper Clip.png" Kind="Collect" Name="Paper Clip" Subtype="19" Variant="350" />
-	<entity Group="Trinkets" ID="5" Image="resources/Entities/Trinkets/5.350.020 - Monkey Paw.png" Kind="Collect" Name="Monkey Paw" Subtype="20" Variant="350" />
-	<entity Group="Trinkets" ID="5" Image="resources/Entities/Trinkets/5.350.021 - Mysterious Paper.png" Kind="Collect" Name="Mysterious Paper" Subtype="21" Variant="350" />
-	<entity Group="Trinkets" ID="5" Image="resources/Entities/Trinkets/5.350.022 - Daemon's Tail.png" Kind="Collect" Name="Daemon's Tail" Subtype="22" Variant="350" />
-	<entity Group="Trinkets" ID="5" Image="resources/Entities/Trinkets/5.350.023 - Missing Poster.png" Kind="Collect" Name="Missing Poster" Subtype="23" Variant="350" />
-	<entity Group="Trinkets" ID="5" Image="resources/Entities/Trinkets/5.350.024 - Butt Penny.png" Kind="Collect" Name="Butt Penny" Subtype="24" Variant="350" />
-	<entity Group="Trinkets" ID="5" Image="resources/Entities/Trinkets/5.350.025 - Mysterious Candy.png" Kind="Collect" Name="Mysterious Candy" Subtype="25" Variant="350" />
-	<entity Group="Trinkets" ID="5" Image="resources/Entities/Trinkets/5.350.026 - Hook Worm.png" Kind="Collect" Name="Hook Worm" Subtype="26" Variant="350" />
-	<entity Group="Trinkets" ID="5" Image="resources/Entities/Trinkets/5.350.027 - Whip Worm.png" Kind="Collect" Name="Whip Worm" Subtype="27" Variant="350" />
-	<entity Group="Trinkets" ID="5" Image="resources/Entities/Trinkets/5.350.028 - Broken Ankh.png" Kind="Collect" Name="Broken Ankh" Subtype="28" Variant="350" />
-	<entity Group="Trinkets" ID="5" Image="resources/Entities/Trinkets/5.350.029 - Fish Head.png" Kind="Collect" Name="Fish Head" Subtype="29" Variant="350" />
-	<entity Group="Trinkets" ID="5" Image="resources/Entities/Trinkets/5.350.030 - Pinky Eye.png" Kind="Collect" Name="Pinky Eye" Subtype="30" Variant="350" />
-	<entity Group="Trinkets" ID="5" Image="resources/Entities/Trinkets/5.350.031 - Push Pin.png" Kind="Collect" Name="Push Pin" Subtype="31" Variant="350" />
-	<entity Group="Trinkets" ID="5" Image="resources/Entities/Trinkets/5.350.032 - Liberty Cap.png" Kind="Collect" Name="Liberty Cap" Subtype="32" Variant="350" />
-	<entity Group="Trinkets" ID="5" Image="resources/Entities/Trinkets/5.350.033 - Umbilical Cord.png" Kind="Collect" Name="Umbilical Cord" Subtype="33" Variant="350" />
-	<entity Group="Trinkets" ID="5" Image="resources/Entities/Trinkets/5.350.034 - Child's Heart.png" Kind="Collect" Name="Child's Heart" Subtype="34" Variant="350" />
-	<entity Group="Trinkets" ID="5" Image="resources/Entities/Trinkets/5.350.035 - Curved Horn.png" Kind="Collect" Name="Curved Horn" Subtype="35" Variant="350" />
-	<entity Group="Trinkets" ID="5" Image="resources/Entities/Trinkets/5.350.036 - Rusted Key.png" Kind="Collect" Name="Rusted Key" Subtype="36" Variant="350" />
-	<entity Group="Trinkets" ID="5" Image="resources/Entities/Trinkets/5.350.037 - Goat Hoof.png" Kind="Collect" Name="Goat Hoof" Subtype="37" Variant="350" />
-	<entity Group="Trinkets" ID="5" Image="resources/Entities/Trinkets/5.350.038 - Mom's Pearl.png" Kind="Collect" Name="Mom's Pearl" Subtype="38" Variant="350" />
-	<entity Group="Trinkets" ID="5" Image="resources/Entities/Trinkets/5.350.039 - Cancer.png" Kind="Collect" Name="Cancer" Subtype="39" Variant="350" />
-	<entity Group="Trinkets" ID="5" Image="resources/Entities/Trinkets/5.350.040 - Red Patch.png" Kind="Collect" Name="Red Patch" Subtype="40" Variant="350" />
-	<entity Group="Trinkets" ID="5" Image="resources/Entities/Trinkets/5.350.041 - Match Stick.png" Kind="Collect" Name="Match Stick" Subtype="41" Variant="350" />
-	<entity Group="Trinkets" ID="5" Image="resources/Entities/Trinkets/5.350.042 - Lucky Toe.png" Kind="Collect" Name="Lucky Toe" Subtype="42" Variant="350" />
-	<entity Group="Trinkets" ID="5" Image="resources/Entities/Trinkets/5.350.043 - Cursed Skull.png" Kind="Collect" Name="Cursed Skull" Subtype="43" Variant="350" />
-	<entity Group="Trinkets" ID="5" Image="resources/Entities/Trinkets/5.350.044 - Safety Cap.png" Kind="Collect" Name="Safety Cap" Subtype="44" Variant="350" />
-	<entity Group="Trinkets" ID="5" Image="resources/Entities/Trinkets/5.350.045 - Ace of Spades.png" Kind="Collect" Name="Ace of Spades" Subtype="45" Variant="350" />
-	<entity Group="Trinkets" ID="5" Image="resources/Entities/Trinkets/5.350.046 - Isaac's Fork.png" Kind="Collect" Name="Isaac's Fork" Subtype="46" Variant="350" />
-	<entity Group="Trinkets" ID="5" Image="resources/Entities/Trinkets/5.350.048 - A Missing Page.png" Kind="Collect" Name="A Missing Page" Subtype="48" Variant="350" />
-	<entity Group="Trinkets" ID="5" Image="resources/Entities/Trinkets/5.350.049 - Bloody Penny.png" Kind="Collect" Name="Bloody Penny" Subtype="49" Variant="350" />
-	<entity Group="Trinkets" ID="5" Image="resources/Entities/Trinkets/5.350.050 - Burnt Penny.png" Kind="Collect" Name="Burnt Penny" Subtype="50" Variant="350" />
-	<entity Group="Trinkets" ID="5" Image="resources/Entities/Trinkets/5.350.051 - Flat Penny.png" Kind="Collect" Name="Flat Penny" Subtype="51" Variant="350" />
-	<entity Group="Trinkets" ID="5" Image="resources/Entities/Trinkets/5.350.052 - Counterfeit Penny.png" Kind="Collect" Name="Counterfeit Penny" Subtype="52" Variant="350" />
-	<entity Group="Trinkets" ID="5" Image="resources/Entities/Trinkets/5.350.053 - Tick.png" Kind="Collect" Name="Tick" Subtype="53" Variant="350" />
-	<entity Group="Trinkets" ID="5" Image="resources/Entities/Trinkets/5.350.054 - Isaac's Head.png" Kind="Collect" Name="Isaac's Head" Subtype="54" Variant="350" />
-	<entity Group="Trinkets" ID="5" Image="resources/Entities/Trinkets/5.350.055 - Maggy's Faith.png" Kind="Collect" Name="Maggy's Faith" Subtype="55" Variant="350" />
-	<entity Group="Trinkets" ID="5" Image="resources/Entities/Trinkets/5.350.056 - Judas' Tongue.png" Kind="Collect" Name="Judas' Tongue" Subtype="56" Variant="350" />
-	<entity Group="Trinkets" ID="5" Image="resources/Entities/Trinkets/5.350.057 - Blue Baby's Soul.png" Kind="Collect" Name="???'s Soul" Subtype="57" Variant="350" />
-	<entity Group="Trinkets" ID="5" Image="resources/Entities/Trinkets/5.350.058 - Samson's Lock.png" Kind="Collect" Name="Samson's Lock" Subtype="58" Variant="350" />
-	<entity Group="Trinkets" ID="5" Image="resources/Entities/Trinkets/5.350.059 - Cain's Eye.png" Kind="Collect" Name="Cain's Eye" Subtype="59" Variant="350" />
-	<entity Group="Trinkets" ID="5" Image="resources/Entities/Trinkets/5.350.060 - Eve's Bird Foot.png" Kind="Collect" Name="Eve's Bird Foot" Subtype="60" Variant="350" />
-	<entity Group="Trinkets" ID="5" Image="resources/Entities/Trinkets/5.350.061 - The Left Hand.png" Kind="Collect" Name="The Left Hand" Subtype="61" Variant="350" />
-	<entity Group="Trinkets" ID="5" Image="resources/Entities/Trinkets/5.350.062 - Shiny Rock.png" Kind="Collect" Name="Shiny Rock" Subtype="62" Variant="350" />
-	<entity Group="Trinkets" ID="5" Image="resources/Entities/Trinkets/5.350.063 - Safety Scissors.png" Kind="Collect" Name="Safety Scissors" Subtype="63" Variant="350" />
-	<entity Group="Trinkets" ID="5" Image="resources/Entities/Trinkets/5.350.064 - Rainbow Worm.png" Kind="Collect" Name="Rainbow Worm" Subtype="64" Variant="350" />
-	<entity Group="Trinkets" ID="5" Image="resources/Entities/Trinkets/5.350.065 - Tape Worm.png" Kind="Collect" Name="Tape Worm" Subtype="65" Variant="350" />
-	<entity Group="Trinkets" ID="5" Image="resources/Entities/Trinkets/5.350.066 - Lazy Worm.png" Kind="Collect" Name="Lazy Worm" Subtype="66" Variant="350" />
-	<entity Group="Trinkets" ID="5" Image="resources/Entities/Trinkets/5.350.067 - Cracked Dice.png" Kind="Collect" Name="Cracked Dice" Subtype="67" Variant="350" />
-	<entity Group="Trinkets" ID="5" Image="resources/Entities/Trinkets/5.350.068 - Super Magnet.png" Kind="Collect" Name="Super Magnet" Subtype="68" Variant="350" />
-	<entity Group="Trinkets" ID="5" Image="resources/Entities/Trinkets/5.350.069 - Faded Polaroid.png" Kind="Collect" Name="Faded Polaroid" Subtype="69" Variant="350" />
-	<entity Group="Trinkets" ID="5" Image="resources/Entities/Trinkets/5.350.070 - Louse.png" Kind="Collect" Name="Louse" Subtype="70" Variant="350" />
-	<entity Group="Trinkets" ID="5" Image="resources/Entities/Trinkets/5.350.071 - Bob's Bladder.png" Kind="Collect" Name="Bob's Bladder" Subtype="71" Variant="350" />
-	<entity Group="Trinkets" ID="5" Image="resources/Entities/Trinkets/5.350.072 - Watch Battery.png" Kind="Collect" Name="Watch Battery" Subtype="72" Variant="350" />
-	<entity Group="Trinkets" ID="5" Image="resources/Entities/Trinkets/5.350.073 - Blasting Cap.png" Kind="Collect" Name="Blasting Cap" Subtype="73" Variant="350" />
-	<entity Group="Trinkets" ID="5" Image="resources/Entities/Trinkets/5.350.074 - Stud Finder.png" Kind="Collect" Name="Stud Finder" Subtype="74" Variant="350" />
-	<entity Group="Trinkets" ID="5" Image="resources/Entities/Trinkets/5.350.075 - Error.png" Kind="Collect" Name="Error" Subtype="75" Variant="350" />
-	<entity Group="Trinkets" ID="5" Image="resources/Entities/Trinkets/5.350.076 - Poker Chip.png" Kind="Collect" Name="Poker Chip" Subtype="76" Variant="350" />
-	<entity Group="Trinkets" ID="5" Image="resources/Entities/Trinkets/5.350.077 - Blister.png" Kind="Collect" Name="Blister" Subtype="77" Variant="350" />
-	<entity Group="Trinkets" ID="5" Image="resources/Entities/Trinkets/5.350.078 - Second Hand.png" Kind="Collect" Name="Second Hand" Subtype="78" Variant="350" />
-	<entity Group="Trinkets" ID="5" Image="resources/Entities/Trinkets/5.350.079 - Endless Nameless.png" Kind="Collect" Name="Endless Nameless" Subtype="79" Variant="350" />
-	<entity Group="Trinkets" ID="5" Image="resources/Entities/Trinkets/5.350.080 - Black Feather.png" Kind="Collect" Name="Black Feather" Subtype="80" Variant="350" />
-	<entity Group="Trinkets" ID="5" Image="resources/Entities/Trinkets/5.350.081 - Blind Rage.png" Kind="Collect" Name="Blind Rage" Subtype="81" Variant="350" />
-	<entity Group="Trinkets" ID="5" Image="resources/Entities/Trinkets/5.350.082 - Golden Horse Shoe.png" Kind="Collect" Name="Golden Horse Shoe" Subtype="82" Variant="350" />
-	<entity Group="Trinkets" ID="5" Image="resources/Entities/Trinkets/5.350.083 - Store Key.png" Kind="Collect" Name="Store Key" Subtype="83" Variant="350" />
-	<entity Group="Trinkets" ID="5" Image="resources/Entities/Trinkets/5.350.084 - Rib of Greed.png" Kind="Collect" Name="Rib of Greed" Subtype="84" Variant="350" />
-	<entity Group="Trinkets" ID="5" Image="resources/Entities/Trinkets/5.350.085 - Karma.png" Kind="Collect" Name="Karma" Subtype="85" Variant="350" />
-	<entity Group="Trinkets" ID="5" Image="resources/Entities/Trinkets/5.350.086 - Lil Larva.png" Kind="Collect" Name="Lil Larva" Subtype="86" Variant="350" />
-	<entity Group="Trinkets" ID="5" Image="resources/Entities/Trinkets/5.350.087 - Mom's Locket.png" Kind="Collect" Name="Mom's Locket" Subtype="87" Variant="350" />
-	<entity Group="Trinkets" ID="5" Image="resources/Entities/Trinkets/5.350.088 - NO.png" Kind="Collect" Name="NO!" Subtype="88" Variant="350" />
-	<entity Group="Trinkets" ID="5" Image="resources/Entities/Trinkets/5.350.089 - Child Leash.png" Kind="Collect" Name="Child Leash" Subtype="89" Variant="350" />
-	<entity Group="Trinkets" ID="5" Image="resources/Entities/Trinkets/5.350.090 - Brown Cap.png" Kind="Collect" Name="Brown Cap" Subtype="90" Variant="350" />
-	<entity Group="Trinkets" ID="5" Image="resources/Entities/Trinkets/5.350.091 - Meconium.png" Kind="Collect" Name="Meconium" Subtype="91" Variant="350" />
-	<entity Group="Trinkets" ID="5" Image="resources/Entities/Trinkets/5.350.092 - Cracked Crown.png" Kind="Collect" Name="Cracked Crown" Subtype="92" Variant="350" />
-	<entity Group="Trinkets" ID="5" Image="resources/Entities/Trinkets/5.350.093 - Used Diaper.png" Kind="Collect" Name="Used Diaper" Subtype="93" Variant="350" />
-	<entity Group="Trinkets" ID="5" Image="resources/Entities/Trinkets/5.350.094 - Fish Tail.png" Kind="Collect" Name="Fish Tail" Subtype="94" Variant="350" />
-	<entity Group="Trinkets" ID="5" Image="resources/Entities/Trinkets/5.350.095 - Black Tooth.png" Kind="Collect" Name="Black Tooth" Subtype="95" Variant="350" />
-	<entity Group="Trinkets" ID="5" Image="resources/Entities/Trinkets/5.350.096 - Ouroboros Worm.png" Kind="Collect" Name="Ouroboros Worm" Subtype="96" Variant="350" />
-	<entity Group="Trinkets" ID="5" Image="resources/Entities/Trinkets/5.350.097 - Tonsil.png" Kind="Collect" Name="Tonsil" Subtype="97" Variant="350" />
-	<entity Group="Trinkets" ID="5" Image="resources/Entities/Trinkets/5.350.098 - Nose Goblin.png" Kind="Collect" Name="Nose Goblin" Subtype="98" Variant="350" />
-	<entity Group="Trinkets" ID="5" Image="resources/Entities/Trinkets/5.350.099 - Super Ball.png" Kind="Collect" Name="Super Ball" Subtype="99" Variant="350" />
-	<entity Group="Trinkets" ID="5" Image="resources/Entities/Trinkets/5.350.100 - Vibrant Bulb.png" Kind="Collect" Name="Vibrant Bulb" Subtype="100" Variant="350" />
-	<entity Group="Trinkets" ID="5" Image="resources/Entities/Trinkets/5.350.101 - Dim Bulb.png" Kind="Collect" Name="Dim Bulb" Subtype="101" Variant="350" />
-	<entity Group="Trinkets" ID="5" Image="resources/Entities/Trinkets/5.350.102 - Fragmented Card.png" Kind="Collect" Name="Fragmented Card" Subtype="102" Variant="350" />
-	<entity Group="Trinkets" ID="5" Image="resources/Entities/Trinkets/5.350.103 - Equality!.png" Kind="Collect" Name="Equality!" Subtype="103" Variant="350" />
-	<entity Group="Trinkets" ID="5" Image="resources/Entities/Trinkets/5.350.104 - Wish Bone.png" Kind="Collect" Name="Wish Bone" Subtype="104" Variant="350" />
-	<entity Group="Trinkets" ID="5" Image="resources/Entities/Trinkets/5.350.105 - Bag Lunch.png" Kind="Collect" Name="Bag Lunch" Subtype="105" Variant="350" />
-	<entity Group="Trinkets" ID="5" Image="resources/Entities/Trinkets/5.350.106 - Lost Cork.png" Kind="Collect" Name="Lost Cork" Subtype="106" Variant="350" />
-	<entity Group="Trinkets" ID="5" Image="resources/Entities/Trinkets/5.350.107 - Crow Heart.png" Kind="Collect" Name="Crow Heart" Subtype="107" Variant="350" />
-	<entity Group="Trinkets" ID="5" Image="resources/Entities/Trinkets/5.350.108 - Walnut.png" Kind="Collect" Name="Walnut" Subtype="108" Variant="350" />
-	<entity Group="Trinkets" ID="5" Image="resources/Entities/Trinkets/5.350.109 - Duct Tape.png" Kind="Collect" Name="Duct Tape" Subtype="109" Variant="350" />
-	<entity Group="Trinkets" ID="5" Image="resources/Entities/Trinkets/5.350.110 - Silver Dollar.png" Kind="Collect" Name="Silver Dollar" Subtype="110" Variant="350" />
-	<entity Group="Trinkets" ID="5" Image="resources/Entities/Trinkets/5.350.111 - Bloody Crown.png" Kind="Collect" Name="Bloody Crown" Subtype="111" Variant="350" />
-	<entity Group="Trinkets" ID="5" Image="resources/Entities/Trinkets/5.350.112 - Pay To Win.png" Kind="Collect" Name="Pay To Win" Subtype="112" Variant="350" />
-	<entity Group="Trinkets" ID="5" Image="resources/Entities/Trinkets/5.350.113 - Locust of Wrath.png" Kind="Collect" Name="Locust of Wrath" Subtype="113" Variant="350" />
-	<entity Group="Trinkets" ID="5" Image="resources/Entities/Trinkets/5.350.114 - Locust of Pestilence.png" Kind="Collect" Name="Locust of Pestilence" Subtype="114" Variant="350" />
-	<entity Group="Trinkets" ID="5" Image="resources/Entities/Trinkets/5.350.115 - Locust of Famine.png" Kind="Collect" Name="Locust of Famine" Subtype="115" Variant="350" />
-	<entity Group="Trinkets" ID="5" Image="resources/Entities/Trinkets/5.350.116 - Locust of Death.png" Kind="Collect" Name="Locust of Death" Subtype="116" Variant="350" />
-	<entity Group="Trinkets" ID="5" Image="resources/Entities/Trinkets/5.350.117 - Locust of Conquest.png" Kind="Collect" Name="Locust of Conquest" Subtype="117" Variant="350" />
-	<entity Group="Trinkets" ID="5" Image="resources/Entities/Trinkets/5.350.118 - Bat Wing.png" Kind="Collect" Name="Bat Wing" Subtype="118" Variant="350" />
-	<entity Group="Trinkets" ID="5" Image="resources/Entities/Trinkets/5.350.119 - Stem Cell.png" Kind="Collect" Name="Stem Cell" Subtype="119" Variant="350" />
-	<entity Group="Trinkets" ID="5" Image="resources/Entities/Trinkets/5.350.120 - Hairpin.png" Kind="Collect" Name="Hairpin" Subtype="120" Variant="350" />
-	<entity Group="Trinkets" ID="5" Image="resources/Entities/Trinkets/5.350.121 - Wooden Cross.png" Kind="Collect" Name="Wooden Cross" Subtype="121" Variant="350" />
-	<entity Group="Trinkets" ID="5" Image="resources/Entities/Trinkets/5.350.122 - Butter!.png" Kind="Collect" Name="Butter!" Subtype="122" Variant="350" />
-	<entity Group="Trinkets" ID="5" Image="resources/Entities/Trinkets/5.350.123 - Filigree Feather.png" Kind="Collect" Name="Filigree Feather" Subtype="123" Variant="350" />
-	<entity Group="Trinkets" ID="5" Image="resources/Entities/Trinkets/5.350.124 - Door Stop.png" Kind="Collect" Name="Door Stop" Subtype="124" Variant="350" />
-	<entity Group="Trinkets" ID="5" Image="resources/Entities/Trinkets/5.350.125 - Extension Cord.png" Kind="Collect" Name="Extension Cord" Subtype="125" Variant="350" />
-	<entity Group="Trinkets" ID="5" Image="resources/Entities/Trinkets/5.350.126 - Rotten Penny.png" Kind="Collect" Name="Rotten Penny" Subtype="126" Variant="350" />
-	<entity Group="Trinkets" ID="5" Image="resources/Entities/Trinkets/5.350.127 - Baby-Bender.png" Kind="Collect" Name="Baby-Bender" Subtype="127" Variant="350" />
-	<entity Group="Trinkets" ID="5" Image="resources/Entities/Trinkets/5.350.128 - Finger Bone.png" Kind="Collect" Name="Finger Bone" Subtype="128" Variant="350" />
-	<entity Group="Trinkets" ID="5" Image="resources/Entities/Trinkets/5.350.129 - Jawbreaker.png" Kind="Collect" Name="Jawbreaker" Subtype="129" Variant="350" />
-	<entity Group="Trinkets" ID="5" Image="resources/Entities/Trinkets/5.350.130 - Chewed Pen.png" Kind="Collect" Name="Chewed Pen" Subtype="130" Variant="350" />
-	<entity Group="Trinkets" ID="5" Image="resources/Entities/Trinkets/5.350.131 - Blessed Penny.png" Kind="Collect" Name="Blessed Penny" Subtype="131" Variant="350" />
-	<entity Group="Trinkets" ID="5" Image="resources/Entities/Trinkets/5.350.132 - Broken Syringe.png" Kind="Collect" Name="Broken Syringe" Subtype="132" Variant="350" />
-	<entity Group="Trinkets" ID="5" Image="resources/Entities/Trinkets/5.350.133 - Short Fuse.png" Kind="Collect" Name="Short Fuse" Subtype="133" Variant="350" />
-	<entity Group="Trinkets" ID="5" Image="resources/Entities/Trinkets/5.350.134 - Gigante Bean.png" Kind="Collect" Name="Gigante Bean" Subtype="134" Variant="350" />
-	<entity Group="Trinkets" ID="5" Image="resources/Entities/Trinkets/5.350.135 - Lighter.png" Kind="Collect" Name="A Lighter" Subtype="135" Variant="350" />
-	<entity Group="Trinkets" ID="5" Image="resources/Entities/Trinkets/5.350.136 - Broken Padlock.png" Kind="Collect" Name="Broken Padlock" Subtype="136" Variant="350" />
-	<entity Group="Trinkets" ID="5" Image="resources/Entities/Trinkets/5.350.137 - Myosotis.png" Kind="Collect" Name="Myosotis" Subtype="137" Variant="350" />
-	<entity Group="Trinkets" ID="5" Image="resources/Entities/Trinkets/5.350.138 - 'M.png" Kind="Collect" Name="'M" Subtype="138" Variant="350" />
-	<entity Group="Trinkets" ID="5" Image="resources/Entities/Trinkets/5.350.139 - Teardrop Charm.png" Kind="Collect" Name="Teardrop Charm" Subtype="139" Variant="350" />
-	<entity Group="Trinkets" ID="5" Image="resources/Entities/Trinkets/5.350.140 - Apple of Sodom.png" Kind="Collect" Name="Apple of Sodom" Subtype="140" Variant="350" />
-	<entity Group="Trinkets" ID="5" Image="resources/Entities/Trinkets/5.350.141 - Forgotten Lullaby.png" Kind="Collect" Name="Forgotten Lullaby" Subtype="141" Variant="350" />
-	<entity Group="Trinkets" ID="5" Image="resources/Entities/Trinkets/5.350.142 - Beths Faith.png" Kind="Collect" Name="Beth's Faith" Subtype="142" Variant="350" />
-	<entity Group="Trinkets" ID="5" Image="resources/Entities/Trinkets/5.350.143 - Old Capacitor.png" Kind="Collect" Name="Old Capacitor" Subtype="143" Variant="350" />
-	<entity Group="Trinkets" ID="5" Image="resources/Entities/Trinkets/5.350.144 - Brain Worm.png" Kind="Collect" Name="Brain Worm" Subtype="144" Variant="350" />
-	<entity Group="Trinkets" ID="5" Image="resources/Entities/Trinkets/5.350.145 - Perfection.png" Kind="Collect" Name="Perfection" Subtype="145" Variant="350" />
-	<entity Group="Trinkets" ID="5" Image="resources/Entities/Trinkets/5.350.146 - Devils Crown.png" Kind="Collect" Name="Devil's Crown" Subtype="146" Variant="350" />
-	<entity Group="Trinkets" ID="5" Image="resources/Entities/Trinkets/5.350.147 - Charged Penny.png" Kind="Collect" Name="Charged Penny" Subtype="147" Variant="350" />
-	<entity Group="Trinkets" ID="5" Image="resources/Entities/Trinkets/5.350.148 - Friendship Necklace.png" Kind="Collect" Name="Friendship Necklace" Subtype="148" Variant="350" />
-	<entity Group="Trinkets" ID="5" Image="resources/Entities/Trinkets/5.350.149 - Panic Button.png" Kind="Collect" Name="Panic Button" Subtype="149" Variant="350" />
-	<entity Group="Trinkets" ID="5" Image="resources/Entities/Trinkets/5.350.150 - Blue Key.png" Kind="Collect" Name="Blue Key" Subtype="150" Variant="350" />
-	<entity Group="Trinkets" ID="5" Image="resources/Entities/Trinkets/5.350.151 - Flat File.png" Kind="Collect" Name="Flat File" Subtype="151" Variant="350" />
-	<entity Group="Trinkets" ID="5" Image="resources/Entities/Trinkets/5.350.152 - Telescope Lens.png" Kind="Collect" Name="Telescope Lens" Subtype="152" Variant="350" />
-	<entity Group="Trinkets" ID="5" Image="resources/Entities/Trinkets/5.350.153 - Mom's Lock.png" Kind="Collect" Name="Mom's Lock" Subtype="153" Variant="350" />
-	<entity Group="Trinkets" ID="5" Image="resources/Entities/Trinkets/5.350.154 - Dice Bag.png" Kind="Collect" Name="Dice Bag" Subtype="154" Variant="350" />
-	<entity Group="Trinkets" ID="5" Image="resources/Entities/Trinkets/5.350.155 - Holy Crown.png" Kind="Collect" Name="Holy Crown" Subtype="155" Variant="350" />
-	<entity Group="Trinkets" ID="5" Image="resources/Entities/Trinkets/5.350.156 - Mother's Kiss.png" Kind="Collect" Name="Mother's Kiss" Subtype="156" Variant="350" />
-	<entity Group="Trinkets" ID="5" Image="resources/Entities/Trinkets/5.350.157 - Torn Card.png" Kind="Collect" Name="Torn Card" Subtype="157" Variant="350" />
-	<entity Group="Trinkets" ID="5" Image="resources/Entities/Trinkets/5.350.158 - Torn Pocket.png" Kind="Collect" Name="Torn Pocket" Subtype="158" Variant="350" />
-	<entity Group="Trinkets" ID="5" Image="resources/Entities/Trinkets/5.350.159 - Gilded Key.png" Kind="Collect" Name="Gilded Key" Subtype="159" Variant="350" />
-	<entity Group="Trinkets" ID="5" Image="resources/Entities/Trinkets/5.350.160 - Lucky Sack.png" Kind="Collect" Name="Lucky Sack" Subtype="160" Variant="350" />
-	<entity Group="Trinkets" ID="5" Image="resources/Entities/Trinkets/5.350.161 - Wicked Crown.png" Kind="Collect" Name="Wicked Crown" Subtype="161" Variant="350" />
-	<entity Group="Trinkets" ID="5" Image="resources/Entities/Trinkets/5.350.162 - Azazel's Stump.png" Kind="Collect" Name="Azazel's Stump" Subtype="162" Variant="350" />
-	<entity Group="Trinkets" ID="5" Image="resources/Entities/Trinkets/5.350.163 - Dingle Berry.png" Kind="Collect" Name="Dingle Berry" Subtype="163" Variant="350" />
-	<entity Group="Trinkets" ID="5" Image="resources/Entities/Trinkets/5.350.164 - Ring Cap.png" Kind="Collect" Name="Ring Cap" Subtype="164" Variant="350" />
-	<entity Group="Trinkets" ID="5" Image="resources/Entities/Trinkets/5.350.165 - Nuh Uh.png" Kind="Collect" Name="Nuh Uh!" Subtype="165" Variant="350" />
-	<entity Group="Trinkets" ID="5" Image="resources/Entities/Trinkets/5.350.166 - Modeling Clay.png" Kind="Collect" Name="Modeling Clay" Subtype="166" Variant="350" />
-	<entity Group="Trinkets" ID="5" Image="resources/Entities/Trinkets/5.350.167 - Polished Bone.png" Kind="Collect" Name="Polished Bone" Subtype="167" Variant="350" />
-	<entity Group="Trinkets" ID="5" Image="resources/Entities/Trinkets/5.350.168 - Hollow Heart.png" Kind="Collect" Name="Hollow Heart" Subtype="168" Variant="350" />
-	<entity Group="Trinkets" ID="5" Image="resources/Entities/Trinkets/5.350.169 - Kid's Drawing.png" Kind="Collect" Name="Kid's Drawing" Subtype="169" Variant="350" />
-	<entity Group="Trinkets" ID="5" Image="resources/Entities/Trinkets/5.350.170 - Crystal Key.png" Kind="Collect" Name="Crystal Key" Subtype="170" Variant="350" />
-	<entity Group="Trinkets" ID="5" Image="resources/Entities/Trinkets/5.350.171 - Keeper's Bargain.png" Kind="Collect" Name="Keeper's Bargain" Subtype="171" Variant="350" />
-	<entity Group="Trinkets" ID="5" Image="resources/Entities/Trinkets/5.350.172 - Cursed Penny.png" Kind="Collect" Name="Cursed Penny" Subtype="172" Variant="350" />
-	<entity Group="Trinkets" ID="5" Image="resources/Entities/Trinkets/5.350.173 - Your Soul.png" Kind="Collect" Name="Your Soul" Subtype="173" Variant="350" />
-	<entity Group="Trinkets" ID="5" Image="resources/Entities/Trinkets/5.350.174 - Number Magnet.png" Kind="Collect" Name="Number Magnet" Subtype="174" Variant="350" />
-	<entity Group="Trinkets" ID="5" Image="resources/Entities/Trinkets/5.350.175 - Strange Key.png" Kind="Collect" Name="Strange Key" Subtype="175" Variant="350" />
-	<entity Group="Trinkets" ID="5" Image="resources/Entities/Trinkets/5.350.176 - Lil Clot.png" Kind="Collect" Name="Lil Clot" Subtype="176" Variant="350" />
-	<entity Group="Trinkets" ID="5" Image="resources/Entities/Trinkets/5.350.177 - Temporary Tattoo.png" Kind="Collect" Name="Temporary Tattoo" Subtype="177" Variant="350" />
-	<entity Group="Trinkets" ID="5" Image="resources/Entities/Trinkets/5.350.178 - Swallowed M80.png" Kind="Collect" Name="Swallowed M80" Subtype="178" Variant="350" />
-	<entity Group="Trinkets" ID="5" Image="resources/Entities/Trinkets/5.350.179 - RC Remote.png" Kind="Collect" Name="RC Remote" Subtype="179" Variant="350" />
-	<entity Group="Trinkets" ID="5" Image="resources/Entities/Trinkets/5.350.180 - Found Soul.png" Kind="Collect" Name="Found Soul" Subtype="180" Variant="350" />
-	<entity Group="Trinkets" ID="5" Image="resources/Entities/Trinkets/5.350.181 - Expansion Pack.png" Kind="Collect" Name="Expansion Pack" Subtype="181" Variant="350" />
-	<entity Group="Trinkets" ID="5" Image="resources/Entities/Trinkets/5.350.182 - Beth's Essence.png" Kind="Collect" Name="Beth's Essence" Subtype="182" Variant="350" />
-	<entity Group="Trinkets" ID="5" Image="resources/Entities/Trinkets/5.350.183 - The Twins.png" Kind="Collect" Name="The Twins" Subtype="183" Variant="350" />
-	<entity Group="Trinkets" ID="5" Image="resources/Entities/Trinkets/5.350.184 - Adoption Papers.png" Kind="Collect" Name="Adoption Papers" Subtype="184" Variant="350" />
-	<entity Group="Trinkets" ID="5" Image="resources/Entities/Trinkets/5.350.185 - Cricket Leg.png" Kind="Collect" Name="Cricket Leg" Subtype="185" Variant="350" />
-	<entity Group="Trinkets" ID="5" Image="resources/Entities/Trinkets/5.350.186 - Apollyon's Best Friend.png" Kind="Collect" Name="Apollyon's Best Friend" Subtype="186" Variant="350" />
-	<entity Group="Trinkets" ID="5" Image="resources/Entities/Trinkets/5.350.187 - Broken Glasses.png" Kind="Collect" Name="Broken Glasses" Subtype="187" Variant="350" />
-	<entity Group="Trinkets" ID="5" Image="resources/Entities/Trinkets/5.350.188 - Ice Cube.png" Kind="Collect" Name="Ice Cube" Subtype="188" Variant="350" />
-	<entity Group="Trinkets" ID="5" Image="resources/Entities/Trinkets/5.350.189 - Sigil of Baphomet.png" Kind="Collect" Name="Sigil of Baphomet" Subtype="189" Variant="350" />
-
+	<group Name="Special Bosses">
+		<group Name="Unfinished Bosses" Label="Unfinished">
+			<entity BaseHP="792" ID="919" Image="Entities/919.0.0 - Raglich.png" Name="Raglich" Variant="0" Subtype="0" />
+			<entity BaseHP="500" ID="921" Image="Entities/921.0.0 - Clutch.png" Name="Clutch" Variant="0" Subtype="0" />
+		</group>
+	</group>
 
 	<!--——— Unused ———-->
+	<group Name="Unused Enemies">
+		<entity BaseHP="18" Tags="Champion" ID="803" Image="Entities/803.0.0 - Blind Bat.png" Name="Blind Bat" Variant="0" Subtype="0" />
+		<entity BaseHP="16" Tags="Champion" ID="241" Image="Entities/241.1.0 - Split Rage Creep.png" PlaceVisual="WallSnap" Name="Split Rage Creep" Variant="1" Subtype="0"/>
+		<entity BaseHP="17" ID="240" Image="Entities/240.2.0 - Rag Creep.png" PlaceVisual="WallSnap" Name="Rag Creep" Variant="2" Subtype="0" />
+		<entity BaseHP="60" Tags="Champion" ID="858" Image="Entities/858.0.0 - Vessel.png" Name="Vessel" Variant="0" Subtype="0"/>
+		<entity BaseHP="6.5" ID="815" Image="Entities/815.0.0 - Fissure.png" Name="Fissure" Variant="0" Subtype="0" />
+	</group>
 
-	<!-- Misc -->
-	<entity Image="resources/Entities/216.1.0 - Swinger Head.png" ID="216" Variant="1" Name="Swinger Head" BaseHP="38" />
-	<entity Image="resources/Entities/216.10.0 - Swinger Neck.png" ID="216" Variant="10" Name="Swinger Neck" BaseHP="25" />
-	<entity Image="resources/Entities/1500.0.0 - Poop.png" Name="Pushable Poop" ID="245" Subtype="0" Variant="0" />
+	<group Name="Unused Fireplaces" Label="Fireplaces">
+		<defaults>
+			<entity>
+				<tag>Grid</tag>
+				<tag>InEmptyRooms</tag>
+				<tag>InNonCombatRooms</tag>
+			</entity>
+		</defaults>
+		<entity BaseHP="5" ID="33" Image="Entities/33.10.0 - Moveable Fireplace.png" Name="Moveable Fireplace" Variant="10" Subtype="0" />
+		<entity BaseHP="5" ID="33" Image="Entities/33.12.0 - Moveable Blue Fireplace.png" Name="Moveable Blue Fireplace" Variant="12" Subtype="0" />
+		<entity BaseHP="5" ID="33" Image="Entities/33.13.0 - Moveable Purple Fireplace.png" Name="Moveable Purple Fireplace" Variant="13" Subtype="0" />
+	</group>
 
-	<!-- Tears -->
-	<entity ID="2" Image="resources/Entities/2.0.0 - Tear.png" Name="Tear" Subtype="0" Variant="0" />
-	<entity ID="2" Image="resources/Entities/2.1.0 - Blood Tear.png" Name="Blood Tear" Subtype="0" Variant="1" />
-	<entity ID="2" Image="resources/Entities/2.2.0 - Tooth Tear.png" Name="Tooth Tear" Subtype="0" Variant="2" />
-	<entity ID="2" Image="resources/Entities/2.3.0 - Metallic Tear.png" Name="Metallic Tear" Subtype="0" Variant="3" />
-	<entity ID="2" Image="resources/Entities/2.4.0 - Bob's Tear.png" Name="Bob's Tear" Subtype="0" Variant="4" />
-	<entity ID="2" Image="resources/Entities/2.5.0 - Fire Tear.png" Name="Fire Tear" Subtype="0" Variant="5" />
-	<entity ID="2" Image="resources/Entities/2.6.0 - Dark Matter Tear.png" Name="Dark Matter Tear" Subtype="0" Variant="6" />
-	<entity ID="2" Image="resources/Entities/2.7.0 - Mysterious Tear.png" Name="Mysterious Tear" Subtype="0" Variant="7" />
-	<entity ID="2" Image="resources/Entities/2.8.0 - Scythe Tear.png" Name="Scythe Tear" Subtype="0" Variant="8" />
-	<entity ID="2" Image="resources/Entities/2.10.0 - Shield Tear.png" Name="Shield Tear" Subtype="0" Variant="10" />
-	<entity ID="2" Image="resources/Entities/2.11.0 - Cupid Tear.png" Name="Cupid Tear" Subtype="0" Variant="11" />
-	<!-- 
-	<entity ID="2" Image="resources/Entities/2.12.0 - Blood Tear.png" Name="Blood Tear" Variant="12" Subtype="0" />
-	<entity ID="2" Image="resources/Entities/2.13.0 - Nail Tear.png" Name="Nail Tear" Variant="13" Subtype="0" />
-	<entity ID="2" Image="resources/Entities/2.14.0 - Pupula Tear.png" Name="Pupula Tear" Variant="14" Subtype="0" />
-	<entity ID="2" Image="resources/Entities/2.15.0 - Pupula Blood Tear.png" Name="Pupula Blood Tear" Variant="15" Subtype="0" />
-	<entity ID="2" Image="resources/Entities/2.16.0 - God's Flesh Tear.png" Name="God's Flesh Tear" Variant="16" Subtype="0" />
-	<entity ID="2" Image="resources/Entities/2.17.0 - God's Flesh Blood Tear.png" Name="God's Flesh Blood Tear" Variant="17" Subtype="0" />
-	<entity ID="2" Image="resources/Entities/2.18.0 - Diamond Tear.png" Name="Diamond Tear" Variant="18" Subtype="0" />
-	<entity ID="2" Image="resources/Entities/2.19.0 - Explosivo Tear.png" Name="Explosivo Tear" Variant="19" Subtype="0" />
-	<entity ID="2" Image="resources/Entities/2.20.0 - Coin Tear.png" Name="Coin Tear" Variant="20" Subtype="0" />
-	<entity ID="2" Image="resources/Entities/2.21.0 - Multidimensional Tear.png" Name="Multidimensional Tear" Variant="21" Subtype="0" />
-	<entity ID="2" Image="resources/Entities/2.22.0 - Stone Tear.png" Name="Stone Tear" Variant="22" Subtype="0" />
-	<entity ID="2" Image="resources/Entities/2.23.0 - Nail Blood Tear.png" Name="Nail Blood Tear" Variant="23" Subtype="0" />
-	<entity ID="2" Image="resources/Entities/2.24.0 - Glaucoma Tear.png" Name="Glaucoma Tear" Variant="24" Subtype="0" />
-	<entity ID="2" Image="resources/Entities/2.25.0 - Glaucoma Blood Tear.png" Name="Glaucoma Blood Tear" Variant="25" Subtype="0" />
-	<entity ID="2" Image="resources/Entities/2.26.0 - Booger Tear.png" Name="Booger Tear" Variant="26" Subtype="0" />
-	<entity ID="2" Image="resources/Entities/2.27.0 - Egg Tear.png" Name="Egg Tear" Variant="27" Subtype="0" />
-	<entity ID="2" Image="resources/Entities/2.28.0 - Razor Tear.png" Name="Razor Tear" Variant="28" Subtype="0" />
-	<entity ID="2" Image="resources/Entities/2.29.0 - Bone Tear.png" Name="Bone Tear" Variant="29" Subtype="0" />
-	<entity ID="2" Image="resources/Entities/2.30.0 - Black Tooth Tear.png" Name="Black Tooth Tear" Variant="30" Subtype="0" />
-	<entity ID="2" Image="resources/Entities/2.31.0 - Needle Tear.png" Name="Needle Tear" Variant="31" Subtype="0" />
-	<entity ID="2" Image="resources/Entities/2.32.0 - Belial Tear.png" Name="Belial Tear" Variant="32" Subtype="0" />
-	<entity ID="2" Image="resources/Entities/2.33.0 - Pop Tear.png" Name="Pop Tear" Variant="33" Subtype="0" />
-	<entity ID="2" Image="resources/Entities/2.34.0 - Pop Blood Tear.png" Name="Pop Blood Tear" Variant="34" Subtype="0" />
-	<entity ID="2" Image="resources/Entities/2.35.0 - Balloon Tear.png" Name="Balloon Tear" Variant="35" Subtype="0" />
-	<entity ID="2" Image="resources/Entities/2.36.0 - Hungry Tear.png" Name="Hungry Tear" Variant="36" Subtype="0" />
-	<entity ID="2" Image="resources/Entities/2.37.0 - Brimstone Balloon Tear.png" Name="Brimstone Balloon Tear" Variant="37" Subtype="0" />
-	<entity ID="2" Image="resources/Entities/2.38.0 - Bomb Balloon Tear.png" Name="Bomb Balloon Tear" Variant="38" Subtype="0" />
-	<entity ID="2" Image="resources/Entities/2.39.0 - Fist Tear.png" Name="Fist Tear" Variant="39" Subtype="0" />
-	<entity ID="2" Image="resources/Entities/2.40.0 - Grid Tear.png" Name="Grid Tear" Variant="40" Subtype="0" />
-	<entity ID="2" Image="resources/Entities/2.41.0 - Ice Tear.png" Name="Ice Tear" Variant="41" Subtype="0" />
-	<entity ID="2" Image="resources/Entities/2.42.0 - Rock Tear.png" Name="Rock Tear" Variant="42" Subtype="0" />
-	<entity ID="2" Image="resources/Entities/2.43.0 - Key Tear.png" Name="Key Tear" Variant="43" Subtype="0" />
-	<entity ID="2" Image="resources/Entities/2.44.0 - Bloody Key Tear.png" Name="Bloody Key Tear" Variant="44" Subtype="0" />
-	<entity ID="2" Image="resources/Entities/2.45.0 - Eraser Tear.png" Name="Eraser Tear" Variant="45" Subtype="0" />
-	<entity ID="2" Image="resources/Entities/2.46.0 - Fire Tear.png" Name="Fire Tear" Variant="46" Subtype="0" />
-	<entity ID="2" Image="resources/Entities/2.47.0 - Sword Tear.png" Name="Sword Tear" Variant="47" Subtype="0" />
-	<entity ID="2" Image="resources/Entities/2.48.0 - Spore Tear.png" Name="Spore Tear" Variant="48" Subtype="0" />
-	<entity ID="2" Image="resources/Entities/2.49.0 - Tech Sword Tear.png" Name="Tech Sword Tear" Variant="49" Subtype="0" />
-	 -->
-	<entity ID="9" Image="resources/Entities/9.0.0 - Enemy Tear.png" Name="Enemy Tear" Subtype="0" Variant="0" />
-	<entity ID="9" Image="resources/Entities/9.0.1 - Bone.png" Name="Bone" Subtype="0" Variant="1" />
-	<entity ID="9" Image="resources/Entities/9.0.2 - Fire.png" Name="Fire" Subtype="0" Variant="2" />
-	<entity ID="9" Image="resources/Entities/9.0.3 - Puke.png" Name="Puke" Subtype="0" Variant="3" />
-
-	<!-- Broken -->
-	<entity ID="1" Image="resources/Entities/1.0.0 - Player.png" Name="Player (crashes)" Subtype="0" Variant="0" />
-	<entity ID="3" Image="resources/Entities/3.0.0 - Familiar.png" Name="Familiar (No Effect)" Subtype="0" Variant="0" />
-	<entity ID="7" Image="resources/Entities/7.0.0 - Laser.png" Name="Laser (crashes)" Subtype="0" Variant="0" />
-	<entity ID="8" Image="resources/Entities/8.0.0 - Knife.png" Name="Knife" Subtype="0" Variant="0" />
-	<entity BaseHP="140" ID="79" Image="resources/Entities/79.20.0 - Umbilical Cord.png" Name="Umbilical Cord" Variant="20" />
-	<entity BaseHP="60" ID="251" Image="resources/Entities/251.10.0 - Begotten Chain.png" Name="Begotten Chain" Subtype="0" Variant="10" />
-	<entity BaseHP="30" Champion="1" ID="294" Image="resources/Entities/294.0.0 - Ultra Greed Door.png" Kind="Stage" Subtype="0" Variant="0" />
-	
-	<!-- UNORDERED Repentance-->
-	
-	<!-- Nightwatchers -->
-	<entity BaseHP="25" Group="Nightwatchers" ID="842" Image="resources/Entities/842.0.0 - Nightwatch.png" Kind="Enemies" Name="Nightwatch" Variant="0" Subtype="0" />
-	
-	<!-- Tainted -->
-	<entity BaseHP="75" Group="Tainted" ID="14" Image="resources/Entities/14.2.0 - Tainted Pooter.png" Kind="Enemies" Name="Tainted Pooter" Subtype="0" Variant="2" />
-	<entity BaseHP="120" Group="Tainted" ID="22" Image="resources/Entities/22.3.0 - Tainted Mulligan.png" Kind="Enemies" Name="Tainted Mulligan" Variant="3" Subtype="0" />
-	<entity BaseHP="20" Group="Tainted" ID="25" Image="resources/Entities/25.6.0 - Tainted Boom Fly.png" Kind="Enemies" Name="Tainted Boom Fly" Variant="6" Subtype="0" />
-	<entity BaseHP="80" Group="Tainted" ID="29" Image="resources/Entities/29.3.0 - Tainted Hopper.png" Kind="Enemies" Name="Tainted Hopper" Variant="3" Subtype="0" />
-	<entity BaseHP="60" Group="Tainted" ID="31" Image="resources/Entities/31.1.0 - Tainted Spitty.png" Kind="Enemies" Name="Tainted Spitty" Variant="1" Subtype="0" />
-	<entity BaseHP="14" Group="Tainted" ID="61" Image="resources/Entities/61.7.0 - Tainted Sucker.png" Kind="Enemies" Name="Tainted Sucker" Variant="7" Subtype="0" />
-	<entity BaseHP="50" Group="Tainted" ID="240" Image="resources/Entities/240.3.0 - Tainted Soy Creep.png" Kind="Enemies" Name="Tainted Soy Creep" Variant="3" Subtype="0" />
-	<entity BaseHP="100" Group="Tainted" ID="244" Image="resources/Entities/244.2.0 - Tainted Round Worm.png" Kind="Enemies" Name="Tainted Round Worm" Variant="2" Subtype="0" />
-	<entity BaseHP="100" Group="Tainted" ID="244" Image="resources/Entities/244.2.1 - Tainted Round Worm Butt.png" Kind="Enemies" Name="Tainted Round Worm Butt" Variant="2" Subtype="1" />
-	<entity BaseHP="100" Group="Tainted" ID="244" Image="resources/Entities/244.3.0 - Tainted Tube Worm.png" Kind="Enemies" Name="Tainted Tube Worm" Variant="3" Subtype="0" />
-	<entity BaseHP="50" Group="Tainted" ID="812" Image="resources/Entities/812.1.0 - Tainted Sub Horf.png" Kind="Enemies" Name="Tainted Sub Horf" Variant="1" Subtype="0" />
-	<entity BaseHP="100" Group="Tainted" ID="827" Image="resources/Entities/827.1.0 - Tainted Faceless.png" Kind="Enemies" Name="Tainted Faceless" Variant="1" Subtype="0" />
-	<entity BaseHP="80" Champion="1" Group="Tainted" ID="829" Image="resources/Entities/829.1.0 - Tainted Mole.png" Kind="Enemies" Name="Tainted Mole" Variant="1" Subtype="0" />
-	<entity BaseHP="60" Group="Tainted" ID="855" Image="resources/Entities/855.1.0 - Elleech.png" Kind="Enemies" Name="Elleech" Variant="1" Subtype="0" />
-	
-	<!--
-	<entity BaseHP="10" Group="" ID="1" Image="resources/Entities/1.1.0 - Coplayer.png" Kind="" Name="Coplayer" Variant="1" Subtype="0" />
-
-	<entity Group="" ID="5" Image="resources/Entities/5.110.0 - Broken Shovel.png" Kind="" Name="Broken Shovel" Variant="110" Subtype="0" />
-	<entity Group="" ID="9" Image="resources/Entities/9.4.0 - Tear Projectile.png" Kind="" Name="Tear Projectile" Variant="4" Subtype="0" />
-	<entity BaseHP="10" Group="" ID="9" Image="resources/Entities/9.5.0 - Corn Projectile.png" Kind="" Name="Corn Projectile" Variant="5" Subtype="0" />
-	<entity BaseHP="10" Group="" ID="9" Image="resources/Entities/9.6.0 - Hush Projectile.png" Kind="" Name="Hush Projectile" Variant="6" Subtype="0" />
-	<entity BaseHP="10" Group="" ID="9" Image="resources/Entities/9.7.0 - Coin Projectile.png" Kind="" Name="Coin Projectile" Variant="7" Subtype="0" />
-	<entity BaseHP="10" Group="" ID="9" Image="resources/Entities/9.12.0 - Steven Projectile.png" Kind="" Name="Steven Projectile" Variant="12" Subtype="0" />
-	<entity BaseHP="20" Champion="1" Group="" ID="23" Image="resources/Entities/23.0.1 - My Shadow.png" Kind="" Name="My Shadow" Variant="0" Subtype="1" />
-	<entity BaseHP="25" Group="" ID="35" Image="resources/Entities/35.1.0 - Mr. Maw Head.png" Kind="" Name="Mr. Maw Head" Variant="1" Subtype="0" />
-	<entity BaseHP="10" Group="" ID="35" Image="resources/Entities/35.3.0 - Mr. Red Maw Head.png" Kind="" Name="Mr. Red Maw Head" Variant="3" Subtype="0" />
-	<entity BaseHP="25" Group="" ID="35" Image="resources/Entities/35.10.0 - Mr. Maw Neck.png" Kind="" Name="Mr. Maw Neck" Variant="10" Subtype="0" />
-	<entity BaseHP="1000" Champion="1" Group="" ID="39" Image="resources/Entities/39.22.0 - Chubber Projectile.png" Kind="" Name="Chubber Projectile" Variant="22" Subtype="0" />
-	<entity BaseHP="645" Boss="1" Group="" ID="45" Image="resources/Entities/45.10.0 - Mom Stomp.png" Kind="" Name="Mom Stomp" Variant="10" Subtype="0" />
-	<entity BaseHP="40" Champion="1" Boss="1" Group="" ID="51" Image="resources/Entities/51.11.0 - Super Envy (big).png" Kind="" Name="Super Envy (big)" Variant="11" Subtype="0" />
-	<entity BaseHP="40" Champion="1" Boss="1" Group="" ID="51" Image="resources/Entities/51.21.0 - Super Envy (medium).png" Kind="" Name="Super Envy (medium)" Variant="21" Subtype="0" />
-	<entity BaseHP="40" Champion="1" Boss="1" Group="" ID="51" Image="resources/Entities/51.31.0 - Super Envy (small).png" Kind="" Name="Super Envy (small)" Variant="31" Subtype="0" />
-	<entity BaseHP="50" Group="" ID="66" Image="resources/Entities/66.10.0 - Death Scythe.png" Kind="" Name="Death Scythe" Variant="10" Subtype="0" />
-	<entity BaseHP="450" Group="" ID="68" Image="resources/Entities/68.10.0 - Peep Eye.png" Kind="" Name="Peep Eye" Variant="10" Subtype="0" />
-	<entity BaseHP="450" Group="" ID="68" Image="resources/Entities/68.11.0 - Bloat Eye.png" Kind="" Name="Bloat Eye" Variant="11" Subtype="0" />
-	<entity Group="" ID="78" Image="resources/Entities/78.10.0 - Moms Guts.png" Kind="" Name="Moms Guts" Variant="10" Subtype="0" />
-	<entity BaseHP="140" Boss="1" Group="" ID="79" Image="resources/Entities/79.12.0 - The Blighted Ovum Baby.png" Kind="" Name="The Blighted Ovum Baby" Variant="12" Subtype="0" />
-	<entity BaseHP="300" Group="" ID="96" Image="resources/Entities/96.0.0 - Eternal Fly.png" Kind="" Name="Eternal Fly" Variant="0" Subtype="0" />
-	<entity BaseHP="20" Group="" ID="228" Image="resources/Entities/228.10.0 - Homunculus Cord.png" Kind="" Name="Homunculus Cord" Variant="10" Subtype="0" />
-	<entity BaseHP="1" Boss="1" Group="" ID="266" Image="resources/Entities/266.1.0 - Mama Gurdy Left Hand.png" Kind="" Name="Mama Gurdy Left Hand" Variant="1" Subtype="0" />
-	<entity BaseHP="1" Boss="1" Group="" ID="266" Image="resources/Entities/266.2.0 - Mama Gurdy Right Hand.png" Kind="" Name="Mama Gurdy Right Hand" Variant="2" Subtype="0" />
-	<entity BaseHP="600" Boss="1" Group="" ID="273" Image="resources/Entities/273.10.0 - Lamb Body.png" Kind="" Name="Lamb Body" Variant="10" Subtype="0" />
-	<entity BaseHP="2000" Boss="1" Group="" ID="275" Image="resources/Entities/275.0.0 - Mega Satan 2.png" Kind="" Name="Mega Satan 2" Variant="0" Subtype="0" />
-	<entity BaseHP="600" Boss="1" Group="" ID="275" Image="resources/Entities/275.1.0 - Mega Satan 2's Right Hand.png" Kind="" Name="Mega Satan 2's Right Hand" Variant="1" Subtype="0" />
-	<entity BaseHP="600" Boss="1" Group="" ID="275" Image="resources/Entities/275.2.0 - Mega Satan 2's Left Hand.png" Kind="" Name="Mega Satan 2's Left Hand" Variant="2" Subtype="0" />
-	<entity BaseHP="4" Group="" ID="292" Image="resources/Entities/292.1.0 - Movable TNT (Mine Crafter).png" Kind="" Name="Movable TNT (Mine Crafter)" Variant="1" Subtype="0" />
-	<entity BaseHP="1" Group="" ID="307" Image="resources/Entities/307.0.1 - Tar Boy (mouth).png" Kind="" Name="Tar Boy (mouth)" Variant="0" Subtype="1" />
-	<entity BaseHP="20" Group="" ID="311" Image="resources/Entities/311.10.0 - Mr. Mine Neck.png" Kind="" Name="Mr. Mine Neck" Variant="10" Subtype="0" />
-	<entity BaseHP="25" Group="" ID="405" Image="resources/Entities/405.1.0 - Rag Man's Head.png" Kind="" Name="Rag Man's Head" Variant="1" Subtype="0" />
-	<entity BaseHP="10" Group="" ID="409" Image="resources/Entities/409.1.0 - Purple Ball.png" Kind="" Name="Purple Ball" Variant="1" Subtype="0" />
-	<entity BaseHP="10" Group="" ID="409" Image="resources/Entities/409.2.0 - Rag Mega's Rebirth Pillar.png" Kind="" Name="Rag Mega's Rebirth Pillar" Variant="2" Subtype="0" />
-	<entity BaseHP="480" Boss="1" Group="" ID="411" Image="resources/Entities/411.1.0 - Small Hole.png" Kind="" Name="Small Hole" Variant="1" Subtype="0" />
-	<entity BaseHP="480" Boss="1" Group="" ID="411" Image="resources/Entities/411.2.0 - Big Hole.png" Kind="" Name="Big Hole" Variant="2" Subtype="0" />
-	
-	<entity BaseHP="10" Group="" ID="9" Image="resources/Entities/9.8.0 - Grid Projectile.png" Kind="" Name="Grid Projectile" Variant="8" Subtype="0" />
-	<entity BaseHP="10" Group="" ID="9" Image="resources/Entities/9.9.0 - Rock Projectile.png" Kind="" Name="Rock Projectile" Variant="9" Subtype="0" />
-	<entity BaseHP="10" Group="" ID="9" Image="resources/Entities/9.11.0 - Meat Projectile.png" Kind="" Name="Meat Projectile" Variant="11" Subtype="0" />
-	<entity BaseHP="10" Group="" ID="9" Image="resources/Entities/9.13.0 - Feather Projectile.png" Kind="" Name="Feather Projectile" Variant="13" Subtype="0" />
-	<entity BaseHP="10" Group="" ID="9" Image="resources/Entities/9.14.0 - Lava Projectile.png" Kind="" Name="Lava Projectile" Variant="14" Subtype="0" />
-	<entity BaseHP="10" Group="" ID="9" Image="resources/Entities/9.15.0 - Head Projectile.png" Kind="" Name="Head Projectile" Variant="15" Subtype="0" />
-	<entity BaseHP="10" Group="" ID="9" Image="resources/Entities/9.16.0 - Eyeball Projectile.png" Kind="" Name="Eyeball Projectile" Variant="16" Subtype="0" />
-	
-	
-	<entity BaseHP="5" Champion="1" Group="" ID="830" Image="resources/Entities/830.10.0 - Big Bone.png" Kind="" Name="Big Bone" Variant="10" Subtype="0" />
-	
-	<entity Group="" ID="865" Image="resources/Entities/865.10.0 - Evis Guts.png" Kind="" Name="Evis Guts" Variant="10" Subtype="0" />
-	
-	<entity BaseHP="8" Group="" ID="885" Image="resources/Entities/885.10.0 - Bone Trap.png" Kind="" Name="Bone Trap" Variant="10" Subtype="0" />
-	
-	<entity BaseHP="150" Group="" ID="903" Image="resources/Entities/903.10.0 - Visage Chain.png" Kind="" Name="Visage Chain" Variant="10" Subtype="0" />
-	<entity BaseHP="50" Group="" ID="903" Image="resources/Entities/903.20.0 - Visage Plasma.png" Kind="" Name="Visage Plasma" Variant="20" Subtype="0" />
-	<entity Group="" ID="904" Image="resources/Entities/904.10.0 - Siren Helper Projectile.png" Kind="" Name="Siren Helper Projectile" Variant="10" Subtype="0" />
-	<entity BaseHP="4" Boss="1" Group="" ID="906" Image="resources/Entities/906.1.0 - Hornfel Decoy.png" Kind="" Name="Hornfel Decoy" Variant="1" Subtype="0" />
-	<entity BaseHP="400" Group="" ID="909" Image="resources/Entities/909.10.0 - The Scourge (chain).png" Kind="" Name="The Scourge (chain)" Variant="10" Subtype="0" />
-
-	<entity BaseHP="100" Group="Other" ID="951" Image="resources/Entities/951.1.0 - Stalactite.png" Kind="Stages" Name="Stalactite" Variant="1" Subtype="0" />
-	<entity BaseHP="2.5" Group="" ID="951" Image="resources/Entities/951.2.0 - Beast Rock Projectile.png" Kind="" Name="Beast Rock Projectile" Variant="2" Subtype="0" />
-	<entity BaseHP="100" Group="" ID="951" Image="resources/Entities/951.3.0 - Beast Soul.png" Kind="" Name="Beast Soul" Variant="3" Subtype="0" />
-	<entity BaseHP="1000" Boss="1" Group="" ID="951" Image="resources/Entities/951.100.0 - Background (Beast).png" Kind="" Name="Background (Beast)" Variant="100" Subtype="0" />
-	<entity BaseHP="1000" Boss="1" Group="" ID="951" Image="resources/Entities/951.101.0 - Background (Famine).png" Kind="" Name="Background (Famine)" Variant="101" Subtype="0" />
-	<entity BaseHP="1000" Boss="1" Group="" ID="951" Image="resources/Entities/951.102.0 - Background (Pestilence).png" Kind="" Name="Background (Pestilence)" Variant="102" Subtype="0" />
-	<entity BaseHP="1000" Boss="1" Group="" ID="951" Image="resources/Entities/951.103.0 - Background (War).png" Kind="" Name="Background (War)" Variant="103" Subtype="0" />
-	<entity BaseHP="1000" Boss="1" Group="" ID="951" Image="resources/Entities/951.104.0 - Background (Death).png" Kind="" Name="Background (Death)" Variant="104" Subtype="0" />
-	<entity BaseHP="1" Group="Props" ID="960" Image="resources/Entities/960.0.0 - Generic Prop.png" Kind="Stages" Name="Generic Prop" Variant="0" Subtype="0" />
-	<entity BaseHP="10" Group="" ID="963" Image="resources/Entities/963.0.0 - Frozen Enemy.png" Kind="" Name="Frozen Enemy" Variant="0" Subtype="0" />
-	<entity BaseHP="10000" Boss="1" Group="" ID="964" Image="resources/Entities/964.0.0 - Dummy.png" Kind="" Name="Dummy" Variant="0" Subtype="0" />
-	<entity Group="" ID="965" Image="resources/Entities/965.0.0 - Minecart.png" Kind="" Name="Minecart" Variant="0" Subtype="0" />
-	<entity BaseHP="60" Group="" ID="966" Image="resources/Entities/966.0.0 - Siren Helper.png" Kind="" Name="Siren Helper" Variant="0" Subtype="0" />
-	<entity Group="" ID="967" Image="resources/Entities/967.0.0 - Hornfel Door.png" Kind="Effect" Name="Hornfel Door" Variant="0" Subtype="0" />
-	
-	<entity Group="" ID="1000" Image="resources/Entities/1000.1.0 - Bomb Explosion.png" Kind="Effect" Name="Bomb Explosion" Variant="1" Subtype="0" />
-	<entity Group="" ID="1000" Image="resources/Entities/1000.2.0 - Blood Explosion.png" Kind="Effect" Name="Blood Explosion" Variant="2" Subtype="0" />
-	<entity Group="" ID="1000" Image="resources/Entities/1000.3.0 - Fly Explosion.png" Kind="Effect" Name="Fly Explosion" Variant="3" Subtype="0" />
-	<entity Group="" ID="1000" Image="resources/Entities/1000.4.0 - Rock Particle.png" Kind="Effect" Name="Rock Particle" Variant="4" Subtype="0" />
-	<entity Group="" ID="1000" Image="resources/Entities/1000.5.0 - Blood Particle.png" Kind="Effect" Name="Blood Particle" Variant="5" Subtype="0" />
-	<entity Group="" ID="1000" Image="resources/Entities/1000.6.0 - Devil.png" Kind="Effect" Name="Devil" Variant="6" Subtype="0" />
-	<entity Group="" ID="1000" Image="resources/Entities/1000.7.0 - Blood Splat.png" Kind="Effect" Name="Blood Splat" Variant="7" Subtype="0" />
-	<entity Group="" ID="1000" Image="resources/Entities/1000.8.0 - Ladder.png" Kind="Effect" Name="Ladder" Variant="8" Subtype="0" />
-	<entity Group="" ID="1000" Image="resources/Entities/1000.9.0 - Angel.png" Kind="Effect" Name="Angel" Variant="9" Subtype="0" />
-	<entity Group="" ID="1000" Image="resources/Entities/1000.10.0 - Blue Flame.png" Kind="Effect" Name="Blue Flame" Variant="10" Subtype="0" />
-	<entity Group="" ID="1000" Image="resources/Entities/1000.11.0 - Bullet Poof.png" Kind="Effect" Name="Bullet Poof" Variant="11" Subtype="0" />
-	<entity Group="" ID="1000" Image="resources/Entities/1000.12.0 - Tear PoofA.png" Kind="Effect" Name="Tear PoofA" Variant="12" Subtype="0" />
-	<entity Group="" ID="1000" Image="resources/Entities/1000.12.10 - Tear PoofA (no tear).png" Kind="Effect" Name="Tear PoofA (no tear)" Variant="12" Subtype="10" />
-	<entity Group="" ID="1000" Image="resources/Entities/1000.13.0 - Tear PoofB.png" Kind="Effect" Name="Tear PoofB" Variant="13" Subtype="0" />
-	<entity Group="" ID="1000" Image="resources/Entities/1000.14.0 - Ripple Poof.png" Kind="Effect" Name="Ripple Poof" Variant="14" Subtype="0" />
-	<entity Group="" ID="1000" Image="resources/Entities/1000.14.1 - Ripple Poof.png" Kind="Effect" Name="Ripple Poof" Variant="14" Subtype="1" />
-	<entity Group="" ID="1000" Image="resources/Entities/1000.15.0 - Poof01.png" Kind="Effect" Name="Poof01" Variant="15" Subtype="0" />
-	<entity Group="" ID="1000" Image="resources/Entities/1000.16.0 - Poof02.png" Kind="Effect" Name="Poof02" Variant="16" Subtype="0" />
-	<entity Group="" ID="1000" Image="resources/Entities/1000.16.1 - Large Ground Poof.png" Kind="Effect" Name="Large Ground Poof" Variant="16" Subtype="1" />
-	<entity Group="" ID="1000" Image="resources/Entities/1000.16.2 - Large Ground Poof (foreground).png" Kind="Effect" Name="Large Ground Poof (foreground)" Variant="16" Subtype="2" />
-	<entity Group="" ID="1000" Image="resources/Entities/1000.16.3 - Large Blood Poof.png" Kind="Effect" Name="Large Blood Poof" Variant="16" Subtype="3" />
-	<entity Group="" ID="1000" Image="resources/Entities/1000.16.4 - Large Blood Poof (foreground).png" Kind="Effect" Name="Large Blood Poof (foreground)" Variant="16" Subtype="4" />
-	<entity Group="" ID="1000" Image="resources/Entities/1000.16.5 - Blood Cloud.png" Kind="Effect" Name="Blood Cloud" Variant="16" Subtype="5" />
-	<entity Group="" ID="1000" Image="resources/Entities/1000.16.10 - Forgotten Soul Poof.png" Kind="Effect" Name="Forgotten Soul Poof" Variant="16" Subtype="10" />
-	<entity Group="" ID="1000" Image="resources/Entities/1000.16.11 - Holy Mantle Poof.png" Kind="Effect" Name="Holy Mantle Poof" Variant="16" Subtype="11" />
-	<entity Group="" ID="1000" Image="resources/Entities/1000.17.0 - Poof04.png" Kind="Effect" Name="Poof04" Variant="17" Subtype="0" />
-	<entity Group="" ID="1000" Image="resources/Entities/1000.18.0 - Bomb Crater.png" Kind="Effect" Name="Bomb Crater" Variant="18" Subtype="0" />
-	<entity Champion="1" Boss="1" Group="" ID="1000" Image="resources/Entities/1000.19.0 - Crack The Sky.png" Kind="Effect" Name="Crack The Sky" Variant="19" Subtype="0" />
-	<entity Group="" ID="1000" Image="resources/Entities/1000.20.0 - Scythe Break.png" Kind="Effect" Name="Scythe Break" Variant="20" Subtype="0" />
-	<entity Group="" ID="1000" Image="resources/Entities/1000.21.0 - Tiny Bug.png" Kind="Effect" Name="Tiny Bug" Variant="21" Subtype="0" />
-	<entity Group="" ID="1000" Image="resources/Entities/1000.68.0 - Wall Bug.png" Kind="Effect" Name="Wall Bug" Variant="68" Subtype="0" />
-	<entity Group="" ID="1000" Image="resources/Entities/1000.22.0 - Creep (Red).png" Kind="Effect" Name="Creep (Red)" Variant="22" Subtype="0" />
-	<entity Group="" ID="1000" Image="resources/Entities/1000.23.0 - Creep (Green).png" Kind="Effect" Name="Creep (Green)" Variant="23" Subtype="0" />
-	<entity Group="" ID="1000" Image="resources/Entities/1000.24.0 - Creep (Yellow).png" Kind="Effect" Name="Creep (Yellow)" Variant="24" Subtype="0" />
-	<entity Group="" ID="1000" Image="resources/Entities/1000.25.0 - Creep (White).png" Kind="Effect" Name="Creep (White)" Variant="25" Subtype="0" />
-	<entity Group="" ID="1000" Image="resources/Entities/1000.26.0 - Creep (Black).png" Kind="Effect" Name="Creep (Black)" Variant="26" Subtype="0" />
-	<entity Group="" ID="1000" Image="resources/Entities/1000.27.0 - Wood Particle.png" Kind="Effect" Name="Wood Particle" Variant="27" Subtype="0" />
-	<entity Boss="1" Group="" ID="1000" Image="resources/Entities/1000.28.0 - Monstros Tooth.png" Kind="Effect" Name="Monstros Tooth" Variant="28" Subtype="0" />
-	<entity Boss="1" Group="" ID="1000" Image="resources/Entities/1000.29.0 - Mom Foot Stomp.png" Kind="Effect" Name="Mom Foot Stomp" Variant="29" Subtype="0" />
-	<entity Group="" ID="1000" Image="resources/Entities/1000.30.0 - Dr. Fetus Target.png" Kind="Effect" Name="Dr. Fetus Target" Variant="30" Subtype="0" />
-	<entity Group="" ID="1000" Image="resources/Entities/1000.31.0 - Dr. Fetus Rocket.png" Kind="Effect" Name="Dr. Fetus Rocket" Variant="31" Subtype="0" />
-	<entity Group="" ID="1000" Image="resources/Entities/1000.32.0 - Lemon Mishap.png" Kind="Effect" Name="Lemon Mishap" Variant="32" Subtype="0" />
-	<entity Group="" ID="1000" Image="resources/Entities/1000.78.0 - Lemon Party.png" Kind="Effect" Name="Lemon Party" Variant="78" Subtype="0" />
-	<entity Group="" ID="1000" Image="resources/Entities/1000.33.0 - Tiny Fly.png" Kind="Effect" Name="Tiny Fly" Variant="33" Subtype="0" />
-	<entity Group="" ID="1000" Image="resources/Entities/1000.34.0 - Fart.png" Kind="Effect" Name="Fart" Variant="34" Subtype="0" />
-	<entity Boss="1" Group="" ID="1000" Image="resources/Entities/1000.35.0 - Tooth Particle.png" Kind="Effect" Name="Tooth Particle" Variant="35" Subtype="0" />
-	<entity Group="" ID="1000" Image="resources/Entities/1000.36.0 - Wall Hole X-Ray.png" Kind="Effect" Name="Wall Hole X-Ray" Variant="36" Subtype="0" />
-	<entity Group="" ID="1000" Image="resources/Entities/1000.37.0 - Player Creep (Holy Water).png" Kind="Effect" Name="Player Creep (Holy Water)" Variant="37" Subtype="0" />
-	<entity Group="" ID="1000" Image="resources/Entities/1000.38.0 - Spider Explosion.png" Kind="Effect" Name="Spider Explosion" Variant="38" Subtype="0" />
-	<entity Boss="1" Group="" ID="1000" Image="resources/Entities/1000.39.0 - Heaven Door.png" Kind="Effect" Name="Heaven Door" Variant="39" Subtype="0" />
-	<entity Group="" ID="1000" Image="resources/Entities/1000.41.0 - Water Droplet.png" Kind="Effect" Name="Water Droplet" Variant="41" Subtype="0" />
-	<entity Group="" ID="1000" Image="resources/Entities/1000.42.0 - Blood Gush.png" Kind="Effect" Name="Blood Gush" Variant="42" Subtype="0" />
-	<entity Group="" ID="1000" Image="resources/Entities/1000.43.0 - Poop Explosion.png" Kind="Effect" Name="Poop Explosion" Variant="43" Subtype="0" />
-	<entity Group="" ID="1000" Image="resources/Entities/1000.44.0 - Player Creep (White).png" Kind="Effect" Name="Player Creep (White)" Variant="44" Subtype="0" />
-	<entity Group="" ID="1000" Image="resources/Entities/1000.45.0 - Player Creep (Black).png" Kind="Effect" Name="Player Creep (Black)" Variant="45" Subtype="0" />
-	<entity Group="" ID="1000" Image="resources/Entities/1000.46.0 - Player Creep (Red).png" Kind="Effect" Name="Player Creep (Red)" Variant="46" Subtype="0" />
-	<entity Boss="1" Group="" ID="1000" Image="resources/Entities/1000.47.0 - Trinity Shield.png" Kind="Effect" Name="Trinity Shield" Variant="47" Subtype="0" />
-	<entity Group="" ID="1000" Image="resources/Entities/1000.48.0 - Battery up.png" Kind="Effect" Name="Battery up" Variant="48" Subtype="0" />
-	<entity Group="" ID="1000" Image="resources/Entities/1000.49.0 - Effect Notification.png" Kind="Effect" Name="Effect Notification" Variant="49" Subtype="0" />
-	<entity Group="" ID="1000" Image="resources/Entities/1000.50.0 - Laser Impact.png" Kind="Effect" Name="Laser Impact" Variant="50" Subtype="0" />
-	<entity Group="" ID="1000" Image="resources/Entities/1000.50.1 - Brimstone Impact.png" Kind="Effect" Name="Brimstone Impact" Variant="50" Subtype="1" />
-	<entity Group="" ID="1000" Image="resources/Entities/1000.50.2 - Shoop Impact.png" Kind="Effect" Name="Shoop Impact" Variant="50" Subtype="2" />
-	<entity Group="" ID="1000" Image="resources/Entities/1000.50.3 - Brimstone Impact CageVis.png" Kind="Effect" Name="Brimstone Impact CageVis" Variant="50" Subtype="3" />
-	<entity Group="" ID="1000" Image="resources/Entities/1000.50.4 - Bouncing Impact.png" Kind="Effect" Name="Bouncing Impact" Variant="50" Subtype="4" />
-	<entity Group="" ID="1000" Image="resources/Entities/1000.50.5 - Ring Impact.png" Kind="Effect" Name="Ring Impact" Variant="50" Subtype="5" />
-	<entity Group="" ID="1000" Image="resources/Entities/1000.51.0 - Fire.png" Kind="Effect" Name="Fire" Variant="51" Subtype="0" />
-	<entity Group="" ID="1000" Image="resources/Entities/1000.52.0 - Red Flame.png" Kind="Effect" Name="Red Flame" Variant="52" Subtype="0" />
-	<entity Group="" ID="1000" Image="resources/Entities/1000.53.0 - Tear Creep (Green).png" Kind="Effect" Name="Tear Creep (Green)" Variant="53" Subtype="0" />
-	<entity Group="" ID="1000" Image="resources/Entities/1000.54.0 - Player Creep Holy Water Trail.png" Kind="Effect" Name="Player Creep Holy Water Trail" Variant="54" Subtype="0" />
-	<entity Group="" ID="1000" Image="resources/Entities/1000.55.0 - Spike Effect.png" Kind="Effect" Name="Spike Effect" Variant="55" Subtype="0" />
-	<entity Group="" ID="1000" Image="resources/Entities/1000.56.0 - Brown Creep.png" Kind="Effect" Name="Brown Creep" Variant="56" Subtype="0" />
-	<entity Group="" ID="1000" Image="resources/Entities/1000.57.0 - Pulling Effect.png" Kind="Effect" Name="Pulling Effect" Variant="57" Subtype="0" />
-	<entity Group="" ID="1000" Image="resources/Entities/1000.58.0 - Poop Particle.png" Kind="Effect" Name="Poop Particle" Variant="58" Subtype="0" />
-	<entity Group="" ID="1000" Image="resources/Entities/1000.59.0 - Dust Cloud.png" Kind="Effect" Name="Dust Cloud" Variant="59" Subtype="0" />
-	<entity Group="" ID="1000" Image="resources/Entities/1000.60.0 - Boomerang.png" Kind="Effect" Name="Boomerang" Variant="60" Subtype="0" />
-	<entity Group="" ID="1000" Image="resources/Entities/1000.61.0 - Shockwave (Radial).png" Kind="Effect" Name="Shockwave (Radial)" Variant="61" Subtype="0" />
-	<entity Group="" ID="1000" Image="resources/Entities/1000.62.0 - Rock Explosion.png" Kind="Effect" Name="Rock Explosion" Variant="62" Subtype="0" />
-	<entity Group="" ID="1000" Image="resources/Entities/1000.63.0 - Worm.png" Kind="Effect" Name="Worm" Variant="63" Subtype="0" />
-	<entity Group="" ID="1000" Image="resources/Entities/1000.63.1 - Maggot.png" Kind="Effect" Name="Maggot" Variant="63" Subtype="1" />
-	<entity Group="" ID="1000" Image="resources/Entities/1000.63.2 - Leech.png" Kind="Effect" Name="Leech" Variant="63" Subtype="2" />
-	<entity Group="" ID="1000" Image="resources/Entities/1000.64.0 - Beetle.png" Kind="Effect" Name="Beetle" Variant="64" Subtype="0" />
-	<entity Group="" ID="1000" Image="resources/Entities/1000.65.0 - Wisp.png" Kind="Effect" Name="Wisp" Variant="65" Subtype="0" />
-	<entity Group="" ID="1000" Image="resources/Entities/1000.66.0 - Ember Particle.png" Kind="Effect" Name="Ember Particle" Variant="66" Subtype="0" />
-	<entity Group="" ID="1000" Image="resources/Entities/1000.69.0 - Butterfly.png" Kind="Effect" Name="Butterfly" Variant="69" Subtype="0" />
-	<entity Group="" ID="1000" Image="resources/Entities/1000.70.0 - Blood Drop.png" Kind="Effect" Name="Blood Drop" Variant="70" Subtype="0" />
-	<entity Group="" ID="1000" Image="resources/Entities/1000.71.0 - Brimstone Swirl.png" Kind="Effect" Name="Brimstone Swirl" Variant="71" Subtype="0" />
-	<entity Group="" ID="1000" Image="resources/Entities/1000.74.0 - Isaac's Carpet.png" Kind="Effect" Name="Isaac's Carpet" Variant="74" Subtype="0" />
-	<entity Group="" ID="1000" Image="resources/Entities/1000.76.0 - Dice Room Floor.png" Kind="Effect" Name="Dice Room Floor" Variant="76" Subtype="0" />
-	<entity Group="" ID="1000" Image="resources/Entities/1000.77.0 - Large Blood Explosion.png" Kind="Effect" Name="Large Blood Explosion" Variant="77" Subtype="0" />
-	<entity Group="" ID="1000" Image="resources/Entities/1000.75.0 - Bar Particle.png" Kind="Effect" Name="Bar Particle" Variant="75" Subtype="0" />
-	<entity Group="" ID="1000" Image="resources/Entities/1000.67.0 - Shockwave (Directional).png" Kind="Effect" Name="Shockwave (Directional)" Variant="67" Subtype="0" />
-	<entity Group="" ID="1000" Image="resources/Entities/1000.72.0 - Crackwave.png" Kind="Effect" Name="Crackwave" Variant="72" Subtype="0" />
-	<entity Group="" ID="1000" Image="resources/Entities/1000.73.0 - Shockwave (Random).png" Kind="Effect" Name="Shockwave (Random)" Variant="73" Subtype="0" />
-	<entity Group="" ID="1000" Image="resources/Entities/1000.79.0 - Tear Poof small.png" Kind="Effect" Name="Tear Poof small" Variant="79" Subtype="0" />
-	<entity Group="" ID="1000" Image="resources/Entities/1000.80.0 - Tear Poof very small.png" Kind="Effect" Name="Tear Poof very small" Variant="80" Subtype="0" />
-	<entity Group="" ID="1000" Image="resources/Entities/1000.81.0 - Friendly ball.png" Kind="Effect" Name="Friendly ball" Variant="81" Subtype="0" />
-	<entity Group="" ID="1000" Image="resources/Entities/1000.82.0 - Womb hole teleport.png" Kind="Effect" Name="Womb hole teleport" Variant="82" Subtype="0" />
-	<entity Group="" ID="1000" Image="resources/Entities/1000.83.0 - Spear of destiny.png" Kind="Effect" Name="Spear of destiny" Variant="83" Subtype="0" />
-	<entity Group="" ID="1000" Image="resources/Entities/1000.84.0 - Evil Eye.png" Kind="Effect" Name="Evil Eye" Variant="84" Subtype="0" />
-	<entity Boss="1" Group="" ID="1000" Image="resources/Entities/1000.85.0 - Diamond Particle.png" Kind="Effect" Name="Diamond Particle" Variant="85" Subtype="0" />
-	<entity Boss="1" Group="" ID="1000" Image="resources/Entities/1000.86.0 - Nail Particle.png" Kind="Effect" Name="Nail Particle" Variant="86" Subtype="0" />
-	<entity Group="" ID="1000" Image="resources/Entities/1000.87.0 - Falling Ember.png" Kind="Effect" Name="Falling Ember" Variant="87" Subtype="0" />
-	<entity Group="" ID="1000" Image="resources/Entities/1000.88.0 - Dark Ball Smoke Particle.png" Kind="Effect" Name="Dark Ball Smoke Particle" Variant="88" Subtype="0" />
-	<entity Group="" ID="1000" Image="resources/Entities/1000.89.0 - Ultra Greed Footprint.png" Kind="Effect" Name="Ultra Greed Footprint" Variant="89" Subtype="0" />
-	<entity Group="" ID="1000" Image="resources/Entities/1000.90.0 - Milk Puddle.png" Kind="Effect" Name="Milk Puddle" Variant="90" Subtype="0" />
-	<entity Group="" ID="1000" Image="resources/Entities/1000.91.0 - Mom's Hand (Emergency Contact).png" Kind="Effect" Name="Mom's Hand (Emergency Contact)" Variant="91" Subtype="0" />
-	<entity Group="" ID="1000" Image="resources/Entities/1000.92.0 - Player Creep (Black Powder).png" Kind="Effect" Name="Player Creep (Black Powder)" Variant="92" Subtype="0" />
-	<entity Group="" ID="1000" Image="resources/Entities/1000.93.0 - Pentagram (Black Powder).png" Kind="Effect" Name="Pentagram (Black Powder)" Variant="93" Subtype="0" />
-	<entity Group="" ID="1000" Image="resources/Entities/1000.94.0 - Slippery Brown Creep.png" Kind="Effect" Name="Slippery Brown Creep" Variant="94" Subtype="0" />
-	<entity Group="" ID="1000" Image="resources/Entities/1000.95.0 - Diamond Particle.png" Kind="Effect" Name="Diamond Particle" Variant="95" Subtype="0" />
-	<entity Champion="1" Boss="1" Group="" ID="1000" Image="resources/Entities/1000.96.0 - Hush Laser.png" Kind="Effect" Name="Hush Laser" Variant="96" Subtype="0" />
-	<entity Group="" ID="1000" Image="resources/Entities/1000.97.0 - Impact.png" Kind="Effect" Name="Impact" Variant="97" Subtype="0" />
-	<entity Group="" ID="1000" Image="resources/Entities/1000.98.0 - Coin Particle.png" Kind="Effect" Name="Coin Particle" Variant="98" Subtype="0" />
-	<entity Group="" ID="1000" Image="resources/Entities/1000.99.0 - Water Splash.png" Kind="Effect" Name="Water Splash" Variant="99" Subtype="0" />
-	<entity Group="" ID="1000" Image="resources/Entities/1000.100.0 - Hush Ashes.png" Kind="Effect" Name="Hush Ashes" Variant="100" Subtype="0" />
-	<entity Champion="1" Boss="1" Group="" ID="1000" Image="resources/Entities/1000.101.0 - Hush Laser Up.png" Kind="Effect" Name="Hush Laser Up" Variant="101" Subtype="0" />
-	<entity Group="" ID="1000" Image="resources/Entities/1000.102.0 - Bullet Poof.png" Kind="Effect" Name="Bullet Poof" Variant="102" Subtype="0" />
-	<entity Group="" ID="1000" Image="resources/Entities/1000.103.0 - Ultra Greed Bling.png" Kind="Effect" Name="Ultra Greed Bling" Variant="103" Subtype="0" />
-	<entity Group="" ID="1000" Image="resources/Entities/1000.104.0 - Fireworks.png" Kind="Effect" Name="Fireworks" Variant="104" Subtype="0" />
-	<entity Group="" ID="1000" Image="resources/Entities/1000.105.0 - Brown Cloud.png" Kind="Effect" Name="Brown Cloud" Variant="105" Subtype="0" />
-	<entity Group="" ID="1000" Image="resources/Entities/1000.106.0 - Fart Ring.png" Kind="Effect" Name="Fart Ring" Variant="106" Subtype="0" />
-	<entity Group="" ID="1000" Image="resources/Entities/1000.107.0 - BlackHole.png" Kind="Effect" Name="BlackHole" Variant="107" Subtype="0" />
-	<entity Boss="1" Group="" ID="1000" Image="resources/Entities/1000.107.1 - BlackHoleRay.png" Kind="Effect" Name="BlackHoleRay" Variant="107" Subtype="1" />
-	<entity Group="" ID="1000" Image="resources/Entities/1000.108.0 - Mr. Me!.png" Kind="Effect" Name="Mr. Me!" Variant="108" Subtype="0" />
-	<entity Group="" ID="1000" Image="resources/Entities/1000.109.0 - Death Skull.png" Kind="Effect" Name="Death Skull" Variant="109" Subtype="0" />
-	<entity Group="" ID="1000" Image="resources/Entities/1000.110.0 - Enemy Brimstone Swirl.png" Kind="Effect" Name="Enemy Brimstone Swirl" Variant="110" Subtype="0" />
-	<entity Group="" ID="1000" Image="resources/Entities/1000.111.0 - Haemolacria Trail.png" Kind="Effect" Name="Haemolacria Trail" Variant="111" Subtype="0" />
-	<entity Group="" ID="1000" Image="resources/Entities/1000.112.0 - Hallowed Ground.png" Kind="Effect" Name="Hallowed Ground" Variant="112" Subtype="0" />
-	<entity Group="" ID="1000" Image="resources/Entities/1000.113.0 - Brimstone Ball.png" Kind="Effect" Name="Brimstone Ball" Variant="113" Subtype="0" />
-	<entity Group="" ID="1000" Image="resources/Entities/1000.114.0 - Forgotten Chain.png" Kind="Effect" Name="Forgotten Chain" Variant="114" Subtype="0" />
-	<entity Group="" ID="1000" Image="resources/Entities/1000.115.0 - Broken Shovel Shadow.png" Kind="Effect" Name="Broken Shovel Shadow" Variant="115" Subtype="0" />
-	<entity Group="" ID="1000" Image="resources/Entities/1000.116.0 - Dirt Patch.png" Kind="Effect" Name="Dirt Patch" Variant="116" Subtype="0" />
-	<entity Group="" ID="1000" Image="resources/Entities/1000.117.0 - Forgotten Soul.png" Kind="Effect" Name="Forgotten Soul" Variant="117" Subtype="0" />
-	<entity Group="" ID="1000" Image="resources/Entities/1000.118.0 - Small Rocket.png" Kind="Effect" Name="Small Rocket" Variant="118" Subtype="0" />
-	<entity Group="" ID="1000" Image="resources/Entities/1000.119.0 - Timer.png" Kind="Effect" Name="Timer" Variant="119" Subtype="0" />
-	<entity Group="" ID="1000" Image="resources/Entities/1000.120.0 - Spawner.png" Kind="Effect" Name="Spawner" Variant="120" Subtype="0" />
-	<entity Group="" ID="1000" Image="resources/Entities/1000.121.0 - Light.png" Kind="Effect" Name="Light" Variant="121" Subtype="0" />
-	<entity Group="" ID="1000" Image="resources/Entities/1000.122.0 - Big Horn Hole Helper.png" Kind="Effect" Name="Big Horn Hole Helper" Variant="122" Subtype="0" />
-	<entity Group="" ID="1000" Image="resources/Entities/1000.123.0 - Halo.png" Kind="Effect" Name="Halo" Variant="123" Subtype="0" />
-	<entity Group="" ID="1000" Image="resources/Entities/1000.123.1 - Telekinesis Halo.png" Kind="Effect" Name="Telekinesis Halo" Variant="123" Subtype="1" />
-	<entity Group="" ID="1000" Image="resources/Entities/1000.124.0 - Tar Bubble.png" Kind="Effect" Name="Tar Bubble" Variant="124" Subtype="0" />
-	<entity Group="" ID="1000" Image="resources/Entities/1000.125.0 - Big Horn Hand.png" Kind="Effect" Name="Big Horn Hand" Variant="125" Subtype="0" />
-	<entity Group="" ID="1000" Image="resources/Entities/1000.126.0 - Tech Dot.png" Kind="Effect" Name="Tech Dot" Variant="126" Subtype="0" />
-	<entity Group="" ID="1000" Image="resources/Entities/1000.127.0 - Mama Mega Explosion.png" Kind="Effect" Name="Mama Mega Explosion" Variant="127" Subtype="0" />
-	<entity Group="" ID="1000" Image="resources/Entities/1000.12.20 - Key Tear Poof.png" Kind="Effect" Name="Key Tear Poof" Variant="12" Subtype="20" />
-	<entity Group="" ID="1000" Image="resources/Entities/1000.12.21 - Bloody Key Tear Poof.png" Kind="Effect" Name="Bloody Key Tear Poof" Variant="12" Subtype="21" />
-	<entity Group="" ID="1000" Image="resources/Entities/1000.12.22 - Sword Tear Poof.png" Kind="Effect" Name="Sword Tear Poof" Variant="12" Subtype="22" />
-	<entity Group="" ID="1000" Image="resources/Entities/1000.12.23 - Tech Sword Tear Poof.png" Kind="Effect" Name="Tech Sword Tear Poof" Variant="12" Subtype="23" />
-	<entity Group="" ID="1000" Image="resources/Entities/1000.16.66 - Lava Splash.png" Kind="Effect" Name="Lava Splash" Variant="16" Subtype="66" />
-	<entity Group="" ID="1000" Image="resources/Entities/1000.16.67 - Lava Splash (Large).png" Kind="Effect" Name="Lava Splash (Large)" Variant="16" Subtype="67" />
-	<entity Group="" ID="1000" Image="resources/Entities/1000.50.6 - Big Brimstone Impact.png" Kind="Effect" Name="Big Brimstone Impact" Variant="50" Subtype="6" />
-	<entity Group="" ID="1000" Image="resources/Entities/1000.50.7 - Brimstone Impact (Poop).png" Kind="Effect" Name="Brimstone Impact (Poop)" Variant="50" Subtype="7" />
-	<entity Group="" ID="1000" Image="resources/Entities/1000.123.2 - Monstrance Halo.png" Kind="Effect" Name="Monstrance Halo" Variant="123" Subtype="2" />
-	<entity Group="" ID="1000" Image="resources/Entities/1000.123.3 - Curse Halo.png" Kind="Effect" Name="Curse Halo" Variant="123" Subtype="3" />
-	<entity Group="" ID="1000" Image="resources/Entities/1000.123.4 - Static Halo.png" Kind="Effect" Name="Static Halo" Variant="123" Subtype="4" />
-	<entity Group="" ID="1000" Image="resources/Entities/1000.123.5 - Saturnus Halo.png" Kind="Effect" Name="Saturnus Halo" Variant="123" Subtype="5" />
-	<entity Group="" ID="1000" Image="resources/Entities/1000.123.6 - Thorns Halo.png" Kind="Effect" Name="Thorns Halo" Variant="123" Subtype="6" />
-	<entity Group="" ID="1000" Image="resources/Entities/1000.130.0 - Leech Explosion.png" Kind="Effect" Name="Leech Explosion" Variant="130" Subtype="0" />
-	<entity Group="" ID="1000" Image="resources/Entities/1000.131.0 - Maggot Explosion.png" Kind="Effect" Name="Maggot Explosion" Variant="131" Subtype="0" />
-	<entity Group="" ID="1000" Image="resources/Entities/1000.132.0 - Big Water Splash.png" Kind="Effect" Name="Big Water Splash" Variant="132" Subtype="0" />
-	<entity Group="" ID="1000" Image="resources/Entities/1000.132.1 - Static Splash.png" Kind="Effect" Name="Static Splash" Variant="132" Subtype="1" />
-	<entity Group="" ID="1000" Image="resources/Entities/1000.132.2 - Static Splash 2.png" Kind="Effect" Name="Static Splash 2" Variant="132" Subtype="2" />
-	<entity Group="" ID="1000" Image="resources/Entities/1000.133.0 - Water Ripple.png" Kind="Effect" Name="Water Ripple" Variant="133" Subtype="0" />
-	<entity Group="" ID="1000" Image="resources/Entities/1000.133.1 - Small Water Ripple.png" Kind="Effect" Name="Small Water Ripple" Variant="133" Subtype="1" />
-	<entity Group="" ID="1000" Image="resources/Entities/1000.134.0 - Pedestal Ripple.png" Kind="Effect" Name="Pedestal Ripple" Variant="134" Subtype="0" />
-	<entity Group="" ID="1000" Image="resources/Entities/1000.135.0 - Rain Drop.png" Kind="Effect" Name="Rain Drop" Variant="135" Subtype="0" />
-	<entity Group="" ID="1000" Image="resources/Entities/1000.136.0 - Grid Projectile Helper.png" Kind="Effect" Name="Grid Projectile Helper" Variant="136" Subtype="0" />
-	<entity Group="" ID="1000" Image="resources/Entities/1000.137.0 - Wormwood Hole.png" Kind="Effect" Name="Wormwood Hole" Variant="137" Subtype="0" />
-	<entity Group="" ID="1000" Image="resources/Entities/1000.137.1 - Wormwood Hole Spray.png" Kind="Effect" Name="Wormwood Hole Spray" Variant="137" Subtype="1" />
-	<entity Group="" ID="1000" Image="resources/Entities/1000.138.0 - Mist.png" Kind="Effect" Name="Mist" Variant="138" Subtype="0" />
-	<entity Group="" ID="1000" Image="resources/Entities/1000.139.0 - Trap Door Cover.png" Kind="Effect" Name="Trap Door Cover" Variant="139" Subtype="0" />
-	<entity Group="" ID="1000" Image="resources/Entities/1000.140.0 - Backdrop Decoration.png" Kind="Effect" Name="Backdrop Decoration" Variant="140" Subtype="0" />
-	<entity Group="" ID="1000" Image="resources/Entities/1000.142.0 - Whirlpool.png" Kind="Effect" Name="Whirlpool" Variant="142" Subtype="0" />
-	<entity Group="" ID="1000" Image="resources/Entities/1000.142.1 - Whirlpool Particle.png" Kind="Effect" Name="Whirlpool Particle" Variant="142" Subtype="1" />
-	<entity Group="" ID="1000" Image="resources/Entities/1000.143.0 - Fartwave.png" Kind="Effect" Name="Fartwave" Variant="143" Subtype="0" />
-	<entity Group="" ID="1000" Image="resources/Entities/1000.144.0 - Enemy Ghost.png" Kind="Effect" Name="Enemy Ghost" Variant="144" Subtype="0" />
-	<entity Group="" ID="1000" Image="resources/Entities/1000.145.0 - Rock Tear Poof.png" Kind="Effect" Name="Rock Tear Poof" Variant="145" Subtype="0" />
-	<entity Group="" ID="1000" Image="resources/Entities/1000.146.0 - Dirt Pile.png" Kind="Effect" Name="Dirt Pile" Variant="146" Subtype="0" />
-	<entity Group="" ID="1000" Image="resources/Entities/1000.147.0 - Fire Jet.png" Kind="Effect" Name="Fire Jet" Variant="147" Subtype="0" />
-	<entity Group="" ID="1000" Image="resources/Entities/1000.147.1 - Fire Jet (purple).png" Kind="Effect" Name="Fire Jet (purple)" Variant="147" Subtype="1" />
-	<entity Group="" ID="1000" Image="resources/Entities/1000.148.0 - Fire Wave.png" Kind="Effect" Name="Fire Wave" Variant="148" Subtype="0" />
-	<entity Group="" ID="1000" Image="resources/Entities/1000.149.0 - Big Rock Explosion.png" Kind="Effect" Name="Big Rock Explosion" Variant="149" Subtype="0" />
-	<entity Group="" ID="1000" Image="resources/Entities/1000.150.0 - Big Rock Wave.png" Kind="Effect" Name="Big Rock Wave" Variant="150" Subtype="0" />
-	<entity Group="" ID="1000" Image="resources/Entities/1000.151.0 - Gideon Attract Ring.png" Kind="Effect" Name="Gideon Attract Ring" Variant="151" Subtype="0" />
-	<entity Group="" ID="1000" Image="resources/Entities/1000.151.1 - Gideon Attract Trail.png" Kind="Effect" Name="Gideon Attract Trail" Variant="151" Subtype="1" />
-	<entity Group="" ID="1000" Image="resources/Entities/1000.151.10 - Shockwave Ring.png" Kind="Effect" Name="Shockwave Ring" Variant="151" Subtype="10" />
-	<entity Group="" ID="1000" Image="resources/Entities/1000.151.11 - Shockwave Trail.png" Kind="Effect" Name="Shockwave Trail" Variant="151" Subtype="11" />
-	<entity Group="" ID="1000" Image="resources/Entities/1000.152.0 - Hornfel Room Controller.png" Kind="Effect" Name="Hornfel Room Controller" Variant="152" Subtype="0" />
-	<entity Group="" ID="1000" Image="resources/Entities/1000.153.0 - Occult Target.png" Kind="Effect" Name="Occult Target" Variant="153" Subtype="0" />
-	<entity Group="" ID="1000" Image="resources/Entities/1000.154.0 - Door Outline.png" Kind="Effect" Name="Door Outline" Variant="154" Subtype="0" />
-	<entity Boss="1" Group="" ID="1000" Image="resources/Entities/1000.39.1 - Moonlight.png" Kind="Effect" Name="Moonlight" Variant="39" Subtype="1" />
-	<entity Group="" ID="1000" Image="resources/Entities/1000.155.0 - Slippery Brown Creep (growing).png" Kind="Effect" Name="Slippery Brown Creep (growing)" Variant="155" Subtype="0" />
-	<entity Group="" ID="1000" Image="resources/Entities/1000.156.0 - Tall Ladder.png" Kind="Effect" Name="Tall Ladder" Variant="156" Subtype="0" />
-	<entity Group="" ID="1000" Image="resources/Entities/1000.156.1 - Stairway.png" Kind="Effect" Name="Stairway" Variant="156" Subtype="1" />
-	<entity Group="" ID="1000" Image="resources/Entities/1000.157.0 - Willo Spawner.png" Kind="Effect" Name="Willo Spawner" Variant="157" Subtype="0" />
-	<entity Group="" ID="1000" Image="resources/Entities/1000.158.0 - Tadpole.png" Kind="Effect" Name="Tadpole" Variant="158" Subtype="0" />
-	<entity Group="" ID="1000" Image="resources/Entities/1000.159.0 - Lil Ghost.png" Kind="Effect" Name="Lil Ghost" Variant="159" Subtype="0" />
-	<entity Group="" ID="1000" Image="resources/Entities/1000.160.0 - Bishop Shield.png" Kind="Effect" Name="Bishop Shield" Variant="160" Subtype="0" />
-	<entity Group="" ID="1000" Image="resources/Entities/1000.161.0 - Portal Teleport.png" Kind="Effect" Name="Portal Teleport" Variant="161" Subtype="0" />
-	<entity Group="" ID="1000" Image="resources/Entities/1000.162.0 - Heretic Pentagram.png" Kind="Effect" Name="Heretic Pentagram" Variant="162" Subtype="0" />
-	<entity Group="" ID="1000" Image="resources/Entities/1000.163.0 - Chain Gib.png" Kind="Effect" Name="Chain Gib" Variant="163" Subtype="0" />
-	<entity Group="" ID="1000" Image="resources/Entities/1000.164.0 - Siren Ring.png" Kind="Effect" Name="Siren Ring" Variant="164" Subtype="0" />
-	<entity Group="" ID="1000" Image="resources/Entities/1000.165.0 - Siren Charm Effect.png" Kind="Effect" Name="Siren Charm Effect" Variant="165" Subtype="0" />
-	<entity Group="" ID="1000" Image="resources/Entities/1000.165.1 - Siren Charm Glow.png" Kind="Effect" Name="Siren Charm Glow" Variant="165" Subtype="1" />
-	<entity Group="" ID="1000" Image="resources/Entities/1000.166.0 - Sprite Trail.png" Kind="Effect" Name="Sprite Trail" Variant="166" Subtype="0" />
-	<entity Group="" ID="1000" Image="resources/Entities/1000.167.0 - Chain Lightning.png" Kind="Effect" Name="Chain Lightning" Variant="167" Subtype="0" />
-	<entity Group="" ID="1000" Image="resources/Entities/1000.168.0 - Colostomia Puddle.png" Kind="Effect" Name="Colostomia Puddle" Variant="168" Subtype="0" />
-	<entity Group="" ID="1000" Image="resources/Entities/1000.169.0 - Creep (Static).png" Kind="Effect" Name="Creep (Static)" Variant="169" Subtype="0" />
-	<entity Group="" ID="1000" Image="resources/Entities/1000.170.0 - Dogma Debris.png" Kind="Effect" Name="Dogma Debris" Variant="170" Subtype="0" />
-	<entity Group="" ID="1000" Image="resources/Entities/1000.171.0 - Dogma Blackhole.png" Kind="Effect" Name="Dogma Blackhole" Variant="171" Subtype="0" />
-	<entity Group="" ID="1000" Image="resources/Entities/1000.172.0 - Dogma Orb.png" Kind="Effect" Name="Dogma Orb" Variant="172" Subtype="0" />
-	<entity Group="" ID="1000" Image="resources/Entities/1000.173.0 - Cracked Orb Poof.png" Kind="Effect" Name="Cracked Orb Poof" Variant="173" Subtype="0" />
-	<entity Group="" ID="1000" Image="resources/Entities/1000.174.0 - Shop Spikes.png" Kind="Effect" Name="Shop Spikes" Variant="174" Subtype="0" />
-	<entity Group="" ID="1000" Image="resources/Entities/1000.175.0 - Kineti Beam.png" Kind="Effect" Name="Kineti Beam" Variant="175" Subtype="0" />
-	<entity Group="" ID="1000" Image="resources/Entities/1000.176.0 - Cleaver Slash.png" Kind="Effect" Name="Cleaver Slash" Variant="176" Subtype="0" />
-	<entity Group="" ID="1000" Image="resources/Entities/1000.177.0 - Reverse Explosion.png" Kind="Effect" Name="Reverse Explosion" Variant="177" Subtype="0" />
-	<entity Group="" ID="1000" Image="resources/Entities/1000.177.1 - Reverse Explosion Debris.png" Kind="Effect" Name="Reverse Explosion Debris" Variant="177" Subtype="1" />
-	<entity Group="" ID="1000" Image="resources/Entities/1000.178.0 - Urn of Souls.png" Kind="Effect" Name="Urn of Souls" Variant="178" Subtype="0" />
-	<entity Group="" ID="1000" Image="resources/Entities/1000.179.0 - Enemy Soul.png" Kind="Effect" Name="Enemy Soul" Variant="179" Subtype="0" />
-	<entity Group="" ID="1000" Image="resources/Entities/1000.180.0 - Rift.png" Kind="Effect" Name="Rift" Variant="180" Subtype="0" />
-	<entity Group="" ID="1000" Image="resources/Entities/1000.181.0 - Lava Spawner.png" Kind="Effect" Name="Lava Spawner" Variant="181" Subtype="0" />
-	<entity Group="" ID="1000" Image="resources/Entities/1000.182.0 - Big Knife Projectile.png" Kind="Effect" Name="Big Knife Projectile" Variant="182" Subtype="0" />
-	<entity Group="" ID="1000" Image="resources/Entities/1000.183.0 - Mother Shockwave.png" Kind="Effect" Name="Mother Shockwave" Variant="183" Subtype="0" />
-	<entity Group="" ID="1000" Image="resources/Entities/1000.184.0 - Worm Friend Snare.png" Kind="Effect" Name="Worm Friend Snare" Variant="184" Subtype="0" />
-	<entity Group="" ID="1000" Image="resources/Entities/1000.185.0 - Redemption.png" Kind="Effect" Name="Redemption" Variant="185" Subtype="0" />
-	<entity Group="" ID="1000" Image="resources/Entities/1000.186.0 - Hungry Soul.png" Kind="Effect" Name="Hungry Soul" Variant="186" Subtype="0" />
-	<entity Group="" ID="1000" Image="resources/Entities/1000.187.0 - Explosion Wave.png" Kind="Effect" Name="Explosion Wave" Variant="187" Subtype="0" />
-	<entity Group="" ID="1000" Image="resources/Entities/1000.188.0 - Divine Intervention.png" Kind="Effect" Name="Divine Intervention" Variant="188" Subtype="0" />
-	<entity Group="" ID="1000" Image="resources/Entities/1000.189.0 - Purgatory Rift.png" Kind="Effect" Name="Purgatory Rift" Variant="189" Subtype="0" />
-	<entity Group="" ID="1000" Image="resources/Entities/1000.189.1 - Purgatory Soul.png" Kind="Effect" Name="Purgatory Soul" Variant="189" Subtype="1" />
-	<entity Group="" ID="1000" Image="resources/Entities/1000.190.0 - Mother Tracer.png" Kind="Effect" Name="Mother Tracer" Variant="190" Subtype="0" />
-	<entity Group="" ID="1000" Image="resources/Entities/1000.191.0 - Pickup Ghost.png" Kind="Effect" Name="Pickup Ghost" Variant="191" Subtype="0" />
-	<entity Group="" ID="1000" Image="resources/Entities/1000.192.0 - Fissure Spawner.png" Kind="Effect" Name="Fissure Spawner" Variant="192" Subtype="0" />
-	<entity Group="" ID="1000" Image="resources/Entities/1000.193.0 - Anima Chain.png" Kind="Effect" Name="Anima Chain" Variant="193" Subtype="0" />
-	<entity Group="" ID="1000" Image="resources/Entities/1000.194.0 - Dark Snare.png" Kind="Effect" Name="Dark Snare" Variant="194" Subtype="0" />
-	<entity Group="" ID="1000" Image="resources/Entities/1000.195.0 - Liquid Poop Creep.png" Kind="Effect" Name="Liquid Poop Creep" Variant="195" Subtype="0" />
-	<entity Group="" ID="1000" Image="resources/Entities/1000.196.0 - Ground Glow.png" Kind="Effect" Name="Ground Glow" Variant="196" Subtype="0" />
-	<entity Group="" ID="1000" Image="resources/Entities/1000.197.0 - Dead Bird.png" Kind="Effect" Name="Dead Bird" Variant="197" Subtype="0" />
-	<entity Group="" ID="1000" Image="resources/Entities/1000.198.0 - Generic Tracer.png" Kind="Effect" Name="Generic Tracer" Variant="198" Subtype="0" />
-	<entity Group="" ID="1000" Image="resources/Entities/1000.199.0 - Ultra Death Scythe.png" Kind="Effect" Name="Ultra Death Scythe" Variant="199" Subtype="0" />
-	-->
+	<group Name="Live Bombs">
+		<entity ID="4" Image="Entities/4.13.0 - Throwable Bomb.png" Name="Throwable Bomb" Variant="13" Subtype="0" />
+		<entity ID="4" Image="Entities/4.14.0 - Small Bomb.png" Name="Small Bomb" Variant="14" Subtype="0" />
+		<entity ID="4" Image="Entities/4.15.0 - Brimstone Bomb.png" Name="Brimstone Bomb" Variant="15" Subtype="0" />
+		<entity ID="4" Image="Entities/4.16.0 - Bloody Sad Bomb.png" Name="Bloody Sad Bomb" Variant="16" Subtype="0" />
+		<entity ID="4" Image="Entities/4.17.0 - Giga Bomb.png" Name="Giga Bomb" Variant="17" Subtype="0" />
+		<entity ID="4" Image="Entities/4.18.0 - Golden Troll Bomb.png" Name="Golden Troll Bomb (player)" Variant="18" Subtype="0" />
+		<entity ID="4" Image="Entities/4.19.0 - Rocket.png" Name="Rocket" Variant="19" Subtype="0" />
+		<entity ID="4" Image="Entities/4.20.0 - Giga Rocket.png" Name="Giga Rocket" Variant="20" Subtype="0" />
+	</group>
 </data>


### PR DESCRIPTION
Fire (ID 1400) and Red Fire (ID 1410) are used in pre-Repentance rooms, and while Red Fire effectively acts the same as Red Fireplace (ID 33.1) and is a redundant duplicate, Fire acts as a non-replaceable Fireplace (ID 33.0) and will not turn into a Red Fire.
Subsequently, I wanted to move them from Unused tab to the Global tab and gave new respective icons and names, in some attempt to make entity filter searching a little less confusing.

(However just having them stay in the Unused tab is still probably wise, besides some other potential nitpicks in the icons like the Red Fire)